### PR TITLE
Add -Raw to Get-Content

### DIFF
--- a/Functions.Templates/Templates/QueueTrigger-Powershell/run.ps1
+++ b/Functions.Templates/Templates/QueueTrigger-Powershell/run.ps1
@@ -1,2 +1,2 @@
-$in = Get-Content $triggerInput
+$in = Get-Content $triggerInput -Raw
 Write-Output "PowerShell script processed queue message '$in'"


### PR DESCRIPTION
I've found when I try to ConvertFrom-Json the $in it was failing, the issue was down the to Get-Content requiring -Raw. Might be useful for others if by default this is set