### PR TITLE
Updating instructions to include portal parameter names

### DIFF
--- a/Functions.Templates/Documentation/cosmosDBTrigger.md
+++ b/Functions.Templates/Documentation/cosmosDBTrigger.md
@@ -4,19 +4,19 @@ The Cosmos DB Trigger leverages the [Cosmos DB Change Feed](https://docs.microso
 
 Both the collection being monitored for changes and the collection that will hold the leases need to be available for the trigger to work.
 
-The settings for an Azure Cosmos DB trigger specifies the following properties:
+The settings for an Azure Cosmos DB trigger specifies the following properties and they can be set in either the portal or by using the `function.json` in the Advanced Editor with the corresponding property names:
 
-- `type` : Must be set to *cosmosDBTrigger*.
-- `name` : The variable name used in function code for the list of documents. 
-- `direction` : Must be set to *in*. 
-- `connectionStringSetting` : The name of an app setting that contains the connection string to the service which holds the collection to monitor.
-- `databaseName` : The name of the database that holds the collection to monitor.
-- `collectionName` : The name of the collection to monitor.
-- `leaseConnectionStringSetting` : Optional. The name of an app setting that contains the connection string to the service which holds the lease collection. If not set it will connect to the service defined by `connectionStringSetting`.
-- `leaseDatabaseName` : The name of the database that holds the collection to store leases. If not set, it will use the value of `databaseName`.
-- `leaseCollectionName` : The name of the collection to store leases. If not set, it will use "leases".
-- `createLeaseCollectionIfNotExists` : true/false. Checks for existence and automatically creates the leases collection. Default is `false`.
-- `leaseCollectionThroughput` : When `createLeaseCollectionIfNotExists` is set to `true`, defines the amount of Request Units to assign to the created lease collection.
+- **Trigger type** or `type` : Must be set to *cosmosDBTrigger*.
+- **Document collection parameter name** or `name` : The variable name used in function code for the list of documents. 
+- **Trigger direction** or `direction` : Must be set to *in*. This parameter is automatically set if using the Azure Portal.
+- **Cosmos DB account connection** or `connectionStringSetting` : The name of an app setting that contains the connection string to the service which holds the collection to monitor.
+- **Database name** or `databaseName` : The name of the database that holds the collection to monitor.
+- **Collection name** or `collectionName` : The name of the collection to monitor.
+- **Cosmos DB account connection for leases** or `leaseConnectionStringSetting` : Optional. The name of an app setting that contains the connection string to the service which holds the lease collection. If not set it will connect to the service defined by `connectionStringSetting`. This parameter is automatically set if using the Azure Portal.
+- **Database name for leases** or `leaseDatabaseName` : The name of the database that holds the collection to store leases. If not set, it will use the value of `databaseName`. This parameter is automatically set if using the Azure Portal.
+- **Collection name for leases** or `leaseCollectionName` : The name of the collection to store leases. If not set, it will use "leases".
+- **Create lease collection if it does not exist** or `createLeaseCollectionIfNotExists` : true/false. Checks for existence and automatically creates the leases collection. Default is `false`.
+- **Collection throughput for leases** or `leaseCollectionThroughput` : When `createLeaseCollectionIfNotExists` is set to `true`, defines the amount of Request Units to assign to the created lease collection. This parameter is automatically set if using the Azure Portal.
 
 > Connection strings used for the Lease collection require **write permission**.
 

--- a/Functions.Templates/Documentation/documentDBIn.md
+++ b/Functions.Templates/Documentation/documentDBIn.md
@@ -1,13 +1,15 @@
 #### Settings for Cosmos DB input binding
 
-- `name` : Variable name used in function code for the document.
-- `type` : must be set to "documentdb".
-- `databaseName` : The database containing the document.
-- `collectionName` : The collection containing the document.
-- `id` : The Id of the document to retrieve. This property supports bindings similar to `{queueTrigger}`, which will use the string value of the queue message as the document Id.
-- `sqlQuery` : A Cosmos DB SQL query used for retrieving multiple documents. The query supports runtime bindings. For example: `SELECT * FROM c where c.departmentId = {departmentId}`
-- `connection` : This string must be an Application Setting set to the endpoint for your Cosmos DB account. 
-- `direction`  : must be set to *"in"*.
+The following settings can be specified in either the portal or by using the `function.json` in the Advanced Editor with the corresponding property names:
+
+- **Document parameter name** or `name` : Variable name used in function code for the document.
+- **Input type** or `type` : must be set to "documentdb". This parameter is automatically set if using the Azure Portal.
+- **Database name** or `databaseName` : The database containing the document.
+- **Collection name** or `collectionName` : The collection containing the document.
+- **Document ID** or `id` : The Id of the document to retrieve. This property supports bindings similar to `{queueTrigger}`, which will use the string value of the queue message as the document Id. This property is optional in the Azure Portal.
+- **SQL Query** or `sqlQuery` : A Cosmos DB SQL query used for retrieving multiple documents. The query supports runtime bindings. For example: `SELECT * FROM c where c.departmentId = {departmentId}`
+- **Cosmos DB account connection** or `connection` : This string must be an Application Setting set to the endpoint for your Cosmos DB account. 
+- **Input direction** or `direction`  : must be set to *"in"*. This parameter is automatically set if using the Azure Portal.
 
 The properties `id` and `sqlQuery` cannot be set at the same time. If neither `id` nor `sqlQuery` is set, the entire collection is retrieved.
 

--- a/Functions.Templates/Documentation/documentDBOut.md
+++ b/Functions.Templates/Documentation/documentDBOut.md
@@ -1,12 +1,14 @@
 #### Settings for Cosmos DB output binding
 
-- `name` : Variable name used in function code for the new document.
-- `type` : must be set to *"documentdb"*.
-- `databaseName` : The database containing the collection where the new document will be created.
-- `collectionName` : The collection where the new document will be created.
-- `createIfNotExists` : This is a boolean value to indicate whether the collection will be created if it does not exist. The default is *false*. The reason for this is new collections are created with reserved throughput, which has pricing implications. For more details, please visit the [pricing page](https://azure.microsoft.com/en-us/pricing/details/cosmos-db/).
-- `connection` : This string must be an **Application Setting** set to the endpoint for your Cosmos DB account. If you choose your account from the **Integrate** tab, a new App setting will be created for you with a name that takes the following form, `yourAccount_COSMOSDG`. If you need to manually create the App setting, the actual connection string must take the following form, `AccountEndpoint=<Endpoint for your account>;AccountKey=<Your primary access key>;`. 
-- `direction` : must be set to *"out"*. 
+The following settings can be specified in either the portal or by using the `function.json` in the Advanced Editor with the corresponding property names:
+
+- **Document parameter name** or `name` : Variable name used in function code for the new output document.
+- **Output type** or `type` : must be set to *"documentdb"*. This parameter is automatically set if using the Azure Portal.
+- **Database name** or `databaseName` : The database containing the collection where the new document will be created.
+- **Collection Name** or `collectionName` : The collection where the new document will be created.
+- **If true, creates the Cosmos DB database and collection** or `createIfNotExists` : This is a boolean value to indicate whether the collection will be created if it does not exist. The default is *false*. The reason for this is new collections are created with reserved throughput, which has pricing implications. For more details, please visit the [pricing page](https://azure.microsoft.com/en-us/pricing/details/cosmos-db/).
+- **Cosmos DB account connection** or `connection` : This string must be an **Application Setting** set to the endpoint for your Cosmos DB account. If you choose your account from the **Integrate** tab, a new App setting will be created for you with a name that takes the following form, `yourAccount_COSMOSDG`. If you need to manually create the App setting, the actual connection string must take the following form, `AccountEndpoint=<Endpoint for your account>;AccountKey=<Your primary access key>;`. 
+- **Binding direction** or `direction` : must be set to *"out"*. This is automatically set if using the Azure Portal.
 
 #### Azure Cosmos DB output code example for a JavaScript queue trigger
 


### PR DESCRIPTION
For every file:
- Specified that settings can be set both on the portal and in the `function.json` file in the Advanced options.
- Added the portal names next to the parameter names.
- Specified if any of the parameters is not on the Azure portal