### PR TITLE
Update docs

### DIFF
--- a/Documentation/apiHubFileIn.md
+++ b/Documentation/apiHubFileIn.md
@@ -1,2 +1,1 @@
-# Azure Functions Templates
-This repository contains the templates used by the [Azure Functions Portal](https://functions.azure.com/signin). Templates are pre-defined functions that demonstrate a working scenario and could be used as a starting point for more complex ones.
+This feature is experimental. Docs will be coming soon!

--- a/Documentation/apiHubFileOut.md
+++ b/Documentation/apiHubFileOut.md
@@ -1,2 +1,1 @@
-# Azure Functions Templates
-This repository contains the templates used by the [Azure Functions Portal](https://functions.azure.com/signin). Templates are pre-defined functions that demonstrate a working scenario and could be used as a starting point for more complex ones.
+This feature is experimental. Docs will be coming soon!

--- a/Documentation/apiHubFileTrigger.md
+++ b/Documentation/apiHubFileTrigger.md
@@ -1,2 +1,1 @@
-# Azure Functions Templates
-This repository contains the templates used by the [Azure Functions Portal](https://functions.azure.com/signin). Templates are pre-defined functions that demonstrate a working scenario and could be used as a starting point for more complex ones.
+This feature is experimental. Docs will be coming soon!

--- a/Documentation/apiHubTable.md
+++ b/Documentation/apiHubTable.md
@@ -1,2 +1,1 @@
-# Azure Functions Templates
-This repository contains the templates used by the [Azure Functions Portal](https://functions.azure.com/signin). Templates are pre-defined functions that demonstrate a working scenario and could be used as a starting point for more complex ones.
+This feature is experimental. Docs will be coming soon!

--- a/Documentation/apiHubTableOut.md
+++ b/Documentation/apiHubTableOut.md
@@ -1,2 +1,1 @@
-# Azure Functions Templates
-This repository contains the templates used by the [Azure Functions Portal](https://functions.azure.com/signin). Templates are pre-defined functions that demonstrate a working scenario and could be used as a starting point for more complex ones.
+This feature is experimental. Docs will be coming soon!

--- a/Documentation/blobIn.md
+++ b/Documentation/blobIn.md
@@ -1,2 +1,46 @@
-# Azure Functions Templates
-This repository contains the templates used by the [Azure Functions Portal](https://functions.azure.com/signin). Templates are pre-defined functions that demonstrate a working scenario and could be used as a starting point for more complex ones.
+#### Settings for a storage blob input binding
+
+- `name` : The variable name used in function code for the blob . 
+- `path` : A path that specifies the container to read the blob from and optionally a blob name pattern.
+- `connection` : The name of an app setting that contains a storage connection string. If you leave `connection` empty, the binding will work with the default storage connection string for the function app, which is specified by the AzureWebJobsStorage app setting.
+- `type` : Must be set to *blob*.
+- `direction` : Set to *in*
+
+#### Blob input and output supported types
+
+The `blob` binding can serialize or deserialize the following types in Node.js or C# functions:
+
+* Object
+* String
+
+In C# functions, you can also bind to the following types:
+
+* `TextReader`
+* `Stream`
+* `ICloudBlob`
+* `CloudBlockBlob` 
+* `CloudPageBlob` 
+
+#### Blob output C# code example
+
+This C# code example copies a blob whose name is received in a queue message.
+
+```csharp
+public static void Run(string myQueueItem, string myInputBlob, out string myOutputBlob, TraceWriter log)
+{
+    log.Info($"C# Queue trigger function processed: {myQueueItem}");
+    myOutputBlob = myInputBlob;
+}
+```
+
+#### Blob output JavaScript example
+
+```JavaScript
+// this assumes that your blob input is your only input
+module.exports = function(context, trigger, inputBlob) {
+    context.log(inputBlob);
+    //it's also available on context.bindings
+    context.log(context.bindings.inputBlob); // will log the same thing as above
+    context.done();
+}
+```

--- a/Documentation/blobOut.md
+++ b/Documentation/blobOut.md
@@ -1,2 +1,42 @@
-# Azure Functions Templates
-This repository contains the templates used by the [Azure Functions Portal](https://functions.azure.com/signin). Templates are pre-defined functions that demonstrate a working scenario and could be used as a starting point for more complex ones.
+#### Settings for a storage blob output binding
+
+- `name` : The variable name used in function code for the blob . 
+- `path` : A path that specifies the container to write the blob to, and optionally a blob name pattern.
+- `connection` : The name of an app setting that contains a storage connection string. If you leave `connection` empty, the binding will work with the default storage connection string for the function app, which is specified by the AzureWebJobsStorage app setting.
+- `type` : Must be set to *blob*.
+- `direction` : Set to *out*. 
+
+#### Blob input and output supported types
+
+The `blob` binding can serialize or deserialize the following types in Node.js or C# functions:
+
+* Object (`out T` in C# for output blob: creates a blob as null object if parameter value is null when the function ends)
+* String (`out string` in C# for output blob: creates a blob only if the string parameter is non-null when the function returns)
+
+In C# functions, you can also bind to the following types:
+
+* `TextWriter`
+* `Stream`
+* `CloudBlobStream`
+* `ICloudBlob`
+* `CloudBlockBlob` 
+* `CloudPageBlob` 
+
+#### Blob output C# code example
+
+```csharp
+public static void Run(string myQueueItem, string myInputBlob, out string myOutputBlob, TraceWriter log)
+{
+    log.Info($"C# Queue trigger function processed: {myQueueItem}");
+    myOutputBlob = myInputBlob;
+}
+```
+
+#### Blob output JavaScript example
+
+```JavaScript
+module.exports = function(context, trigger) {
+    context.bindings.output = { "hello":"world" }
+    context.done();
+}
+```

--- a/Documentation/blobTrigger.md
+++ b/Documentation/blobTrigger.md
@@ -1,2 +1,75 @@
-# Azure Functions Templates
-This repository contains the templates used by the [Azure Functions Portal](https://functions.azure.com/signin). Templates are pre-defined functions that demonstrate a working scenario and could be used as a starting point for more complex ones.
+#### Settings for storage blob trigger
+
+- `name` : The variable name used in function code for the blob. 
+- `path` : A path that specifies the container to monitor, and optionally a blob name pattern.
+- `connection` : The name of an app setting that contains a storage connection string. If you leave `connection` empty, the trigger will work with the default storage connection string for the function app, which is specified by the AzureWebJobsStorage app setting.
+- `type` : Must be set to *blobTrigger*.
+- `direction` : Must be set to *in*.
+
+#### Blob trigger name patterns
+
+You can specify a blob name pattern in the `path` property. For example:
+
+```json
+"path": "input/original-{name}",
+```
+
+This path would find a blob named *original-Blob1.txt* in the *input* container, and the value of the `name` variable in function code would be `Blob1`.
+
+Another example:
+
+```json
+"path": "input/{blobname}.{blobextension}",
+```
+
+This path would also find a blob named *original-Blob1.txt*, and the value of the `blobname` and `blobextension` variables in function code would be *original-Blob1* and *txt*.
+
+You can restrict the types of blobs that trigger the function by specifying a pattern with a fixed value for the file extension. If you set the `path` to  *samples/{name}.png*, only *.png* blobs in the *samples* container will trigger the function.
+
+If you need to specify a name pattern for blob names that have curly braces in the name, double the curly braces. For example, if you want to find blobs in the *images* container that have names like this:
+
+		{20140101}-soundfile.mp3
+
+use this for the `path` property:
+
+		images/{{20140101}}-{name}
+
+In the example, the `name` variable value would be *soundfile.mp3*. 
+
+#### Blob trigger supported types
+
+The blob can be deserialized to any of the following types in Node or C# functions:
+
+* Object (from JSON)
+* String
+
+In C# functions you can also bind to any of the following types:
+
+* `TextReader`
+* `Stream`
+* `ICloudBlob`
+* `CloudBlockBlob`
+* `CloudPageBlob`
+* `CloudBlobContainer`
+* `CloudBlobDirectory`
+* `IEnumerable<CloudBlockBlob>`
+* `IEnumerable<CloudPageBlob>`
+* Other types deserialized by [ICloudBlobStreamBinder](../app-service-web/websites-dotnet-webjobs-sdk-storage-blobs-how-to.md#icbsb) 
+
+#### Blob trigger C# code example
+
+```csharp
+public static void Run(string myBlob, TraceWriter log)
+{
+    log.Info($"C# Blob trigger function processed: {myBlob}");
+}
+```
+
+#### Blob trigger JavaScript example
+
+```JavaScript
+module.exports = function(context, myBlob) {
+    context.log(myBlob);
+    context.done();
+}
+```

--- a/Documentation/eventHubOut.md
+++ b/Documentation/eventHubOut.md
@@ -1,2 +1,43 @@
-# Azure Functions Templates
-This repository contains the templates used by the [Azure Functions Portal](https://functions.azure.com/signin). Templates are pre-defined functions that demonstrate a working scenario and could be used as a starting point for more complex ones.
+#### Settings for Event Hub output binding
+
+The settings for an Azure Event Hub output binding specifies the following properties:
+
+- `type` : Must be set to *eventHub*.
+- `name` : The variable name used in function code for the event hub message. 
+- `path` : The name of the event hub.
+- `connection` : The name of an app setting that contains the connection string to the namespace that the event hub resides in. Copy this connection string by clicking the **Connection Information** button for the namespace, not the event hub itself.  This connection string must have send permissions to send the message to the Event Hub stream.
+- `direction` : Must be set to *out*. 
+
+#### Azure Event Hub C# code example for output binding
+
+This example uses a Timer Trigger input, but Event Hubs output can work with any trigger.
+ 
+	using System;
+	
+	public static void Run(TimerInfo myTimer, out string outputEventHubMessage, TraceWriter log)
+	{
+	    String msg = $"TimerTriggerCSharp1 executed at: {DateTime.Now}";
+	
+	    log.Verbose(msg);   
+	    
+	    outputEventHubMessage = msg;
+	}
+
+#### Azure Event Hub Node.js code example for output binding
+
+This example uses a Timer Trigger input, but Event Hubs output can work with any trigger.
+ 
+	module.exports = function (context, myTimer) {
+	    var timeStamp = new Date().toISOString();
+	    
+	    if(myTimer.isPastDue)
+	    {
+	        context.log('TimerTriggerNodeJS1 is running late!');
+	    }
+
+	    context.log('TimerTriggerNodeJS1 function ran!', timeStamp);   
+	    
+	    context.bindings.outputEventHubMessage = "TimerTriggerNodeJS1 ran at : " + timeStamp;
+	
+	    context.done();
+	};

--- a/Documentation/eventHubTrigger.md
+++ b/Documentation/eventHubTrigger.md
@@ -1,2 +1,25 @@
-# Azure Functions Templates
-This repository contains the templates used by the [Azure Functions Portal](https://functions.azure.com/signin). Templates are pre-defined functions that demonstrate a working scenario and could be used as a starting point for more complex ones.
+#### Settings for Event Hub trigger binding
+
+The settings for an Azure Event Hub trigger specifies the following properties:
+
+- `type` : Must be set to *eventHubTrigger*.
+- `name` : The variable name used in function code for the event hub message. 
+- `direction` : Must be set to *in*. 
+- `path` : The name of the event hub.
+- `connection` : The name of an app setting that contains the connection string to the namespace that the event hub resides in. Copy this connection string by clicking the **Connection Information** button for the namespace, not the event hub itself.  This connection string must have at least read permissions to activate the trigger.
+
+#### Azure Event Hub trigger C# example
+ 
+	using System;
+	
+	public static void Run(string myEventHubMessage, TraceWriter log)
+	{
+	    log.Info($"C# Event Hub trigger function processed a message: {myEventHubMessage}");
+	}
+
+#### Azure Event Hub trigger Node.js example
+ 
+	module.exports = function (context, myEventHubMessage) {
+	    context.log('Node.js eventhub trigger function processed work item', myEventHubMessage);	
+	    context.done();
+	};

--- a/Documentation/httpOut.md
+++ b/Documentation/httpOut.md
@@ -1,2 +1,12 @@
-# Azure Functions Templates
-This repository contains the templates used by the [Azure Functions Portal](https://functions.azure.com/signin). Templates are pre-defined functions that demonstrate a working scenario and could be used as a starting point for more complex ones.
+You need this binding for http responses. Always use this with the HTTP Trigger.
+
+## Settings for HTTP and webhook bindings
+
+Properties for the HTTP response:
+
+- `name` : Variable name used in function code for the response object.
+- `type` : Must be set to *http*.
+- `direction` : Must be set to *out*. 
+
+
+See HTTP trigger for more samples

--- a/Documentation/httpTrigger.md
+++ b/Documentation/httpTrigger.md
@@ -1,2 +1,140 @@
-# Azure Functions Templates
-This repository contains the templates used by the [Azure Functions Portal](https://functions.azure.com/signin). Templates are pre-defined functions that demonstrate a working scenario and could be used as a starting point for more complex ones.
+## Settings for HTTP and webhook bindings
+
+The settings provide properties that pertain to both the request and response.
+
+Properties for the HTTP request:
+
+- `name` : Variable name used in function code for the request object (or the request body in the case of Node.js functions).
+- `type` : Must be set to *httpTrigger*.
+- `direction` : Must be set to *in*. 
+- `webHookType` : For WebHook triggers, valid values are *github*, *slack*, and *genericJson*. 
+- `authLevel` : Doesn't apply to WebHook triggers. Set to "function" to require the API key, "anonymous" to drop the API key requirement, or "admin" to require the master API key.
+
+Properties for the HTTP response:
+
+- `name` : Variable name used in function code for the response object.
+- `type` : Must be set to *http*.
+- `direction` : Must be set to *out*. 
+
+## WebHook triggers
+
+A WebHook trigger is an HTTP trigger that has the following features designed for WebHooks:
+
+* For specific WebHook providers (currently GitHub and Slack are supported), the Functions runtime validates the provider's signature.
+* For Node.js functions, the Functions runtime provides the request body instead of the request object. There is no special handling for C# functions, because you control what is provided by specifying the parameter type. If you specify `HttpRequestMessage` you get the request object. If you specify a POCO type, the Functions runtime tries to parse a JSON object in the body of the request to populate the object properties.
+* To trigger a WebHook function the HTTP request must include an API key. For non-WebHook HTTP triggers,  this requirement is optional.
+
+For information about how to set up a GitHub WebHook, see [GitHub Developer - Creating WebHooks](http://go.microsoft.com/fwlink/?LinkID=761099&clcid=0x409).
+
+## URL to trigger the function
+
+To trigger a function, you send an HTTP request to a URL that is a combination of the function app URL and the function name:
+
+```
+ https://{function app name}.azurewebsites.net/api/{function name} 
+```
+
+## API keys
+
+By default, an API key must be included with an HTTP request to trigger an HTTP or WebHook function. The key can be included in a query string variable named `code`, or it can be included in an `x-functions-key` HTTP header. For non-WebHook functions, you can indicate that an API key is not required by setting the `authLevel` property to "anonymous" in the *function.json* file.
+
+You can find API key values in the *D:\home\data\Functions\secrets* folder in the file system of the function app.  The master key and function key are set in the *host.json* file, as shown in this example. 
+
+```json
+{
+  "masterKey": "K6P2VxK6P2VxK6P2VxmuefWzd4ljqeOOZWpgDdHW269P2hb7OSJbDg==",
+  "functionKey": "OBmXvc2K6P2VxK6P2VxK6P2VxVvCdB89gChyHbzwTS/YYGWWndAbmA=="
+}
+```
+
+The function key from *host.json* can be used to trigger any function but won't trigger a disabled function. The master key can be used to trigger any function and will trigger a function even if it's disabled. You can configure a function to require the master key by setting the `authLevel` property to "admin". 
+
+If the *secrets* folder contains a JSON file with the same name as a function, the `key` property in that file can also be used to trigger the function, and this key will only work with the function it refers to. For example, the API key for a function named `HttpTrigger` is specified in *HttpTrigger.json* in the *secrets* folder. Here is an example:
+
+```json
+{
+  "key":"0t04nmo37hmoir2rwk16skyb9xsug32pdo75oce9r4kg9zfrn93wn4cx0sxo4af0kdcz69a4i"
+}
+```
+
+## Example C# code for an HTTP trigger function 
+
+```csharp
+using System.Net;
+using System.Threading.Tasks;
+
+public static async Task<HttpResponseMessage> Run(HttpRequestMessage req, TraceWriter log)
+{
+    log.Info($"C# HTTP trigger function processed a request. RequestUri={req.RequestUri}");
+
+    // parse query parameter
+    string name = req.GetQueryNameValuePairs()
+        .FirstOrDefault(q => string.Compare(q.Key, "name", true) == 0)
+        .Value;
+
+    // Get request body
+    dynamic data = await req.Content.ReadAsAsync<object>();
+
+    // Set name to query string or body data
+    name = name ?? data?.name;
+
+    return name == null
+        ? req.CreateResponse(HttpStatusCode.BadRequest, "Please pass a name on the query string or in the request body")
+        : req.CreateResponse(HttpStatusCode.OK, "Hello " + name);
+}
+```
+
+## Example Node.js code for an HTTP trigger function 
+
+```javascript
+module.exports = function(context, req) {
+    context.log('Node.js HTTP trigger function processed a request. RequestUri=%s', req.originalUrl);
+
+    if (req.query.name || (req.body && req.body.name)) {
+        context.res = {
+            // status: 200, /* Defaults to 200 */
+            body: "Hello " + (req.query.name || req.body.name)
+        };
+    }
+    else {
+        context.res = {
+            status: 400,
+            body: "Please pass a name on the query string or in the request body"
+        };
+    }
+    context.done();
+};
+```
+
+## Example C# code for a GitHub WebHook function 
+
+```csharp
+#r "Newtonsoft.Json"
+
+using System;
+using System.Net;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+
+public static async Task<object> Run(HttpRequestMessage req, TraceWriter log)
+{
+    string jsonContent = await req.Content.ReadAsStringAsync();
+    dynamic data = JsonConvert.DeserializeObject(jsonContent);
+
+    log.Info($"WebHook was triggered! Comment: {data.comment.body}");
+
+    return req.CreateResponse(HttpStatusCode.OK, new {
+        body = $"New GitHub comment: {data.comment.body}"
+    });
+}
+```
+
+## Example Node.js code for a GitHub WebHook function 
+
+```javascript
+module.exports = function (context, data) {
+    context.log('GitHub WebHook triggered!', data.comment.body);
+    context.res = { body: 'New GitHub comment: ' + data.comment.body };
+    context.done();
+};
+```

--- a/Documentation/manualTrigger.md
+++ b/Documentation/manualTrigger.md
@@ -1,2 +1,30 @@
-# Azure Functions Templates
-This repository contains the templates used by the [Azure Functions Portal](https://functions.azure.com/signin). Templates are pre-defined functions that demonstrate a working scenario and could be used as a starting point for more complex ones.
+#### Settings for manual trigger
+
+- `type` : Must be set to *manualTrigger*.
+- `name` : The variable name used in function code for the event hub message. 
+
+#### Data types
+
+Manual trigger supports
+ - Object (JSON) (C# supports `T`)
+ - String
+
+#### Manual trigger C# example
+ 
+ ```csharp
+using System;
+
+public static void Run(string trigger, TraceWriter log)
+{
+    log.Info(trigger);
+}
+```
+
+#### Manual trigger Node.js example
+ 
+ ```javascript
+module.exports = function (context, trigger) {
+    context.log(trigger);	
+    context.done();
+};
+```

--- a/Documentation/mobileTableIn.md
+++ b/Documentation/mobileTableIn.md
@@ -1,2 +1,41 @@
-# Azure Functions Templates
-This repository contains the templates used by the [Azure Functions Portal](https://functions.azure.com/signin). Templates are pre-defined functions that demonstrate a working scenario and could be used as a starting point for more complex ones.
+Using Mobile Apps table binding requires setting up an app setting. See these docs to see the full details: [go to azure.com](https://azure.microsoft.com/en-us/documentation/articles/functions-bindings-mobile-apps/#create-an-environment-variable-for-your-mobile-app-backend-url)
+
+#### Settings for Mobile Apps input binding
+
+The *function.json* file supports the following properties:
+
+- `name` : Variable name used in function code for the new record.
+- `type` : Biding type must be set to *mobileTable*.
+- `tableName` : The table where the new record will be created.
+- `id` : The ID of the record to retrieve. This property supports bindings similar to `{queueTrigger}`, which will use the string value of the queue message as the record Id.
+- `apiKey` : String that is the application setting that specifies the optional API key for the mobile app. This is required when your mobile app uses an API key to restrict client access.
+- `connection` : String that is the name of the environment variable in application settings that specifies the URL of your mobile app backend.
+- `direction` : Binding direction, which must be set to *in*.
+
+#### Azure Mobile Apps code example for a C# queue trigger
+
+The input binding retrieves the record from a Mobile Apps table endpoint with the ID that matches the queue message string and passes it to the *record* parameter. When the record is not found, the parameter is null. The record is then updated with the new *Text* value when the function exits.
+
+```csharp
+#r "Newtonsoft.Json"	
+using Newtonsoft.Json.Linq;
+
+public static void Run(string myQueueItem, JObject record)
+{
+    if (record != null)
+    {
+        record["Text"] = "This has changed.";
+    }    
+}
+```
+
+#### Azure Mobile Apps code example for a Node.js queue trigger
+
+The input binding retrieves the record from a Mobile Apps table endpoint with the ID that matches the queue message string and passes it to the *record* parameter. In Node.js functions, updated records are not sent back to the table. This code example writes the retrieved record to the log.
+
+```javascript
+module.exports = function (context, input) {    
+    context.log(context.bindings.record);
+    context.done();
+};
+```

--- a/Documentation/mobileTableOut.md
+++ b/Documentation/mobileTableOut.md
@@ -1,2 +1,40 @@
-# Azure Functions Templates
-This repository contains the templates used by the [Azure Functions Portal](https://functions.azure.com/signin). Templates are pre-defined functions that demonstrate a working scenario and could be used as a starting point for more complex ones.
+Using Mobile Apps table binding requires setting up an app setting. See these docs to see the full details: [go to azure.com](https://azure.microsoft.com/en-us/documentation/articles/functions-bindings-mobile-apps/#create-an-environment-variable-for-your-mobile-app-backend-url)
+
+#### Settings for Mobile Apps output binding
+
+The settings support the following properties:
+
+- `name` : Variable name used in function code for the new record.
+- `type` : Binding type that must be set to *mobileTable*.
+- `tableName` : The table where the new record is created.
+- `apiKey` : String that is the application setting that specifies the optional API key for the mobile app. This is required when your mobile app uses an API key to restrict client access.
+- `connection` : String that is the name of the environment variable in application settings that specifies the URL of your mobile app backend.
+- `direction` : Binding direction, which must be set to *out*.
+
+#### Azure Mobile Apps code example for a C# queue trigger
+
+This C# code example inserts a new record into a Mobile Apps table endpoint with a *Text* property into the table specified in the above binding.
+
+```csharp
+public static void Run(string myQueueItem, out object record)
+{
+    record = new {
+        Text = $"I'm running in a C# function! {myQueueItem}"
+    };
+}
+```
+
+#### Azure Mobile Apps code example for a Node.js queue trigger
+
+This Node.js code example inserts a new record into a Mobile Apps table endpoint with a *text* property into the table specified in the above binding.
+
+```javascript
+module.exports = function (context, input) {
+
+    context.bindings.record = {
+        text : "I'm running in a Node function! Data: '" + input + "'"
+    }   
+
+    context.done();
+};
+```

--- a/Documentation/notificationHubOut.md
+++ b/Documentation/notificationHubOut.md
@@ -1,2 +1,111 @@
-# Azure Functions Templates
-This repository contains the templates used by the [Azure Functions Portal](https://functions.azure.com/signin). Templates are pre-defined functions that demonstrate a working scenario and could be used as a starting point for more complex ones.
+## Settings for Azure Notification Hub output binding
+
+The settings provide the following properties:
+
+- `name` : Variable name used in function code for the notification hub message.
+- `type` : must be set to *"notificationHub"*.
+- `tagExpression` : Tag expressions allow you to specify that notifications be delivered to a set of devices who have registered to receive notifications that match the tag expression.  For more information, see [Routing and tag expressions](https://azure.microsoft.com/en-us/documentation/articles/notification-hubs-tags-segment-push-message/).
+- `hubName` : Name of the notification hub resource in the Azure portal.
+- `connection` : This connection string must be an **Application Setting** connection string set to the *DefaultFullSharedAccessSignature* value for your notification hub.
+- `direction` : must be set to *"out"*. 
+
+## Azure Notification Hub connection string setup
+
+To use a Notification hub output binding you must configure the connection string for the hub. You can do this on the *Integrate* tab by simply selecting your notification hub or creating a new one. 
+
+You can also manually add a connection string for an existing hub by adding a connection string for the *DefaultFullSharedAccessSignature* to your notification hub. This connection string provides your function access permission to send notification messages. The *DefaultFullSharedAccessSignature* connection string value can be accessed from the **keys** button in the main blade of your notification hub resource in the Azure portal. To manually add a connection string for your hub, use the following steps: 
+
+1. On the **Function app** blade of the Azure portal, click **Open Application Settings**.
+2. Scroll down to the **Connection strings** section, and add an named entry for *DefaultFullSharedAccessSignature* value for you notification hub. Change the type to **Custom**.
+3. Reference your connection string name in the output bindings. Similar to **MyHubConnectionString** used in the example above.
+
+## Azure Notification Hub code example for a Node.js timer trigger 
+
+This example sends a notification for a [template registration](../notification-hubs/notification-hubs-templates-cross-platform-push-messages.md) that contains `location` and `message`.
+
+```javascript
+module.exports = function (context, myTimer) {
+    var timeStamp = new Date().toISOString();
+    
+    if(myTimer.isPastDue)
+    {
+        context.log('Node.js is running late!');
+    }
+    context.log('Node.js timer trigger function ran!', timeStamp);  
+    context.bindings.notification = {
+        location: "Redmond",
+        message: "Hello from Node!"
+    };
+    context.done();
+};
+```
+
+## Azure Notification Hub code example for a C# queue trigger
+
+This example sends a notification for a [template registration](https://azure.microsoft.com/en-us/documentation/articles/notification-hubs-templates-cross-platform-push-messages/) that contains `message`.
+
+```csharp
+using System;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+    
+public static void Run(string myQueueItem,  out IDictionary<string, string> notification, TraceWriter log)
+{
+    log.Info($"C# Queue trigger function processed: {myQueueItem}");
+    notification = GetTemplateProperties(myQueueItem);
+}
+    
+private static IDictionary<string, string> GetTemplateProperties(string message)
+{
+    Dictionary<string, string> templateProperties = new Dictionary<string, string>();
+    templateProperties["message"] = message;
+    return templateProperties;
+}
+```
+
+This example sends a notification for a [template registration](https://azure.microsoft.com/en-us/documentation/articles/notification-hubs-templates-cross-platform-push-messages/) that contains `message` using a valid JSON string.
+
+```csharp    
+public static void Run(string myQueueItem,  out string notification, TraceWriter log)
+{
+    log.Info($"C# Queue trigger function processed: {myQueueItem}");
+    notification = "{\"message\":\"Hello from C#. Processed a queue item!\"}";
+}
+```
+
+## Azure Notification Hub queue trigger C# code example using Notification type
+
+This example shows how to use the `Notification` type that is defined in the [Microsoft Azure Notification Hubs Library](https://www.nuget.org/packages/Microsoft.Azure.NotificationHubs/). In order to use this type, and the library, you must upload a *project.json* file for your function app. The project.json file is a JSON text file which will look similar to the follow:
+```json
+{
+    "frameworks": {
+    ".NETFramework,Version=v4.6": {
+        "dependencies": {
+        "Microsoft.Azure.NotificationHubs": "1.0.4"
+        }
+    }
+    }
+}
+```
+
+For more information on uploading your project.json file, see [uploading a project.json file](https://azure.microsoft.com/en-us/documentation/articles/functions-reference-csharp/#_how-to-upload-a-projectjson-file).
+
+Example code:
+
+```csharp
+using System;
+using System.Threading.Tasks;
+using Microsoft.Azure.NotificationHubs;
+    
+public static void Run(string myQueueItem,  out Notification notification, TraceWriter log)
+{
+    log.Info($"C# Queue trigger function processed: {myQueueItem}");
+    notification = GetTemplateNotification(myQueueItem);
+}
+private static TemplateNotification GetTemplateNotification(string message)
+{
+    Dictionary<string, string> templateProperties = new Dictionary<string, string>();
+    templateProperties["message"] = message;
+    return new TemplateNotification(templateProperties);
+}
+```

--- a/Documentation/queueOut.md
+++ b/Documentation/queueOut.md
@@ -1,2 +1,70 @@
-# Azure Functions Templates
-This repository contains the templates used by the [Azure Functions Portal](https://functions.azure.com/signin). Templates are pre-defined functions that demonstrate a working scenario and could be used as a starting point for more complex ones.
+#### Settings for storage queue output binding
+
+The settings specifies the following properties.
+
+- `name` : The variable name used in function code for the queue or the queue message. 
+- `queueName` : The name of the queue. For queue naming rules, see [Naming Queues and Metadata](https://msdn.microsoft.com/library/dd179349.aspx).
+- `connection` : The name of an app setting that contains a storage connection string. If you leave `connection` empty, the trigger will work with the default storage connection string for the function app, which is specified by the AzureWebJobsStorage app setting.
+- `type` : Must be set to *queue*.
+- `direction` : Must be set to *out*. 
+
+#### C# types for Storage Queue
+
+The `queue` binding can serialize the following types to a queue message:
+
+* Object (`out T` in C#, creates a message with a null object if the parameter is null when the function ends)
+* String (`out string` in C#, creates queue message if parameter value is non-null when the function ends)
+* Byte array (`out byte[]` in C#, works like string) 
+* `out CloudQueueMessage` (C#, works like string) 
+
+In C# you can also bind to `ICollector<T>` or `IAsyncCollector<T>` where `T` is one of the supported types.
+
+#### C# Example for Storage Queue
+
+This C# code example writes a single output queue message for each input queue message.
+
+```csharp
+public static void Run(string myQueueItem, out string myOutputQueueItem, TraceWriter log)
+{
+    myOutputQueueItem = myQueueItem + "(next step)";
+}
+```
+
+This C# code example writes multiple messages by using  `ICollector<T>` (use `IAsyncCollector<T>` in an async function):
+
+```csharp
+public static void Run(string myQueueItem, ICollector<string> myQueue, TraceWriter log)
+{
+    myQueue.Add(myQueueItem + "(step 1)");
+    myQueue.Add(myQueueItem + "(step 2)");
+}
+```
+
+#### JavaScript example for Storage Queue
+
+JavaScript supports outputing a single object/string or an array of objects/strings. You access your bindings on `context.bindings` object.
+
+This shows outputing a single item:
+
+```JavaScript
+module.exports = function(context, myQueueItem) {
+    context.bindings.output = "Azure Functions are awesome!"
+    //objects also work:
+    //context.bindings.output = { "name": "world"}
+    context.done();
+}
+```
+
+This shows outputing a collection of items:
+
+```JavaScript
+module.exports = function(context, myQueueItem) {
+    context.bindings.output = [
+        {
+            "name":"world"
+        },
+        "Azure Functions are awesome!"
+    ]
+    context.done();
+}
+```

--- a/Documentation/queueTrigger.md
+++ b/Documentation/queueTrigger.md
@@ -1,2 +1,69 @@
-# Azure Functions Templates
-This repository contains the templates used by the [Azure Functions Portal](https://functions.azure.com/signin). Templates are pre-defined functions that demonstrate a working scenario and could be used as a starting point for more complex ones.
+#### Settings for storage queue trigger
+
+- `name` : The variable name used in function code for the queue or the queue message. 
+- `queueName` : The name of the queue to poll. For queue naming rules, see [Naming Queues and Metadata](https://msdn.microsoft.com/library/dd179349.aspx).
+- `connection` : The name of an app setting that contains a storage connection string. If you leave `connection` empty, the trigger will work with the default storage connection string for the function app, which is specified by the AzureWebJobsStorage app setting.
+- `type` : Must be set to *queueTrigger*.
+- `direction` : Must be set to *in*. 
+
+
+#### Additional metadata for Storage Queue trigger
+
+You can get queue metadata in your function by using these variable names:
+
+* ExpirationTime
+* InsertionTime
+* NextVisibleTime
+* Id
+* PopReceipt
+* DequeueCount
+* QueueTrigger (another way to retrieve the queue message text as a string)
+
+#### C# types for Storage Queue trigger
+
+The queue message can be deserialized to any of the following types:
+
+* Object (from JSON)
+* String
+* Byte array 
+* `CloudQueueMessage` (C#) 
+
+#### C# example for Storage Queue trigger
+
+```csharp
+public static void Run(string myQueueItem, 
+    DateTimeOffset expirationTime, 
+    DateTimeOffset insertionTime, 
+    DateTimeOffset nextVisibleTime,
+    string queueTrigger,
+    string id,
+    string popReceipt,
+    int dequeueCount,
+    TraceWriter log)
+{
+    log.Info($"C# Queue trigger function processed: {myQueueItem}\n" +
+        $"queueTrigger={queueTrigger}\n" +
+        $"expirationTime={expirationTime}\n" +
+        $"insertionTime={insertionTime}\n" +
+        $"nextVisibleTime={nextVisibleTime}\n" +
+        $"id={id}\n" +
+        $"popReceipt={popReceipt}\n" + 
+        $"dequeueCount={dequeueCount}");
+}
+```
+
+#### JavaScript example for Storage Queue trigger
+
+```JavaScript
+module.exports = function(context, myQueueItem) {
+    context.log('Dequeue Count: ' + context.bindingData.DequeueCount);
+
+    // JavaScript supports returning strings or objects for queues
+    if(typeof myQueueItem === 'string') {
+        context.log('Trigger was a string! - ' + myQueueItem);
+    } else if(typeof myQueueItem === 'object') {
+        context.log('Trigger was an object! - \n' + JSON.stringify(myQueueItem, null, ' '));
+    }
+    context.done(); //finish execution
+}
+```

--- a/Documentation/sendGridOut.md
+++ b/Documentation/sendGridOut.md
@@ -1,2 +1,1 @@
-# Azure Functions Templates
-This repository contains the templates used by the [Azure Functions Portal](https://functions.azure.com/signin). Templates are pre-defined functions that demonstrate a working scenario and could be used as a starting point for more complex ones.
+This feature is experimental. Docs will be coming soon!

--- a/Documentation/serviceBusOut.md
+++ b/Documentation/serviceBusOut.md
@@ -1,2 +1,69 @@
-# Azure Functions Templates
-This repository contains the templates used by the [Azure Functions Portal](https://functions.azure.com/signin). Templates are pre-defined functions that demonstrate a working scenario and could be used as a starting point for more complex ones.
+#### Settings for Service Bus queue or topic output binding
+
+The settings specify the following properties.
+
+- `name` : The variable name used in function code for the queue or queue message. 
+- `queueName` : For queue trigger only, the name of the queue to poll.
+- `topicName` : For topic trigger only, the name of the topic to poll.
+- `subscriptionName` : For topic trigger only, the subscription name.
+- `connection` : Same as for Service Bus trigger.
+- `accessRights` : Specifies the access rights available for the connection string. Default value is `manage`. Set to `send` if you're using a connection string that doesn't provide manage permissions. Otherwise the Functions runtime might try and fail to do operations that require manage rights, such as creating queues.
+- `type` : Must be set to *serviceBus*.
+- `direction` : Must be set to *out*. 
+
+#### Supported types
+
+Azure Functions can create a Service Bus queue message from any of the following types.
+
+* Object (always creates a JSON message, creates the message with a null object if the value is null when the function ends)
+* string (creates a message if the value is non-null when the function ends)
+* byte array (works like string) 
+* `BrokeredMessage` (C#, works like string)
+
+For creating multiple messages in a C# function, you can use `ICollector<T>` or `IAsyncCollector<T>`. A message is created when you call the `Add` method. For Node.js, you can return an array.
+
+#### C# code examples that create Service Bus queue messages
+
+```csharp
+public static void Run(TimerInfo myTimer, TraceWriter log, out string outputSbQueue)
+{
+	string message = $"Service Bus queue message created at: {DateTime.Now}";
+    log.Info(message); 
+    outputSbQueue = message;
+}
+```
+
+```csharp
+public static void Run(TimerInfo myTimer, TraceWriter log, ICollector<string> outputSbQueue)
+{
+	string message = $"Service Bus queue message created at: {DateTime.Now}";
+    log.Info(message); 
+    outputSbQueue.Add("1 " + message);
+    outputSbQueue.Add("2 " + message);
+}
+```
+
+#### Node.js code example that creates Service Bus queue messages
+
+```javascript
+module.exports = function (context, myTimer) {
+    var message = 'Service Bus queue message created at ' + timeStamp;
+    context.log(message);   
+    context.bindings.outputSbQueueMsg = message;
+    context.done();
+};
+```
+
+```javascript
+module.exports = function (context, myTimer) {
+    var message = 'Service Bus queue message created at ' + timeStamp;
+    context.log(message);   
+    context.bindings.outputSbQueueMsg = [
+        message,
+        {
+            "hello":"world"
+        }
+    ];
+    context.done();
+};
+```

--- a/Documentation/serviceBusTrigger.md
+++ b/Documentation/serviceBusTrigger.md
@@ -1,2 +1,39 @@
-# Azure Functions Templates
-This repository contains the templates used by the [Azure Functions Portal](https://functions.azure.com/signin). Templates are pre-defined functions that demonstrate a working scenario and could be used as a starting point for more complex ones.
+#### Settings for Service Bus queue or topic trigger
+
+The settings specify the following properties.
+
+- `name` : The variable name used in function code for the queue or topic, or the queue or topic message. 
+- `queueName` : For queue trigger only, the name of the queue to poll.
+- `topicName` : For topic trigger only, the name of the topic to poll.
+- `subscriptionName` : For topic trigger only, the subscription name.
+- `connection` : The name of an app setting that contains a Service Bus connection string. The connection string must be for a Service Bus namespace, not limited to a specific queue or topic. If the connection string doesn't have manage rights, set the `accessRights` property. If you leave `connection` empty, the trigger or binding will work with the default Service Bus connection string for the function app, which is specified by the AzureWebJobsServiceBus app setting.
+- `accessRights` : Specifies the access rights available for the connection string. Default value is `manage`. Set to `listen` if you're using a connection string that doesn't provide manage permissions. Otherwise the Functions runtime might try and fail to do operations that require manage rights.
+- `type` : Must be set to *serviceBusTrigger*.
+- `direction` : Must be set to *in*. 
+
+#### C# code example that processes a Service Bus queue message
+
+```csharp
+public static void Run(string myQueueItem, TraceWriter log)
+{
+    log.Info($"C# ServiceBus queue trigger function processed message: {myQueueItem}");
+}
+```
+
+#### Node.js code example that processes a Service Bus queue message
+
+```javascript
+module.exports = function(context, myQueueItem) {
+    context.log('Node.js ServiceBus queue trigger function processed message', myQueueItem);
+    context.done();
+};
+```
+
+#### Supported types
+
+The Service Bus queue message can be deserialized to any of the following types:
+
+* Object (from JSON)
+* string
+* byte array 
+* `BrokeredMessage` (C#) 

--- a/Documentation/tableIn.md
+++ b/Documentation/tableIn.md
@@ -1,2 +1,88 @@
-# Azure Functions Templates
-This repository contains the templates used by the [Azure Functions Portal](https://functions.azure.com/signin). Templates are pre-defined functions that demonstrate a working scenario and could be used as a starting point for more complex ones.
+#### Settings for storage tables
+
+- `name` : The variable name used in function code for the table binding. 
+- `tableName` : The name of the table.
+- `partitionKey` and `rowKey` : Used together to read a single entity in a C# or Node function
+- `take` : The maximum number of rows to read for table input in a Node function.
+- `filter` : OData filter expression for table input in a Node function.
+- `connection` : The name of an app setting that contains a storage connection string. 
+- `type` : Must be set to *table*.
+- `direction` : Set to *in*
+
+#### Storage tables input supported types
+
+The `table` binding can serialize or deserialize objects in Node.js or C# functions. The objects will have RowKey and PartitionKey properties. 
+
+In C# functions, you can also bind to the following types:
+
+* `T` where `T` implements `ITableEntity`
+* `IQueryable<T>` 
+
+#### Storage tables binding scenarios
+
+The table binding supports the following scenarios:
+
+* Read a single row in a C# or Node function.
+
+	Set `partitionKey` and `rowKey`. The `filter` and `take` properties are not used in this scenario.
+
+* Read multiple rows in a C# function.
+
+	The Functions runtime provides an `IQueryable<T>` object bound to the table. Type `T` must derive from `TableEntity` or implement `ITableEntity`. The `partitionKey`, `rowKey`, `filter`, and `take` properties are not used in this scenario; you can use the `IQueryable` object to do any filtering required. 
+
+* Read multiple rows in a Node function.
+
+	Set the `filter` and `take` properties. Don't set `partitionKey` or `rowKey`.
+
+
+#### Storage tables example: Read a single table entity in C# or Node
+
+The queue message has the row key value and the table entity is read into a type that is user defined. The type includes `PartitionKey` and `RowKey` properties and does not derive from `TableEntity`. 
+
+```csharp
+public static void Run(string myQueueItem, Person personEntity, TraceWriter log)
+{
+    log.Info($"C# Queue trigger function processed: {myQueueItem}");
+    log.Info($"Name in Person entity: {personEntity.Name}");
+}
+
+public class Person
+{
+    public string PartitionKey { get; set; }
+    public string RowKey { get; set; }
+    public string Name { get; set; }
+}
+```
+
+The following Node code example also works to read a single table entity.
+
+```javascript
+module.exports = function (context, myQueueItem) {
+    context.log('Node.js queue trigger function processed work item', myQueueItem);
+    context.log('Person entity name: ' + context.bindings.personEntity.Name);
+    context.done();
+};
+```
+
+#### Storage tables example: Read multiple table entities in C# 
+
+The C# code adds a reference to the Azure Storage SDK so that the entity type can derive from `TableEntity`.
+
+```csharp
+#r "Microsoft.WindowsAzure.Storage"
+using Microsoft.WindowsAzure.Storage.Table;
+
+public static void Run(string myQueueItem, IQueryable<Person> tableBinding, TraceWriter log)
+{
+    log.Info($"C# Queue trigger function processed: {myQueueItem}");
+    foreach (Person person in tableBinding.Where(p => p.PartitionKey == myQueueItem).ToList())
+    {
+        log.Info($"Name: {person.Name}");
+    }
+}
+
+public class Person : TableEntity
+{
+    public string Name { get; set; }
+}
+``` 

--- a/Documentation/tableOut.md
+++ b/Documentation/tableOut.md
@@ -1,2 +1,70 @@
-# Azure Functions Templates
-This repository contains the templates used by the [Azure Functions Portal](https://functions.azure.com/signin). Templates are pre-defined functions that demonstrate a working scenario and could be used as a starting point for more complex ones.
+#### function.json for storage tables
+
+The *function.json* specifies the following properties.
+
+- `name` : The variable name used in function code for the table binding. 
+- `tableName` : The name of the table.
+- `partitionKey` and `rowKey` : Used together to read to write a single entity in a Node function.
+- `connection` : The name of an app setting that contains a storage connection string. If you leave `connection` empty, the binding will work with the default storage connection string for the function app, which is specified by the AzureWebJobsStorage app setting.
+- `type` : Must be set to *table*.
+- `direction` : Set to *out*. 
+
+#### Storage tables input and output supported types
+
+The `table` binding can serialize or deserialize objects in Node.js or C# functions. The objects will have RowKey and PartitionKey properties. 
+
+In C# functions, you can also bind to the following types:
+
+* `T` where `T` implements `ITableEntity`
+* `ICollector<T>` 
+* `IAsyncCollector<T>`
+
+#### Storage tables binding scenarios
+
+The table binding supports the following scenarios:
+
+* Write one or more rows in a C# function.
+
+	The Functions runtime provides an `ICollector<T>` or `IAsyncCollector<T>` bound to the table, where `T` specifies the schema of the entities you want to add. Typically, type `T` derives from `TableEntity` or implements `ITableEntity`, but it doesn't have to. The `partitionKey`, `rowKey`, `filter`, and `take` properties are not used in this scenario.
+
+
+#### Storage tables example: Create table entities in C# 
+
+```csharp
+public static void Run(string input, ICollector<Person> tableBinding, TraceWriter log)
+{
+    for (int i = 1; i < 10; i++)
+        {
+            log.Info($"Adding Person entity {i}");
+            tableBinding.Add(
+                new Person() { 
+                    PartitionKey = "Test", 
+                    RowKey = i.ToString(), 
+                    Name = "Name" + i.ToString() }
+                );
+        }
+
+}
+
+public class Person
+{
+    public string PartitionKey { get; set; }
+    public string RowKey { get; set; }
+    public string Name { get; set; }
+}
+
+```
+
+#### Storage tables example: Create a table entity in Node
+
+```javascript
+module.exports = function (context, myQueueItem) {
+    context.log('Node.js queue trigger function processed work item', myQueueItem);
+    context.bindings.tableOut = {
+        "partitionKey": "123Contoso",
+        "rowKey":"Fabrikam43234",
+        "Name": "Name" + myQueueItem 
+    }
+    context.done();
+};
+```

--- a/Documentation/timerTrigger.md
+++ b/Documentation/timerTrigger.md
@@ -1,2 +1,80 @@
-# Azure Functions Templates
-This repository contains the templates used by the [Azure Functions Portal](https://functions.azure.com/signin). Templates are pre-defined functions that demonstrate a working scenario and could be used as a starting point for more complex ones.
+## Settings for timer trigger
+
+The settings provide a schedule expression. For example, the following schedule runs the function every minute:
+
+ - `schedule`: Cron tab expression which defines schedule 
+ - `name`: The variable name used in function code for the table binding. 
+ - `type`: must be *tableTrigger*
+ - `direction`: must be *in*
+
+The timer trigger handles multi-instance scale-out automatically: only a single instance of a particular timer function will be running across all instances.
+
+## Format of schedule expression
+
+The schedule expression is a [CRON expression](http://en.wikipedia.org/wiki/Cron#CRON_expression) that includes 6 fields:  `{second} {minute} {hour} {day} {month} {day of the week}`. 
+
+Note that many of the cron expressions you find online omit the {second} field, so if you copy from one of those you'll have to adjust for the extra field. 
+
+Here are some other schedule expression examples:
+
+To trigger once every 5 minutes:
+
+```json
+"schedule": "0 */5 * * * *"
+```
+
+To trigger once at the top of every hour:
+
+```json
+"schedule": "0 0 * * * *",
+```
+
+To trigger once every two hours:
+
+```json
+"schedule": "0 0 */2 * * *",
+```
+
+To trigger once every hour from 9 AM to 5 PM:
+
+```json
+"schedule": "0 0 9-17 * * *",
+```
+
+To trigger At 9:30 AM every day:
+
+```json
+"schedule": "0 30 9 * * *",
+```
+
+To trigger At 9:30 AM every weekday:
+
+```json
+"schedule": "0 30 9 * * 1-5",
+```
+
+## Timer trigger C# code example
+
+This C# code example writes a single log each time the function is triggered.
+
+```csharp
+public static void Run(TimerInfo myTimer, TraceWriter log)
+{
+    log.Info($"C# Timer trigger function executed at: {DateTime.Now}");    
+}
+```
+
+## Timer trigger JavaScript example
+
+```JavaScript
+module.exports = function(context, myTimer) {
+    if(myTimer.isPastDue)
+    {
+        context.log('Node.js is running late!');
+    }
+    context.log("Timer last triggered at " + myTimer.last);
+    context.log("Timer triggered at " + myTimer.next);
+    
+    context.done();
+}
+```


### PR DESCRIPTION
Updated docs for all bindings.

The following bindings still have an "experimental" notice in them. We need to develop docs for these. They don't exist yet.

- API Hub File Trigger, In & Out
- API Hub Table In & Out
- SendGrid