### PR TITLE
Fixing Cosmos trigger templates for Consumption Plan

### DIFF
--- a/Functions.Templates/Templates/CosmosDBTrigger-CSharp/CosmosDBTriggerCSharp.cs
+++ b/Functions.Templates/Templates/CosmosDBTrigger-CSharp/CosmosDBTriggerCSharp.cs
@@ -23,8 +23,10 @@ namespace Company.Function
         public static void Run([CosmosDBTrigger("DatabaseValue", "CollectionValue", ConnectionStringSetting = "ConnectionValue", LeaseDatabaseName = "LeaseDatabaseValue", LeaseCollectionName = "LeaseCollectionValue")] IReadOnlyList<Document> input, TraceWriter log)
 #endif
         {
-            log.Verbose("Documents modified " + input.Count);
-            log.Verbose("First document Id " + input[0].Id);
+            if (input != null && input.Count > 0) {
+                log.Verbose("Documents modified " + input.Count);
+                log.Verbose("First document Id " + input[0].Id);
+            }
         }
 #if (vsTemplates)
     }

--- a/Functions.Templates/Templates/CosmosDBTrigger-JavaScript/index.js
+++ b/Functions.Templates/Templates/CosmosDBTrigger-JavaScript/index.js
@@ -1,5 +1,7 @@
 module.exports = function (context, input) {
-    context.log('Document Id: ', input[0].id);
+    if (!!input && input.length > 0) {
+        context.log('Document Id: ', input[0].id);
+    }
 
     context.done();
 }


### PR DESCRIPTION
When a Function is created on Consumption Plan (not Dedicated), the Function gets a first time trigger with an empty list that generates a runtime error on the template.