### PR TITLE
Adding SendGrid output binding and templates

### DIFF
--- a/Bindings/bindings.json
+++ b/Bindings/bindings.json
@@ -389,7 +389,7 @@
                     "required": true,
                     "label": "Path",
                     "help": "The output file path",
-                    "validators": []
+                    "validators": [ ]
                 },
                 {
                     "name": "connection",
@@ -430,7 +430,7 @@
                     "required": true,
                     "label": "Path",
                     "help": "The input file path",
-                    "validators": []
+                    "validators": [ ]
                 },
                 {
                     "name": "connection",
@@ -471,7 +471,7 @@
                     "required": true,
                     "label": "Path",
                     "help": "The path to trigger on. This path must exist.",
-                    "validators": []
+                    "validators": [ ]
                 },
                 {
                     "name": "connection",
@@ -517,7 +517,7 @@
                     "required": false,
                     "label": "[variables('apiHubTableDataSetLabel')]",
                     "help": "[variables('apiHubTableDataSetHelp')]",
-                    "validators": []
+                    "validators": [ ]
                 },
                 {
                     "name": "tableName",
@@ -526,7 +526,7 @@
                     "required": false,
                     "label": "[variables('apiHubTableNameLabel')]",
                     "help": "[variables('apiHubTableHelp')]",
-                    "validators": []
+                    "validators": [ ]
                 },
                 {
                     "name": "entityId",
@@ -535,7 +535,7 @@
                     "required": false,
                     "label": "[variables('apiHubTableEntityLabel')]",
                     "help": "[variables('apiHubTableEntityHelp')]",
-                    "validators": []
+                    "validators": [ ]
                 },
                 {
                     "name": "connection",
@@ -576,7 +576,7 @@
                     "required": false,
                     "label": "[variables('apiHubTableDataSetLabel')]",
                     "help": "[variables('apiHubTableDataSetHelp')]",
-                    "validators": []
+                    "validators": [ ]
                 },
                 {
                     "name": "tableName",
@@ -585,7 +585,7 @@
                     "required": false,
                     "label": "[variables('apiHubTableNameLabel')]",
                     "help": "[variables('apiHubTableHelp')]",
-                    "validators": []
+                    "validators": [ ]
                 },
                 {
                     "name": "entityId",
@@ -594,7 +594,7 @@
                     "required": false,
                     "label": "[variables('apiHubTableEntityLabel')]",
                     "help": "[variables('apiHubTableEntityHelp')]",
-                    "validators": []
+                    "validators": [ ]
                 },
                 {
                     "name": "connection",
@@ -1357,6 +1357,45 @@
                     ],
                     "label": "Notification Platform",
                     "help": "Choose platform to send native notifcations. Select Template to send template notification."
+                }
+            ]
+        },
+        {
+            "type": "sendGrid",
+            "displayName": "SendGrid",
+            "direction": "out",
+            "settings": [
+                {
+                    "name": "to",
+                    "value": "string",
+                    "defaultValue": "",
+                    "required": false,
+                    "label": "To address",
+                    "help": "This is the email address the message should be sent to. Can be of the form 'user@host.com' or 'Display Name <user@host.com>'."
+                },
+                {
+                    "name": "from",
+                    "value": "string",
+                    "defaultValue": "",
+                    "required": false,
+                    "label": "From address",
+                    "help": "This is the email address the message is sent from. Can be of the form 'user@host.com' or 'Display Name <user@host.com>'."
+                },
+                {
+                    "name": "subject",
+                    "value": "string",
+                    "defaultValue": "",
+                    "required": false,
+                    "label": "Message Subject",
+                    "help": "This is the subject line to use for the message."
+                },
+                {
+                    "name": "text",
+                    "value": "string",
+                    "defaultValue": "",
+                    "required": false,
+                    "label": "Message Text",
+                    "help": "This is the text body to use for the message."
                 }
             ]
         }

--- a/Templates.sln
+++ b/Templates.sln
@@ -352,6 +352,22 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Test", "Test", "{84E9734A-2
 		Test\Tests.ps1 = Test\Tests.ps1
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "SendGrid-NodeJS", "SendGrid-NodeJS", "{0BF07FB0-DD2B-4865-BD62-D6A1774CEC36}"
+	ProjectSection(SolutionItems) = preProject
+		Templates\SendGrid-NodeJS\function.json = Templates\SendGrid-NodeJS\function.json
+		Templates\SendGrid-NodeJS\index.js = Templates\SendGrid-NodeJS\index.js
+		Templates\SendGrid-NodeJS\metadata.json = Templates\SendGrid-NodeJS\metadata.json
+		Templates\SendGrid-NodeJS\sample.dat = Templates\SendGrid-NodeJS\sample.dat
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "SendGrid-CSharp", "SendGrid-CSharp", "{849D87EE-A7B3-46C7-8D09-4D4C93D2EE12}"
+	ProjectSection(SolutionItems) = preProject
+		Templates\SendGrid-CSharp\function.json = Templates\SendGrid-CSharp\function.json
+		Templates\SendGrid-CSharp\metadata.json = Templates\SendGrid-CSharp\metadata.json
+		Templates\SendGrid-CSharp\run.csx = Templates\SendGrid-CSharp\run.csx
+		Templates\SendGrid-CSharp\sample.dat = Templates\SendGrid-CSharp\sample.dat
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -402,5 +418,7 @@ Global
 		{B0889BC1-1558-430A-9998-2795C90E6570} = {9131FAC9-F834-4D69-A9F3-0057D7BB5670}
 		{2CE0C2B4-F391-411F-96E4-64D8AE69B708} = {9131FAC9-F834-4D69-A9F3-0057D7BB5670}
 		{C1C799D0-ED2C-45C2-8F09-5F924323BAD7} = {9131FAC9-F834-4D69-A9F3-0057D7BB5670}
+		{0BF07FB0-DD2B-4865-BD62-D6A1774CEC36} = {9131FAC9-F834-4D69-A9F3-0057D7BB5670}
+		{849D87EE-A7B3-46C7-8D09-4D4C93D2EE12} = {9131FAC9-F834-4D69-A9F3-0057D7BB5670}
 	EndGlobalSection
 EndGlobal

--- a/Templates/SendGrid-CSharp/function.json
+++ b/Templates/SendGrid-CSharp/function.json
@@ -1,0 +1,17 @@
+﻿{
+    "bindings": [
+        {
+            "type": "queueTrigger",
+            "name": "order",
+            "direction": "in",
+            "queueName": "samples-orders-csharp"
+        },
+        {
+            "type": "sendGrid",
+            "name": "message",
+            "direction": "out",
+            "from": "Azure Functions <samples@functions.com>",
+            "to": "{CustomerEmail}"
+        }
+    ]
+}

--- a/Templates/SendGrid-CSharp/metadata.json
+++ b/Templates/SendGrid-CSharp/metadata.json
@@ -1,0 +1,17 @@
+{
+    "defaultFunctionName": "SendGridCSharp",
+    "description": "A C# function that sends a SendGrid confirmation mail whenever a new order is added to a specified Azure Storage queue",
+    "name": "SendGrid - C#",
+    "language": "C#",
+    "category": [
+        "Samples"
+    ],
+    "userPrompt": [
+        "connection",
+        "queueName",
+        "to",
+        "from",
+        "subject",
+        "text"
+    ]
+}

--- a/Templates/SendGrid-CSharp/run.csx
+++ b/Templates/SendGrid-CSharp/run.csx
@@ -1,0 +1,34 @@
+#r "SendGridMail"
+
+using System;
+using SendGrid;
+using Microsoft.Azure.WebJobs.Host;
+
+// To use this template you must configure the app setting "AzureWebJobsSendGridApiKey"
+// with your SendGrid Api key. You can also optionally configure the default From/To addresses
+// globally via host.config, e.g.:
+//
+// {
+//   "sendGrid": {
+//      "to": "user@host.com",
+//      "from": "Azure Functions <samples@functions.com>"
+//   }
+// }
+public static void Run(Order order, out SendGridMessage message, TraceWriter log)
+{
+    log.Info($"C# Queue trigger function processed order: {order.OrderId}");
+
+    message = new SendGridMessage()
+    {
+        Subject = string.Format("Thanks for your order (#{0})!", order.OrderId),
+        Text = string.Format("{0}, your order ({1}) is being processed!", order.CustomerName, order.OrderId)
+    };
+    message.AddTo(order.CustomerEmail);
+}
+
+public class Order
+{
+    public string OrderId { get; set; }
+    public string CustomerName { get; set; }
+    public string CustomerEmail { get; set; }
+}

--- a/Templates/SendGrid-CSharp/sample.dat
+++ b/Templates/SendGrid-CSharp/sample.dat
@@ -1,0 +1,1 @@
+{ "OrderId": 12345, "CustomerName": "Joe Schmoe", "CustomerEmail": "joeschmoe@foo.com" }

--- a/Templates/SendGrid-NodeJS/function.json
+++ b/Templates/SendGrid-NodeJS/function.json
@@ -1,0 +1,17 @@
+﻿{
+    "bindings": [
+        {
+            "type": "queueTrigger",
+            "name": "order",
+            "direction": "in",
+            "queueName": "samples-orders"
+        },
+        {
+            "type": "sendGrid",
+            "name": "message",
+            "direction": "out",
+            "from": "Azure Functions <samples@functions.com>",
+            "to": "{customerEmail}"
+        }
+    ]
+}

--- a/Templates/SendGrid-NodeJS/index.js
+++ b/Templates/SendGrid-NodeJS/index.js
@@ -1,0 +1,22 @@
+﻿var util = require('util');
+
+// To use this template you must configure the app setting "AzureWebJobsSendGridApiKey"
+// with your SendGrid Api key. You can also optionally configure the default From/To addresses
+// globally via host.config, e.g.:
+//
+// {
+//   "sendGrid": {
+//      "to": "user@host.com",
+//      "from": "Azure Functions <samples@functions.com>"
+//   }
+// }
+module.exports = function (context, order) {
+    context.log('Node.js queue trigger function processed order', order.orderId);
+
+    context.done(null, {
+        message: {
+            subject: util.format('Thanks for your order (#%d)!', order.orderId),
+            text: util.format("%s, your order (%d) is being processed!", order.customerName, order.orderId)
+        }
+    });
+}

--- a/Templates/SendGrid-NodeJS/metadata.json
+++ b/Templates/SendGrid-NodeJS/metadata.json
@@ -1,0 +1,17 @@
+{
+    "defaultFunctionName": "SendGridNodeJS",
+    "description": "A Node.js function that sends a SendGrid confirmation mail whenever a new order is added to a specified Azure Storage queue",
+    "name": "SendGrid - Node",
+    "language": "JavaScript",
+    "category": [
+        "Samples"
+    ],
+    "userPrompt": [
+        "connection",
+        "queueName",
+        "to",
+        "from",
+        "subject",
+        "text"
+    ]
+}

--- a/Templates/SendGrid-NodeJS/sample.dat
+++ b/Templates/SendGrid-NodeJS/sample.dat
@@ -1,0 +1,1 @@
+{ "orderId": 12345, "customerName": "Joe Schmoe", "customerEmail": "joeschmoe@foo.com" }


### PR DESCRIPTION
See corresponding addition to the runtime [here](https://github.com/Azure/azure-webjobs-sdk-script/commit/81fbaa46cc4f773840c0b5c2c4b62f56270d711a). We won't check in this template work until after that is deployed.

Question: When using this binding, a **AzureWebJobsSendGridApiKey** app setting is required to be configured. Where is the right place to indicate that dependency to the user?