### PR TITLE
Fix permissions to be optional -- if permission was supplied, check if it is a possible value

### DIFF
--- a/Templates/SasToken-CSharp/readme.md
+++ b/Templates/SasToken-CSharp/readme.md
@@ -6,9 +6,9 @@ An HTTP trigger Azure Function that returns a SAS token for Azure Storage for th
 
 To request a SAS token, send an HTTP post to your function URI, including the API key if you've specified one. The request body format is:
 
-- `container` - *required*. Name of container in storage account
-- `blobName` - *optional*. Used to scope permissions to a particular blob
-- `permissions` - *optional*. Default value is read permissions. The format matches the enum values of SharedAccessBlobPermissions. Possible values are "Read", "Write", "Delete", "List", "Add", "Create". Comma-separate multiple permissions, such as "Read, Write, Create".
+- `ContainerName` - *required*. Name of container in storage account
+- `BlobName` - *optional*. Used to scope permissions to a particular blob
+- `Permission` - *optional*. Default value is read permissions. The format matches the enum values of SharedAccessBlobPermissions. Possible values are "Read", "Write", "Delete", "List", "Add", "Create". Comma-separate multiple permissions, such as "Read, Write, Create".
 
 ## How it works
 

--- a/Templates/SasToken-CSharp/run.csx
+++ b/Templates/SasToken-CSharp/run.csx
@@ -18,11 +18,14 @@ using Microsoft.WindowsAzure.Storage.Blob;
 public static HttpResponseMessage Run(Input input, CloudBlobDirectory blobDirectory, TraceWriter log)
 {    
     var permissions = SharedAccessBlobPermissions.Read; // default to read permissions
-    bool success = Enum.TryParse(input.Permission, out permissions);
 
-    if (!success)
+    // if permission was supplied, check if it is a possible value
+    if (!string.IsNullOrWhiteSpace(input.Permission))
     {
-        return new HttpResponseMessage(HttpStatusCode.BadRequest) { Content = new StringContent("Invalid value for 'permissions'") };
+        if (!Enum.TryParse(input.Permission, out permissions))
+        {
+            return new HttpResponseMessage(HttpStatusCode.BadRequest) { Content = new StringContent("Invalid value for 'permissions'") };
+        }
     }
 
     var container = blobDirectory.Container;


### PR DESCRIPTION
Currently, if your request body is:

```
{
"ContainerName": "someContainer"
}
```

You get _Invalid value for 'permissions'_ response.

This change allows implementation to match to documentation and make **Permissions** _optional_ while defaulting to **Read** if it is not supplied.

@fabiocav 
@soninaren 