### PR TITLE
Add FTP and SFTP to ApiHubFile triggers and remove Azure Blob 

### DIFF
--- a/Bindings/bindings.json
+++ b/Bindings/bindings.json
@@ -485,8 +485,7 @@
                         "capability": "blob",
                         "excluded": [
                             "googledrive",
-                            "ftp",
-                            "sftp"
+                            "azureblob"
                         ]
                     }
                 }


### PR DESCRIPTION
Add FTP and SFTP to ApiHubFile triggers and remove Azure Blob from list of triggers