### PR TITLE
Updating F# templates to work with new model

### DIFF
--- a/Templates/Empty-FSharp/run.fsx
+++ b/Templates/Empty-FSharp/run.fsx
@@ -1,0 +1,4 @@
+open System
+
+let Run(log: TraceWriter ) =
+    log.Verbose("F# function executed.");

--- a/Templates/QueueTrigger-CSharp/readme.md
+++ b/Templates/QueueTrigger-CSharp/readme.md
@@ -4,7 +4,7 @@ The `QueueTrigger` makes it incredibly easy to react to new Queues inside of Azu
 
 ## How it works
 
-For a `QueueTrigger` to work, you provide a path which dictates where the queue messages are located inside your container.
+For a `QueueTrigger` to work, you must provide a queue name that defines the queue messages will be read from.
 
 ## Learn more
 

--- a/Templates/QueueTrigger-FSharp/readme.md
+++ b/Templates/QueueTrigger-FSharp/readme.md
@@ -1,0 +1,11 @@
+# QueueTrigger - F<span>#</span>
+
+The `QueueTrigger` makes it incredibly easy to react to new Queues inside of Azure Queue Storage. This sample demonstrates a simple use case of processing data from a given Queue using F#.
+
+## How it works
+
+For a `QueueTrigger` to work, you must provide a queue name that defines the queue messages will be read from.
+
+## Learn more
+
+<TODO> Documentation

--- a/Templates/QueueTrigger-FSharp/run.fsx
+++ b/Templates/QueueTrigger-FSharp/run.fsx
@@ -1,7 +1,4 @@
 open System
-open System.IO
 
-let inputPath = Environment.GetEnvironmentVariable("input")
-let input = File.ReadAllText(inputPath)
-let message = sprintf "F# script processed queue message '%s'" input
-System.Console.Out.WriteLine(message)
+let Run (input: string, log: TraceWriter) =  
+    log.Info(sprintf "F# Queue trigger function processed: '%s'" input)

--- a/Templates/QueueTrigger-FSharp/sample.dat
+++ b/Templates/QueueTrigger-FSharp/sample.dat
@@ -1,0 +1,1 @@
+sample queue data


### PR DESCRIPTION
Updating existing F# samples to work with the new F# language model.

**NOTE**: This will only work with the next release (runtime version 0.5.x +) and should not be pushed before that is available.