### PR TITLE
Simplifying some of the standard templates

### DIFF
--- a/Templates/BlobTrigger-Batch/function.json
+++ b/Templates/BlobTrigger-Batch/function.json
@@ -5,14 +5,7 @@
             "name": "input",
             "type": "blobTrigger",
             "direction": "in",
-            "path": "samples-input/{name}",
-            "connection": ""
-        },
-        {
-            "type": "blob",
-            "name": "output",
-            "direction": "out",
-            "path": "samples-output/{name}",
+            "path": "samples-input",
             "connection": ""
         }
     ]

--- a/Templates/BlobTrigger-Batch/run.bat
+++ b/Templates/BlobTrigger-Batch/run.bat
@@ -1,1 +1,3 @@
-copy %input% %output%
+echo OFF
+SET /p input=<%input%
+echo Windows Batch script processed blob '%input%'

--- a/Templates/QueueTrigger-Batch/function.json
+++ b/Templates/QueueTrigger-Batch/function.json
@@ -7,13 +7,6 @@
             "direction": "in",
             "queueName": "samples-batch",
             "connection":""
-        },
-        {
-            "type": "blob",
-            "name": "output",
-            "direction": "out",
-            "path": "samples-output/{id}",
-            "connection": ""
         }
     ]
 }

--- a/Templates/QueueTrigger-Batch/run.bat
+++ b/Templates/QueueTrigger-Batch/run.bat
@@ -1,4 +1,3 @@
 echo OFF
 SET /p input=<%input%
 echo Windows Batch script processed queue message '%input%'
-echo %input% > %output%

--- a/Templates/QueueTrigger-Powershell/function.json
+++ b/Templates/QueueTrigger-Powershell/function.json
@@ -7,15 +7,6 @@
             "direction": "in",
             "queueName": "samples-powershell",
             "connection":""
-        },
-        {
-            "type": "table",
-            "name": "output",
-            "direction": "out",
-            "tableName": "samples",
-            "partitionKey": "samples",
-            "rowKey": "%rand-guid%",
-            "connection": ""
         }
     ]
 }

--- a/Templates/QueueTrigger-Powershell/metadata.json
+++ b/Templates/QueueTrigger-Powershell/metadata.json
@@ -7,7 +7,6 @@
     "category": [ "Experimental" ],
     "userPrompt": [
         "connection",
-        "queueName",
-        "tableName"
+        "queueName"
     ]
 }

--- a/Templates/QueueTrigger-Powershell/run.ps1
+++ b/Templates/QueueTrigger-Powershell/run.ps1
@@ -1,6 +1,3 @@
 $in = Get-Content $Env:input
-$output = $Env:output
 
 [Console]::WriteLine("Powershell script processed queue message '$in'")
-$entity = [string]::Format('{{ "timestamp": "{0}", "title": "queue message: {1}" }}', $(get-date).ToString(), $in)
-$entity | Out-File -Encoding Ascii $output

--- a/Templates/QueueTrigger-Python/function.json
+++ b/Templates/QueueTrigger-Python/function.json
@@ -7,14 +7,6 @@
             "direction": "in",
             "queueName": "samples-python",
             "connection":""
-        },
-        {
-            "type": "table",
-            "name": "tableInput",
-            "direction": "in",
-            "tableName": "samples",
-            "take": 5,
-            "connection": ""
         }
     ]
 }

--- a/Templates/QueueTrigger-Python/metadata.json
+++ b/Templates/QueueTrigger-Python/metadata.json
@@ -7,7 +7,6 @@
     "category": [ "Experimental" ],
     "userPrompt": [
         "connection",
-        "queueName",
-        "tableName"
+        "queueName"
     ]
 }

--- a/Templates/QueueTrigger-Python/run.py
+++ b/Templates/QueueTrigger-Python/run.py
@@ -1,14 +1,6 @@
 import os
-import json
 
 # read the queue message and write to stdout
 input = open(os.environ['input']).read()
 message = "Python script processed queue message '{0}'".format(input)
 print(message)
-
-# read the entities from the table binding
-tableData = open(os.environ['tableInput'])
-table = json.load(tableData)
-print("Read {0} Table entities".format(len(table)))
-for entity in table:
-  print(entity)


### PR DESCRIPTION
For most of the standard templates (e.g. queue trigger, blob trigger) the templates should be a clean starting point, just receiving the trigger input, not performing convoluted operations on additional tables, etc. I shouldn't have to configure a table connection when starting from a queue template.

I think we're struggling with defining the difference between templates that people use day to day as starting points, v.s. samples that demonstrate different capabilities. I think many of the templates we have now are samples that should be moved to the samples repo.