### PR TITLE
Change AuthenticationHeaderValue scheme to "token"

### DIFF
--- a/Functions.Templates/Templates/GitHubCommenter-CSharp/GitHubCommenterCSharp.cs
+++ b/Functions.Templates/Templates/GitHubCommenter-CSharp/GitHubCommenterCSharp.cs
@@ -60,9 +60,9 @@ namespace Company.Function
                 client.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("username", "version"));
 
                 // Add the GITHUB_CREDENTIALS as an app setting, Value for the app setting is a base64 encoded string in the following format
-                // "Username:Password" or "Username:PersonalAccessToken"
+                // "PersonalAccessToken"
                 // Please follow the link https://developer.github.com/v3/oauth/ to get more information on GitHub authentication 
-                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", Environment.GetEnvironmentVariable("GITHUB_CREDENTIALS"));
+                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("token", Environment.GetEnvironmentVariable("GITHUB_CREDENTIALS"));
                 var content = new StringContent(requestBody, Encoding.UTF8, "application/json");
                 await client.PostAsync(url, content);
             }


### PR DESCRIPTION
When the scheme is set to "Basic", neither of the formats given for the "GITHUB_CREDENTIALS" setting are able to successfully authenticate the account.

I was able to successfully authenticate against GitHub and have the function comment on the issue opened by switching the scheme from "Basic" to "token" (See [this](https://developer.github.com/v3/#oauth2-token-sent-in-a-header) section in the Rest API v3 doc).