### PR TITLE
Add authLevel setting for Http Trigger

### DIFF
--- a/Bindings/bindings.json
+++ b/Bindings/bindings.json
@@ -274,6 +274,7 @@
                 {
                     "name": "authLevel",
                     "value": "enum",
+                    "defaultValue": "function",
                     "enum": [
                         {
                             "value": "function",

--- a/Bindings/bindings.json
+++ b/Bindings/bindings.json
@@ -270,6 +270,26 @@
                     ],
                     "label": "WebHook type",
                     "help": "WebHooks allow services to call one another easily. If the type you need isn't listed here, choose 'Not a WebHook'."
+                },
+                {
+                    "name": "authLevel",
+                    "value": "enum",
+                    "enum": [
+                        {
+                            "value": "anonymous",
+                            "display":"Anonymous"
+                        },
+                        {
+                            "value": "function",
+                            "display":"Function"
+                        },
+                        {
+                            "value": "admin",
+                            "display": "Admin"
+                        }
+                    ],
+                    "label": "Authorization level",
+                    "help": "Authorization level controls whether you're using an API key and which key to use. The function & master keys are found in your host.json. For user-based authentication, go to Function App Settings."
                 }
             ]
         },

--- a/Bindings/bindings.json
+++ b/Bindings/bindings.json
@@ -276,12 +276,12 @@
                     "value": "enum",
                     "enum": [
                         {
-                            "value": "anonymous",
-                            "display":"Anonymous"
-                        },
-                        {
                             "value": "function",
                             "display":"Function"
+                        },
+                        {
+                            "value": "anonymous",
+                            "display":"Anonymous"
                         },
                         {
                             "value": "admin",
@@ -289,7 +289,7 @@
                         }
                     ],
                     "label": "Authorization level",
-                    "help": "Authorization level controls whether you're using an API key and which key to use. The function & master keys are found in your host.json. For user-based authentication, go to Function App Settings."
+                    "help": "Authorization level controls whether you're using an API key and which key to use; Function uses your function key; Admin uses your master key. The function & master keys are found in your host secrets file. For user-based authentication, go to Function App Settings."
                 }
             ]
         },

--- a/Templates/GenericWebHook-CSharp/function.json
+++ b/Templates/GenericWebHook-CSharp/function.json
@@ -5,6 +5,7 @@
             "type": "httpTrigger",
             "direction": "in",
             "webHookType": "genericJson",
+            "authLevel": "function",
             "name": "req"
         },
         {

--- a/Templates/GenericWebHook-NodeJS/function.json
+++ b/Templates/GenericWebHook-NodeJS/function.json
@@ -5,6 +5,7 @@
             "type": "httpTrigger",
             "direction": "in",
             "webHookType": "genericJson",
+            "authLevel": "function",
             "name": "req"
         },
         {

--- a/Templates/GitHubWebHook-CSharp/function.json
+++ b/Templates/GitHubWebHook-CSharp/function.json
@@ -5,6 +5,7 @@
             "type": "httpTrigger",
             "direction": "in",
             "webHookType": "github",
+            "authLevel": "function",
             "name": "req"
         },
         {

--- a/Templates/GitHubWebHook-NodeJS/function.json
+++ b/Templates/GitHubWebHook-NodeJS/function.json
@@ -5,6 +5,7 @@
             "type": "httpTrigger",
             "direction": "in",
             "webHookType": "github",
+            "authLevel": "function",
             "name": "req"
         },
         {

--- a/Templates/HttpTrigger-Batch/function.json
+++ b/Templates/HttpTrigger-Batch/function.json
@@ -4,6 +4,7 @@
         {
             "name": "req",
             "type": "httpTrigger",
+            "authLevel": "function",
             "direction": "in"
         },
         {

--- a/Templates/HttpTrigger-CSharp/function.json
+++ b/Templates/HttpTrigger-CSharp/function.json
@@ -4,6 +4,7 @@
         {
             "name": "req",
             "type": "httpTrigger",
+            "authLevel": "function",
             "direction": "in"
         },
         {

--- a/Templates/HttpTrigger-NodeJS/function.json
+++ b/Templates/HttpTrigger-NodeJS/function.json
@@ -4,6 +4,7 @@
         {
             "type": "httpTrigger",
             "direction": "in",
+            "authLevel": "function",
             "name": "req"
         },
         {


### PR DESCRIPTION
This enables the authLevel config for Http Trigger.

I've tested these settings on a production Function App.

The original enum can be found here: https://github.com/Azure/azure-webjobs-sdk-script/blob/master/src/WebJobs.Script/AuthorizationLevel.cs

Note that we're ignoring the `User` setting for now since it doesn't work as intended.