### PR TITLE
Fixing ServiceBus template name + Generic JSON WebHook binding

### DIFF
--- a/Bindings/bindings.json
+++ b/Bindings/bindings.json
@@ -228,8 +228,8 @@
                             "display": "Slack"
                         },
                         {
-                            "value": "generic",
-                            "display": "Generic"
+                            "value": "genericJson",
+                            "display": "Generic JSON"
                         }
                     ],
                     "label": "Is this a WebHook? If so, what type of webhook is it?",

--- a/Templates/ServiceBusQueueTrigger-NodeJS/metadata.json
+++ b/Templates/ServiceBusQueueTrigger-NodeJS/metadata.json
@@ -1,5 +1,5 @@
 {
-    "name": "ServiceBusQueueTrigger Nodejs Function",
+    "name": "ServiceBusQueueTrigger - Node",
     "description": "A Node.JS function that will be run whenever a message is added to a specified Service Bus queue",
     "defaultFunctionName": "ServiceBusQueueTriggerNodeJS",
     "language": "JavaScript",


### PR DESCRIPTION
We missed this one when I did the renames in https://github.com/Azure/azure-webjobs-sdk-templates/commit/c5cd105875b09e0ea7ec3d0d17df4e34c984fa14.