### PR TITLE
Adding Licence.txt and Readme pointer

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,21 @@
+﻿The MIT License (MIT)
+
+Copyright (c) .NET Foundation.  All rights reserved.  
+ 
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+ 
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+ 
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -71,9 +71,13 @@ To run the test script located [here](test/TemplateTest.ps1), Execute the follow
 - blobTrigger
 - timerTrigger
 
+## License
+
+This project is under the benevolent umbrella of the [.NET Foundation](http://www.dotnetfoundation.org/) and is licensed under [the MIT License](LICENSE.txt)
+
 ## Related Github Repositories
 - [Azure Functions Portal](https://github.com/projectkudu/AzureFunctionsPortal)
-- [Script SDK](https://github.com/Azure/azure-webjobs-sdk-script/)
+- [WebJobs Script SDK](https://github.com/Azure/azure-webjobs-sdk-script/)
 - [WebJobs SDK Extensions](https://github.com/Azure/azure-webjobs-sdk-extensions)
 
 ## Contribute Code or Provide Feedback


### PR DESCRIPTION
Putting the same license + readme pointer that we use for our other repos (e.g. https://github.com/Azure/azure-webjobs-sdk)