### PR TITLE
Adding Table binding Take default

### DIFF
--- a/Bindings/bindings.json
+++ b/Bindings/bindings.json
@@ -1225,6 +1225,7 @@
                 {
                     "name": "take",
                     "value": "int",
+                    "defaultValue": 50,
                     "required": false,
                     "label": "$tableIn_take_label",
                     "help": "$tableIn_take_help"


### PR DESCRIPTION
The binding data for Table binding results in an incorrectly configured Table binding. Repro steps:

- add a new table binding to a function and save
- note that PartitionKey/RowKey/Filter/Take properties are not defaulted (which is expected)
- add a Filter value
- PartitionKey/RowKey/Take values become defaulted to empty string, even though not all of those declare a default value in bindings
- importantly the defaulted value for Take is a string, when it should be an int

This is causing the runtime to choke on parsing the value. I've tested this locally in the Portal - it fixes the issue.