### PR TITLE
Updating Twilio binding settings descriptions

### DIFF
--- a/Resources/Resources.resx
+++ b/Resources/Resources.resx
@@ -1042,16 +1042,16 @@
     <value>Invalid Cron Expression. Please consult the &lt;a target='_blank' href='https://azure.microsoft.com/en-us/documentation/articles/functions-bindings-timer/'&gt;documentation&lt;/a&gt; to learn more.</value>
   </data>
   <data name="twilioSms_accountsid_help" xml:space="preserve">
-    <value>This is your Twilio account SID</value>
+    <value>The name of the app setting containing your Twilio account SID</value>
   </data>
   <data name="twilioSms_accountsid_label" xml:space="preserve">
-    <value>Account SID</value>
+    <value>Account SID setting</value>
   </data>
   <data name="twilioSms_authtoken_help" xml:space="preserve">
-    <value>This is your Twilio Auth Token</value>
+    <value>The name of the app setting containing your Twilio Auth Token</value>
   </data>
   <data name="twilioSms_authtoken_label" xml:space="preserve">
-    <value>Twilio Auth Token</value>
+    <value>Auth Token setting</value>
   </data>
   <data name="twilioSms_body_help" xml:space="preserve">
     <value>This is the text body to use for the message. If not specified here, the value can be specified in code.</value>

--- a/Resources/cs-CZ/Resources/Resources.resx
+++ b/Resources/cs-CZ/Resources/Resources.resx
@@ -967,16 +967,16 @@
     <value>Neplatný výraz Cronu. Další informace najdete v &lt;a target='_blank' href='https://azure.microsoft.com/en-us/documentation/articles/functions-bindings-timer/'&gt;dokumentaci&lt;/a&gt;.</value>
   </data>
   <data name="twilioSms_accountsid_help" xml:space="preserve">
-    <value>This is your Twilio account SID</value>
+    <value>The name of the app setting containing your Twilio account SID</value>
   </data>
   <data name="twilioSms_accountsid_label" xml:space="preserve">
-    <value>Account SID</value>
+    <value>Account SID setting</value>
   </data>
   <data name="twilioSms_authtoken_help" xml:space="preserve">
-    <value>This is your Twilio Auth Token</value>
+    <value>The name of the app setting containing your Twilio Auth Token</value>
   </data>
   <data name="twilioSms_authtoken_label" xml:space="preserve">
-    <value>Twilio Auth Token</value>
+    <value>Auth Token setting</value>
   </data>
   <data name="twilioSms_body_help" xml:space="preserve">
     <value>This is the text body to use for the message. If not specified here, the value can be specified in code.</value>

--- a/Resources/de-DE/Resources/Resources.resx
+++ b/Resources/de-DE/Resources/Resources.resx
@@ -967,16 +967,16 @@
     <value>Ungültiger Cron-Ausdruck. Weitere Informationen finden Sie in der &lt;a target='_blank' href='https://azure.microsoft.com/de-de/documentation/articles/functions-bindings-timer/'&gt;Dokumentation&lt;/a&gt;.</value>
   </data>
   <data name="twilioSms_accountsid_help" xml:space="preserve">
-    <value>This is your Twilio account SID</value>
+    <value>The name of the app setting containing your Twilio account SID</value>
   </data>
   <data name="twilioSms_accountsid_label" xml:space="preserve">
-    <value>Account SID</value>
+    <value>Account SID setting</value>
   </data>
   <data name="twilioSms_authtoken_help" xml:space="preserve">
-    <value>This is your Twilio Auth Token</value>
+    <value>The name of the app setting containing your Twilio Auth Token</value>
   </data>
   <data name="twilioSms_authtoken_label" xml:space="preserve">
-    <value>Twilio Auth Token</value>
+    <value>Auth Token setting</value>
   </data>
   <data name="twilioSms_body_help" xml:space="preserve">
     <value>This is the text body to use for the message. If not specified here, the value can be specified in code.</value>

--- a/Resources/es-ES/Resources/Resources.resx
+++ b/Resources/es-ES/Resources/Resources.resx
@@ -967,16 +967,16 @@
     <value>Expresión CRON no válida. Para más información, consulte la &lt;a target='_blank' href='https://azure.microsoft.com/en-us/documentation/articles/functions-bindings-timer/'&gt;documentación&lt;/a&gt;.</value>
   </data>
   <data name="twilioSms_accountsid_help" xml:space="preserve">
-    <value>This is your Twilio account SID</value>
+    <value>The name of the app setting containing your Twilio account SID</value>
   </data>
   <data name="twilioSms_accountsid_label" xml:space="preserve">
-    <value>Account SID</value>
+    <value>Account SID setting</value>
   </data>
   <data name="twilioSms_authtoken_help" xml:space="preserve">
-    <value>This is your Twilio Auth Token</value>
+    <value>The name of the app setting containing your Twilio Auth Token</value>
   </data>
   <data name="twilioSms_authtoken_label" xml:space="preserve">
-    <value>Twilio Auth Token</value>
+    <value>Auth Token setting</value>
   </data>
   <data name="twilioSms_body_help" xml:space="preserve">
     <value>This is the text body to use for the message. If not specified here, the value can be specified in code.</value>

--- a/Resources/fr-FR/Resources/Resources.resx
+++ b/Resources/fr-FR/Resources/Resources.resx
@@ -967,16 +967,16 @@
     <value>Expression Cron non valide. Pour plus d'informations, consultez la &lt;a target='_blank' href='https://azure.microsoft.com/en-us/documentation/articles/functions-bindings-timer/'&gt;documentation&lt;/a&gt;.</value>
   </data>
   <data name="twilioSms_accountsid_help" xml:space="preserve">
-    <value>This is your Twilio account SID</value>
+    <value>The name of the app setting containing your Twilio account SID</value>
   </data>
   <data name="twilioSms_accountsid_label" xml:space="preserve">
-    <value>Account SID</value>
+    <value>Account SID setting</value>
   </data>
   <data name="twilioSms_authtoken_help" xml:space="preserve">
-    <value>This is your Twilio Auth Token</value>
+    <value>The name of the app setting containing your Twilio Auth Token</value>
   </data>
   <data name="twilioSms_authtoken_label" xml:space="preserve">
-    <value>Twilio Auth Token</value>
+    <value>Auth Token setting</value>
   </data>
   <data name="twilioSms_body_help" xml:space="preserve">
     <value>This is the text body to use for the message. If not specified here, the value can be specified in code.</value>

--- a/Resources/hu-HU/Resources/Resources.resx
+++ b/Resources/hu-HU/Resources/Resources.resx
@@ -967,16 +967,16 @@
     <value>Érvénytelen CRON-kifejezés. További információkért tanulmányozza a &lt;a target='_blank' href='https://azure.microsoft.com/en-us/documentation/articles/functions-bindings-timer/'&gt;dokumentációt&lt;/a&gt;.</value>
   </data>
   <data name="twilioSms_accountsid_help" xml:space="preserve">
-    <value>This is your Twilio account SID</value>
+    <value>The name of the app setting containing your Twilio account SID</value>
   </data>
   <data name="twilioSms_accountsid_label" xml:space="preserve">
-    <value>Account SID</value>
+    <value>Account SID setting</value>
   </data>
   <data name="twilioSms_authtoken_help" xml:space="preserve">
-    <value>This is your Twilio Auth Token</value>
+    <value>The name of the app setting containing your Twilio Auth Token</value>
   </data>
   <data name="twilioSms_authtoken_label" xml:space="preserve">
-    <value>Twilio Auth Token</value>
+    <value>Auth Token setting</value>
   </data>
   <data name="twilioSms_body_help" xml:space="preserve">
     <value>This is the text body to use for the message. If not specified here, the value can be specified in code.</value>

--- a/Resources/it-IT/Resources/Resources.resx
+++ b/Resources/it-IT/Resources/Resources.resx
@@ -967,16 +967,16 @@
     <value>L'espressione Cron non è valida. Per altre informazioni, vedere la &lt;a target='_blank' href='https://azure.microsoft.com/it-it/documentation/articles/functions-bindings-timer/'&gt;documentation&lt;/a&gt;.</value>
   </data>
   <data name="twilioSms_accountsid_help" xml:space="preserve">
-    <value>This is your Twilio account SID</value>
+    <value>The name of the app setting containing your Twilio account SID</value>
   </data>
   <data name="twilioSms_accountsid_label" xml:space="preserve">
-    <value>Account SID</value>
+    <value>Account SID setting</value>
   </data>
   <data name="twilioSms_authtoken_help" xml:space="preserve">
-    <value>This is your Twilio Auth Token</value>
+    <value>The name of the app setting containing your Twilio Auth Token</value>
   </data>
   <data name="twilioSms_authtoken_label" xml:space="preserve">
-    <value>Twilio Auth Token</value>
+    <value>Auth Token setting</value>
   </data>
   <data name="twilioSms_body_help" xml:space="preserve">
     <value>This is the text body to use for the message. If not specified here, the value can be specified in code.</value>

--- a/Resources/ja-JP/Resources/Resources.resx
+++ b/Resources/ja-JP/Resources/Resources.resx
@@ -967,16 +967,16 @@
     <value>無効な CRON 式です。詳細については、&lt;a target='_blank' href='https://azure.microsoft.com/en-us/documentation/articles/functions-bindings-timer/'&gt;ドキュメント&lt;/a&gt;を参照してください。</value>
   </data>
   <data name="twilioSms_accountsid_help" xml:space="preserve">
-    <value>This is your Twilio account SID</value>
+    <value>The name of the app setting containing your Twilio account SID</value>
   </data>
   <data name="twilioSms_accountsid_label" xml:space="preserve">
-    <value>Account SID</value>
+    <value>Account SID setting</value>
   </data>
   <data name="twilioSms_authtoken_help" xml:space="preserve">
-    <value>This is your Twilio Auth Token</value>
+    <value>The name of the app setting containing your Twilio Auth Token</value>
   </data>
   <data name="twilioSms_authtoken_label" xml:space="preserve">
-    <value>Twilio Auth Token</value>
+    <value>Auth Token setting</value>
   </data>
   <data name="twilioSms_body_help" xml:space="preserve">
     <value>This is the text body to use for the message. If not specified here, the value can be specified in code.</value>

--- a/Resources/ko-KR/Resources/Resources.resx
+++ b/Resources/ko-KR/Resources/Resources.resx
@@ -967,16 +967,16 @@
     <value>Cron 식이 잘못되었습니다. 자세한 내용은 &lt;a target='_blank' href='https://azure.microsoft.com/ko-kr/documentation/articles/functions-bindings-timer/'&gt;설명서&lt;/a&gt;를 참조하세요.</value>
   </data>
   <data name="twilioSms_accountsid_help" xml:space="preserve">
-    <value>This is your Twilio account SID</value>
+    <value>The name of the app setting containing your Twilio account SID</value>
   </data>
   <data name="twilioSms_accountsid_label" xml:space="preserve">
-    <value>Account SID</value>
+    <value>Account SID setting</value>
   </data>
   <data name="twilioSms_authtoken_help" xml:space="preserve">
-    <value>This is your Twilio Auth Token</value>
+    <value>The name of the app setting containing your Twilio Auth Token</value>
   </data>
   <data name="twilioSms_authtoken_label" xml:space="preserve">
-    <value>Twilio Auth Token</value>
+    <value>Auth Token setting</value>
   </data>
   <data name="twilioSms_body_help" xml:space="preserve">
     <value>This is the text body to use for the message. If not specified here, the value can be specified in code.</value>

--- a/Resources/nl-NL/Resources/Resources.resx
+++ b/Resources/nl-NL/Resources/Resources.resx
@@ -967,16 +967,16 @@
     <value>Ongeldig Cron-expressie. Raadpleeg de &lt;a target='_blank' href='https://azure.microsoft.com/en-us/documentation/articles/functions-bindings-timer/'&gt;documentatie&lt;/a&gt; voor meer informatie.</value>
   </data>
   <data name="twilioSms_accountsid_help" xml:space="preserve">
-    <value>This is your Twilio account SID</value>
+    <value>The name of the app setting containing your Twilio account SID</value>
   </data>
   <data name="twilioSms_accountsid_label" xml:space="preserve">
-    <value>Account SID</value>
+    <value>Account SID setting</value>
   </data>
   <data name="twilioSms_authtoken_help" xml:space="preserve">
-    <value>This is your Twilio Auth Token</value>
+    <value>The name of the app setting containing your Twilio Auth Token</value>
   </data>
   <data name="twilioSms_authtoken_label" xml:space="preserve">
-    <value>Twilio Auth Token</value>
+    <value>Auth Token setting</value>
   </data>
   <data name="twilioSms_body_help" xml:space="preserve">
     <value>This is the text body to use for the message. If not specified here, the value can be specified in code.</value>

--- a/Resources/pl-PL/Resources/Resources.resx
+++ b/Resources/pl-PL/Resources/Resources.resx
@@ -967,16 +967,16 @@
     <value>Nieprawidłowe wyrażenie narzędzia Cron. Zapoznaj się z &lt;a target='_blank' href='https://azure.microsoft.com/en-us/documentation/articles/functions-bindings-timer/'&gt;dokumentacją&lt;/a&gt;, aby dowiedzieć się więcej.</value>
   </data>
   <data name="twilioSms_accountsid_help" xml:space="preserve">
-    <value>This is your Twilio account SID</value>
+    <value>The name of the app setting containing your Twilio account SID</value>
   </data>
   <data name="twilioSms_accountsid_label" xml:space="preserve">
-    <value>Account SID</value>
+    <value>Account SID setting</value>
   </data>
   <data name="twilioSms_authtoken_help" xml:space="preserve">
-    <value>This is your Twilio Auth Token</value>
+    <value>The name of the app setting containing your Twilio Auth Token</value>
   </data>
   <data name="twilioSms_authtoken_label" xml:space="preserve">
-    <value>Twilio Auth Token</value>
+    <value>Auth Token setting</value>
   </data>
   <data name="twilioSms_body_help" xml:space="preserve">
     <value>This is the text body to use for the message. If not specified here, the value can be specified in code.</value>

--- a/Resources/pt-BR/Resources/Resources.resx
+++ b/Resources/pt-BR/Resources/Resources.resx
@@ -967,16 +967,16 @@
     <value>Expressão Cron inválida. Consulte a &lt;a target='_blank' href='https://azure.microsoft.com/en-us/documentation/articles/functions-bindings-timer/'&gt;documentação&lt;/a&gt; para saber mais.</value>
   </data>
   <data name="twilioSms_accountsid_help" xml:space="preserve">
-    <value>This is your Twilio account SID</value>
+    <value>The name of the app setting containing your Twilio account SID</value>
   </data>
   <data name="twilioSms_accountsid_label" xml:space="preserve">
-    <value>Account SID</value>
+    <value>Account SID setting</value>
   </data>
   <data name="twilioSms_authtoken_help" xml:space="preserve">
-    <value>This is your Twilio Auth Token</value>
+    <value>The name of the app setting containing your Twilio Auth Token</value>
   </data>
   <data name="twilioSms_authtoken_label" xml:space="preserve">
-    <value>Twilio Auth Token</value>
+    <value>Auth Token setting</value>
   </data>
   <data name="twilioSms_body_help" xml:space="preserve">
     <value>This is the text body to use for the message. If not specified here, the value can be specified in code.</value>

--- a/Resources/pt-PT/Resources/Resources.resx
+++ b/Resources/pt-PT/Resources/Resources.resx
@@ -967,16 +967,16 @@
     <value>Expressão Cron inválida. Consulte a &lt;a target='_blank' href='https://azure.microsoft.com/en-us/documentation/articles/functions-bindings-timer/'&gt;documentação&lt;/a&gt; para saber mais.</value>
   </data>
   <data name="twilioSms_accountsid_help" xml:space="preserve">
-    <value>This is your Twilio account SID</value>
+    <value>The name of the app setting containing your Twilio account SID</value>
   </data>
   <data name="twilioSms_accountsid_label" xml:space="preserve">
-    <value>Account SID</value>
+    <value>Account SID setting</value>
   </data>
   <data name="twilioSms_authtoken_help" xml:space="preserve">
-    <value>This is your Twilio Auth Token</value>
+    <value>The name of the app setting containing your Twilio Auth Token</value>
   </data>
   <data name="twilioSms_authtoken_label" xml:space="preserve">
-    <value>Twilio Auth Token</value>
+    <value>Auth Token setting</value>
   </data>
   <data name="twilioSms_body_help" xml:space="preserve">
     <value>This is the text body to use for the message. If not specified here, the value can be specified in code.</value>

--- a/Resources/ru-RU/Resources/Resources.resx
+++ b/Resources/ru-RU/Resources/Resources.resx
@@ -967,16 +967,16 @@
     <value>Недопустимое выражение Cron. Дополнительные сведения см. в &lt;a target="_blank" href="https://azure.microsoft.com/en-us/documentation/articles/functions-bindings-timer/"&gt;документации&lt;/a&gt;.</value>
   </data>
   <data name="twilioSms_accountsid_help" xml:space="preserve">
-    <value>This is your Twilio account SID</value>
+    <value>The name of the app setting containing your Twilio account SID</value>
   </data>
   <data name="twilioSms_accountsid_label" xml:space="preserve">
-    <value>Account SID</value>
+    <value>Account SID setting</value>
   </data>
   <data name="twilioSms_authtoken_help" xml:space="preserve">
-    <value>This is your Twilio Auth Token</value>
+    <value>The name of the app setting containing your Twilio Auth Token</value>
   </data>
   <data name="twilioSms_authtoken_label" xml:space="preserve">
-    <value>Twilio Auth Token</value>
+    <value>Auth Token setting</value>
   </data>
   <data name="twilioSms_body_help" xml:space="preserve">
     <value>This is the text body to use for the message. If not specified here, the value can be specified in code.</value>

--- a/Resources/sv-SE/Resources/Resources.resx
+++ b/Resources/sv-SE/Resources/Resources.resx
@@ -967,16 +967,16 @@
     <value>Ogiltigt Cron-uttryck. Mer information hittar du i &lt;a target='_blank' href='https://azure.microsoft.com/en-us/documentation/articles/functions-bindings-timer/'&gt;dokumentationen&lt;/a&gt;.</value>
   </data>
   <data name="twilioSms_accountsid_help" xml:space="preserve">
-    <value>This is your Twilio account SID</value>
+    <value>The name of the app setting containing your Twilio account SID</value>
   </data>
   <data name="twilioSms_accountsid_label" xml:space="preserve">
-    <value>Account SID</value>
+    <value>Account SID setting</value>
   </data>
   <data name="twilioSms_authtoken_help" xml:space="preserve">
-    <value>This is your Twilio Auth Token</value>
+    <value>The name of the app setting containing your Twilio Auth Token</value>
   </data>
   <data name="twilioSms_authtoken_label" xml:space="preserve">
-    <value>Twilio Auth Token</value>
+    <value>Auth Token setting</value>
   </data>
   <data name="twilioSms_body_help" xml:space="preserve">
     <value>This is the text body to use for the message. If not specified here, the value can be specified in code.</value>

--- a/Resources/tr-TR/Resources/Resources.resx
+++ b/Resources/tr-TR/Resources/Resources.resx
@@ -967,16 +967,16 @@
     <value>Geçersiz Cron İfadesi. Daha fazla bilgi için lütfen &lt;a target='_blank' href='https://azure.microsoft.com/en-us/documentation/articles/functions-bindings-timer/'&gt;belgelere&lt;/a&gt; bakın.</value>
   </data>
   <data name="twilioSms_accountsid_help" xml:space="preserve">
-    <value>This is your Twilio account SID</value>
+    <value>The name of the app setting containing your Twilio account SID</value>
   </data>
   <data name="twilioSms_accountsid_label" xml:space="preserve">
-    <value>Account SID</value>
+    <value>Account SID setting</value>
   </data>
   <data name="twilioSms_authtoken_help" xml:space="preserve">
-    <value>This is your Twilio Auth Token</value>
+    <value>The name of the app setting containing your Twilio Auth Token</value>
   </data>
   <data name="twilioSms_authtoken_label" xml:space="preserve">
-    <value>Twilio Auth Token</value>
+    <value>Auth Token setting</value>
   </data>
   <data name="twilioSms_body_help" xml:space="preserve">
     <value>This is the text body to use for the message. If not specified here, the value can be specified in code.</value>

--- a/Resources/zh-CN/Resources/Resources.resx
+++ b/Resources/zh-CN/Resources/Resources.resx
@@ -967,16 +967,16 @@
     <value>无效的 Cron 表达式。请查阅&lt;a target='_blank' href='https://azure.microsoft.com/en-us/documentation/articles/functions-bindings-timer/'&gt;文档&lt;/a&gt;以了解详细信息。</value>
   </data>
   <data name="twilioSms_accountsid_help" xml:space="preserve">
-    <value>This is your Twilio account SID</value>
+    <value>The name of the app setting containing your Twilio account SID</value>
   </data>
   <data name="twilioSms_accountsid_label" xml:space="preserve">
-    <value>Account SID</value>
+    <value>Account SID setting</value>
   </data>
   <data name="twilioSms_authtoken_help" xml:space="preserve">
-    <value>This is your Twilio Auth Token</value>
+    <value>The name of the app setting containing your Twilio Auth Token</value>
   </data>
   <data name="twilioSms_authtoken_label" xml:space="preserve">
-    <value>Twilio Auth Token</value>
+    <value>Auth Token setting</value>
   </data>
   <data name="twilioSms_body_help" xml:space="preserve">
     <value>This is the text body to use for the message. If not specified here, the value can be specified in code.</value>

--- a/Resources/zh-TW/Resources/Resources.resx
+++ b/Resources/zh-TW/Resources/Resources.resx
@@ -967,16 +967,16 @@
     <value>Cron 運算式無效。如需深入了解，請參閱&lt;a target='_blank' href='https://azure.microsoft.com/en-us/documentation/articles/functions-bindings-timer/'&gt;文件&lt;/a&gt;。</value>
   </data>
   <data name="twilioSms_accountsid_help" xml:space="preserve">
-    <value>This is your Twilio account SID</value>
+    <value>The name of the app setting containing your Twilio account SID</value>
   </data>
   <data name="twilioSms_accountsid_label" xml:space="preserve">
-    <value>Account SID</value>
+    <value>Account SID setting</value>
   </data>
   <data name="twilioSms_authtoken_help" xml:space="preserve">
-    <value>This is your Twilio Auth Token</value>
+    <value>The name of the app setting containing your Twilio Auth Token</value>
   </data>
   <data name="twilioSms_authtoken_label" xml:space="preserve">
-    <value>Twilio Auth Token</value>
+    <value>Auth Token setting</value>
   </data>
   <data name="twilioSms_body_help" xml:space="preserve">
     <value>This is the text body to use for the message. If not specified here, the value can be specified in code.</value>


### PR DESCRIPTION
Updating Twilio binding settings descriptions to make it clear that app settings should be used for Account SID and Auth Token