### PR TITLE
Removing redundant C# namespace imports

### DIFF
--- a/Templates/BlobTrigger-CSharp/run.csx
+++ b/Templates/BlobTrigger-CSharp/run.csx
@@ -1,7 +1,5 @@
 using System;
-using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.Azure.WebJobs.Host;
 
 public static void Run(string myBlob, TraceWriter log)
 {

--- a/Templates/Empty-CSharp/run.csx
+++ b/Templates/Empty-CSharp/run.csx
@@ -1,7 +1,5 @@
 using System;
 using System.Diagnostics;
-using Microsoft.Azure.WebJobs;
-using Microsoft.Azure.WebJobs.Host;
 
 public static void Run()
 {

--- a/Templates/Empty-CSharp/run.csx
+++ b/Templates/Empty-CSharp/run.csx
@@ -1,5 +1,4 @@
 using System;
-using System.Diagnostics;
 
 public static void Run()
 {

--- a/Templates/HttpTrigger-CSharp/run.csx
+++ b/Templates/HttpTrigger-CSharp/run.csx
@@ -1,8 +1,6 @@
 using System;
 using System.Net;
-using System.Net.Http;
 using System.Threading.Tasks;
-using System.Diagnostics;
 
 public static Task<HttpResponseMessage> Run(HttpRequestMessage req, TraceWriter log)
 {

--- a/Templates/HttpTrigger-CSharp/run.csx
+++ b/Templates/HttpTrigger-CSharp/run.csx
@@ -1,10 +1,8 @@
 using System;
-using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using System.Diagnostics;
-using Microsoft.Azure.WebJobs.Host;
 
 public static Task<HttpResponseMessage> Run(HttpRequestMessage req, TraceWriter log)
 {

--- a/Templates/QueueTrigger-CSharp/run.csx
+++ b/Templates/QueueTrigger-CSharp/run.csx
@@ -1,7 +1,5 @@
 using System;
-using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.Azure.WebJobs.Host;
 
 public static void Run(string myQueueItem, TraceWriter log)
 {

--- a/Templates/TimerTrigger-CSharp/run.csx
+++ b/Templates/TimerTrigger-CSharp/run.csx
@@ -1,7 +1,5 @@
 using System;
 using System.Diagnostics;
-using Microsoft.Azure.WebJobs;
-using Microsoft.Azure.WebJobs.Host;
 
 public static void Run(TimerInfo myTimer, TraceWriter log)
 {

--- a/Templates/TimerTrigger-CSharp/run.csx
+++ b/Templates/TimerTrigger-CSharp/run.csx
@@ -1,5 +1,4 @@
 using System;
-using System.Diagnostics;
 
 public static void Run(TimerInfo myTimer, TraceWriter log)
 {

--- a/Templates/WebHook-Generic-CSharp/run.csx
+++ b/Templates/WebHook-Generic-CSharp/run.csx
@@ -2,7 +2,6 @@
 
 using System;
 using System.Net;
-using System.Net.Http;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 

--- a/Templates/WebHook-Generic-CSharp/run.csx
+++ b/Templates/WebHook-Generic-CSharp/run.csx
@@ -4,7 +4,6 @@ using System;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
-using Microsoft.Azure.WebJobs.Host;
 using Newtonsoft.Json;
 
 public static async Task<object> Run(HttpRequestMessage req, TraceWriter log)


### PR DESCRIPTION
The removed namespaces are automatically added by the C# function compilation process. Removing from the templates to reduce the amount of code and bring the function (relevant) code up.