### PR TITLE
Changing text to remove the trailing # in C#

### DIFF
--- a/Documentation/tableIn.md
+++ b/Documentation/tableIn.md
@@ -64,7 +64,7 @@ module.exports = function (context, myQueueItem) {
 };
 ```
 
-#### Storage tables example: C# example tha reads multiple table entities
+#### Storage tables example: C# example that reads multiple table entities
 
 The C# code adds a reference to the Azure Storage SDK so that the entity type can derive from `TableEntity`.
 

--- a/Documentation/tableIn.md
+++ b/Documentation/tableIn.md
@@ -64,7 +64,7 @@ module.exports = function (context, myQueueItem) {
 };
 ```
 
-#### Storage tables example: Read multiple table entities in C# 
+#### Storage tables example: C# example tha reads multiple table entities
 
 The C# code adds a reference to the Azure Storage SDK so that the entity type can derive from `TableEntity`.
 

--- a/Documentation/tableOut.md
+++ b/Documentation/tableOut.md
@@ -28,7 +28,7 @@ The table binding supports the following scenarios:
 	The Functions runtime provides an `ICollector<T>` or `IAsyncCollector<T>` bound to the table, where `T` specifies the schema of the entities you want to add. Typically, type `T` derives from `TableEntity` or implements `ITableEntity`, but it doesn't have to. The `partitionKey`, `rowKey`, `filter`, and `take` properties are not used in this scenario.
 
 
-#### Storage tables example: Create table entities in C# 
+#### Storage tables example: C# code that creates table entities
 
 ```csharp
 public static void Run(string input, ICollector<Person> tableBinding, TraceWriter log)
@@ -55,7 +55,7 @@ public class Person
 
 ```
 
-#### Storage tables example: Create a table entity in Node
+#### Storage tables example: Node example that creates a table entity
 
 ```javascript
 module.exports = function (context, myQueueItem) {


### PR DESCRIPTION
marked ignores the trailing `#`. I tried escaping with `\` but that didn't work. 
A trailing `&nbsp;` is an option , where we get to keep the text as is, but I don't know how it'll look like in parsers.