### PR TITLE
Absorbing connectionString/storageAccount metadata name changes

### DIFF
--- a/Bindings/bindings.json
+++ b/Bindings/bindings.json
@@ -46,11 +46,11 @@
                     "help": "[variables('appSettingsHelp')]"
                 },
                 {
-                    "name": "connectionString",
+                    "name": "connection",
                     "value": "string",
                     "resource": "EventHub",
                     "required": true,
-                    "label": "Please provide a Connection string with receive permissions to an EventHub.",
+                    "label": "Please provide a connection with receive permissions to an EventHub.",
                     "help": "[variables('appSettingsHelp')]"
                 }
             ]
@@ -70,11 +70,11 @@
                     "help": "[variables('appSettingsHelp')]"
                 },
                 {
-                    "name": "connectionString",
+                    "name": "connection",
                     "value": "string",
                     "resource": "EventHub",
                     "required": true,
-                    "label": "Please provide a Connection string with send permissions to an EventHub.",
+                    "label": "Please provide a connection with send permissions to an EventHub.",
                     "help": "[variables('appSettingsHelp')]"
                 }
             ]
@@ -95,7 +95,7 @@
                     "help": "If your queue doesn't exist yet, don't worry. We'll create one for you in your specifed Storage Account."
                 },
                 {
-                    "name": "storageAccount",
+                    "name": "connection",
                     "value": "string",
                     "resource": "Storage",
                     "required": true,
@@ -120,7 +120,7 @@
                     "help": "If your queue doesn't exist yet, don't worry. We'll wait for it to exist before we start creating events."
                 },
                 {
-                    "name": "storageAccount",
+                    "name": "connection",
                     "value": "string",
                     "resource": "Storage",
                     "required": true,
@@ -145,7 +145,7 @@
                     "help": "Please enter a path within your storage account."
                 },
                 {
-                    "name": "storageAccount",
+                    "name": "connection",
                     "value": "string",
                     "resource": "Storage",
                     "required": true,
@@ -170,7 +170,7 @@
                     "help": "Please enter a path within your storage account."
                 },
                 {
-                    "name": "storageAccount",
+                    "name": "connection",
                     "value": "string",
                     "resource": "Storage",
                     "required": true,
@@ -195,7 +195,7 @@
                     "help": "Please enter a path within your storage account."
                 },
                 {
-                    "name": "storageAccount",
+                    "name": "connection",
                     "value": "string",
                     "resource": "Storage",
                     "required": true,
@@ -333,7 +333,7 @@
                     "help": "[variables('triggerRefHelp')]"
                 },
                 {
-                    "name": "storageAccount",
+                    "name": "connection",
                     "value": "string",
                     "resource": "Storage",
                     "required": true,
@@ -382,7 +382,7 @@
                     "help": "<TBD>"
                 },
                 {
-                    "name": "storageAccount",
+                    "name": "connection",
                     "value": "string",
                     "resource": "Storage",
                     "required": true,
@@ -423,7 +423,7 @@
                     "help": "When true, your database and collection will be created automatically."
                 },
                 {
-                    "name": "connectionString",
+                    "name": "connection",
                     "value": "string",
                     "resource": "DocumentDB",
                     "required": true,

--- a/Templates/BlobTrigger-CSharp/function.json
+++ b/Templates/BlobTrigger-CSharp/function.json
@@ -6,7 +6,7 @@
             "type": "blobTrigger",
             "direction": "in",
             "path": "samples-workitems",
-            "storageAccount":""
+            "connection":""
         }
     ]
 }

--- a/Templates/BlobTrigger-CSharp/metadata.json
+++ b/Templates/BlobTrigger-CSharp/metadata.json
@@ -4,7 +4,7 @@
     "language": "C#",
     "category": [ "Core" ],
     "userPrompt": [
-        "storageAccount",
+        "connection",
         "path"
     ]
 }

--- a/Templates/BlobTrigger-NodeJS/function.json
+++ b/Templates/BlobTrigger-NodeJS/function.json
@@ -6,7 +6,7 @@
             "type": "blobTrigger",
             "direction": "in",
             "path": "samples-workitems",
-            "storageAccount":""
+            "connection":""
         }
     ]
 }

--- a/Templates/BlobTrigger-NodeJS/metadata.json
+++ b/Templates/BlobTrigger-NodeJS/metadata.json
@@ -4,7 +4,7 @@
     "language": "JavaScript",
     "category": [ "Core" ],
     "userPrompt": [
-        "storageAccount",
+        "connection",
         "path"
     ]
 }

--- a/Templates/EventHubTrigger-NodeJS/function.json
+++ b/Templates/EventHubTrigger-NodeJS/function.json
@@ -6,7 +6,7 @@
             "name": "myEventHubTrigger",
             "direction": "in",
             "path": "samples-workitems",
-            "connectionString": "<your EventHub receiving connection string here>"
+            "connection": "<AppSetting name pointing to your EventHub receiving connection string>"
         }
     ]
 }

--- a/Templates/EventHubTrigger-NodeJS/metadata.json
+++ b/Templates/EventHubTrigger-NodeJS/metadata.json
@@ -4,7 +4,7 @@
     "language": "JavaScript",
     "category": [ "Core" ],
     "userPrompt": [
-        "connectionString",
+        "connection",
         "path"
     ]
 }

--- a/Templates/QueueTrigger-Bash/function.json
+++ b/Templates/QueueTrigger-Bash/function.json
@@ -6,7 +6,7 @@
             "type": "queueTrigger",
             "direction": "in",
             "queueName": "samples-bash",
-            "storageAccount":""
+            "connection":""
         }
     ]
 }

--- a/Templates/QueueTrigger-Bash/metadata.json
+++ b/Templates/QueueTrigger-Bash/metadata.json
@@ -5,7 +5,7 @@
     "trigger": "QueueTrigger",
     "category": [ "Experimental" ],
     "userPrompt": [
-        "storageAccount",
+        "connection",
         "queueName"
     ]
 }

--- a/Templates/QueueTrigger-Batch/function.json
+++ b/Templates/QueueTrigger-Batch/function.json
@@ -6,7 +6,7 @@
             "type": "queueTrigger",
             "direction": "in",
             "queueName": "samples-batch",
-            "storageAccount":""
+            "connection":""
         },
         {
             "type": "blob",

--- a/Templates/QueueTrigger-Batch/metadata.json
+++ b/Templates/QueueTrigger-Batch/metadata.json
@@ -5,7 +5,7 @@
     "trigger": "QueueTrigger",
     "category": [ "Experimental" ],
     "userPrompt": [
-        "storageAccount",
+        "connection",
         "queueName"
     ]
 }

--- a/Templates/QueueTrigger-CSharp/function.json
+++ b/Templates/QueueTrigger-CSharp/function.json
@@ -6,7 +6,7 @@
             "type": "queueTrigger",
             "direction": "in",
             "queueName": "myqueue-items",
-            "storageAccount":""
+            "connection":""
         }
     ]
 }

--- a/Templates/QueueTrigger-CSharp/metadata.json
+++ b/Templates/QueueTrigger-CSharp/metadata.json
@@ -4,7 +4,7 @@
     "language": "C#",
     "category": [ "Core" ],
     "userPrompt": [
-        "storageAccount",
+        "connection",
         "queueName"
     ]
 }

--- a/Templates/QueueTrigger-FSharp/function.json
+++ b/Templates/QueueTrigger-FSharp/function.json
@@ -6,7 +6,7 @@
             "type": "queueTrigger",
             "direction": "in",
             "queueName": "samples-fsharp",
-            "storageAccount":""
+            "connection":""
         }
     ]
 }

--- a/Templates/QueueTrigger-FSharp/metadata.json
+++ b/Templates/QueueTrigger-FSharp/metadata.json
@@ -5,7 +5,7 @@
     "trigger": "QueueTrigger",
     "category": [ "Experimental" ],
     "userPrompt": [
-        "storageAccount",
+        "connection",
         "queueName"
     ]
 }

--- a/Templates/QueueTrigger-NodeJS/function.json
+++ b/Templates/QueueTrigger-NodeJS/function.json
@@ -6,7 +6,7 @@
             "type": "queueTrigger",
             "direction": "in",
             "queueName": "js-queue-items",
-            "storageAccount":""
+            "connection":""
         }
     ]
 }

--- a/Templates/QueueTrigger-NodeJS/metadata.json
+++ b/Templates/QueueTrigger-NodeJS/metadata.json
@@ -4,7 +4,7 @@
     "language": "JavaScript",
     "category": [ "Experimental" ],
     "userPrompt": [
-        "storageAccount",
+        "connection",
         "queueName"
     ]
 }

--- a/Templates/QueueTrigger-Php/function.json
+++ b/Templates/QueueTrigger-Php/function.json
@@ -6,7 +6,7 @@
             "type": "queueTrigger",
             "direction": "in",
             "queueName": "samples-php",
-            "storageAccount":""
+            "connection":""
         }
     ]
 }

--- a/Templates/QueueTrigger-Php/metadata.json
+++ b/Templates/QueueTrigger-Php/metadata.json
@@ -5,7 +5,7 @@
     "trigger": "QueueTrigger",
     "category": [ "Experimental" ],
     "userPrompt": [
-        "storageAccount",
+        "connection",
         "queueName"
     ]
 }

--- a/Templates/QueueTrigger-Powershell/function.json
+++ b/Templates/QueueTrigger-Powershell/function.json
@@ -6,7 +6,7 @@
             "type": "queueTrigger",
             "direction": "in",
             "queueName": "samples-powershell",
-            "storageAccount":""
+            "connection":""
         },
         {
             "type": "table",

--- a/Templates/QueueTrigger-Powershell/metadata.json
+++ b/Templates/QueueTrigger-Powershell/metadata.json
@@ -5,7 +5,7 @@
     "trigger": "QueueTrigger",
     "category": [ "Experimental" ],
     "userPrompt": [
-        "storageAccount",
+        "connection",
         "queueName"
     ]
 }

--- a/Templates/QueueTrigger-Python/function.json
+++ b/Templates/QueueTrigger-Python/function.json
@@ -6,7 +6,7 @@
             "type": "queueTrigger",
             "direction": "in",
             "queueName": "samples-python",
-            "storageAccount":""
+            "connection":""
         },
         {
             "type": "table",

--- a/Templates/QueueTrigger-Python/metadata.json
+++ b/Templates/QueueTrigger-Python/metadata.json
@@ -5,7 +5,7 @@
     "trigger": "QueueTrigger",
     "category": [ "Experimental" ],
     "userPrompt": [
-        "storageAccount",
+        "connection",
         "queueName"
     ]
 }


### PR DESCRIPTION
See the script PR https://github.com/Azure/azure-webjobs-sdk-script/pull/128 for details.

Basically we've made the "connection string" metadata property consistent across the bindings.