### PR TITLE
Remove default value for Notification Hub name

### DIFF
--- a/Bindings/bindings.json
+++ b/Bindings/bindings.json
@@ -1483,7 +1483,6 @@
                 {
                     "name": "hubName",
                     "value": "string",
-                    "defaultValue": "myNotificationHub",
                     "required": true,
                     "label": "$notificationHubOut_hubName_label",
                     "help": "$notificationHubOut_hubName_help"


### PR DESCRIPTION
Notification Hub name is a required value and customers might miss configuring this value if there is a default value.
