### PR TITLE
Removing azurefile and filesystem from ExternalFile triggers

### DIFF
--- a/Functions.Templates/Bindings/bindings.json
+++ b/Functions.Templates/Bindings/bindings.json
@@ -567,7 +567,9 @@
             "capability": "blob",
             "excluded": [
               "googledrive",
-              "azureblob"
+              "azureblob",
+              "azurefile",
+              "filesystem"
             ]
           }
         }


### PR DESCRIPTION
Removing azurefile and filesystem from ExternalFile triggers as they are not supported.