### PR TITLE
Renaming Cosmos DB Trigger input parameter to "documents"

### DIFF
--- a/Functions.Templates/Templates/CosmosDBTrigger-CSharp/CosmosDBTriggerCSharp.cs
+++ b/Functions.Templates/Templates/CosmosDBTrigger-CSharp/CosmosDBTriggerCSharp.cs
@@ -4,7 +4,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.Azure.Documents;
 
-public static void Run(IReadOnlyList<Document> input, TraceWriter log)
+public static void Run(IReadOnlyList<Document> documents, TraceWriter log)
 #endif
 #if (vsTemplates)
 using System.Collections.Generic;
@@ -21,12 +21,12 @@ namespace Company.Function
             databaseName: "DatabaseValue",
             collectionName: "CollectionValue",
             ConnectionStringSetting = "ConnectionValue",
-            LeaseCollectionName = "leases")]IReadOnlyList<Document> input, TraceWriter log)
+            LeaseCollectionName = "leases")]IReadOnlyList<Document> documents, TraceWriter log)
 #endif
         {
-            if (input != null && input.Count > 0) {
-                log.Verbose("Documents modified " + input.Count);
-                log.Verbose("First document Id " + input[0].Id);
+            if (documents != null && documents.Count > 0) {
+                log.Verbose("Documents modified " + documents.Count);
+                log.Verbose("First document Id " + documents[0].Id);
             }
         }
 #if (vsTemplates)

--- a/Functions.Templates/Templates/CosmosDBTrigger-CSharp/function.json
+++ b/Functions.Templates/Templates/CosmosDBTrigger-CSharp/function.json
@@ -2,7 +2,7 @@
   "bindings": [
     {
       "type": "cosmosDBTrigger",
-      "name": "input",
+      "name": "documents",
       "direction": "in",
       "leaseCollectionName": "leases"
     }

--- a/Functions.Templates/Templates/CosmosDBTrigger-JavaScript/function.json
+++ b/Functions.Templates/Templates/CosmosDBTrigger-JavaScript/function.json
@@ -2,7 +2,7 @@
   "bindings": [
     {
       "type": "cosmosDBTrigger",
-      "name": "input",
+      "name": "documents",
       "direction": "in",
       "leaseCollectionName": "leases"
     }

--- a/Functions.Templates/Templates/CosmosDBTrigger-JavaScript/index.js
+++ b/Functions.Templates/Templates/CosmosDBTrigger-JavaScript/index.js
@@ -1,6 +1,6 @@
-module.exports = function (context, input) {
-    if (!!input && input.length > 0) {
-        context.log('Document Id: ', input[0].id);
+module.exports = function (context, documents) {
+    if (!!documents && documents.length > 0) {
+        context.log('Document Id: ', documents[0].id);
     }
 
     context.done();


### PR DESCRIPTION
This PR fixes #576 by renaming the variable that holds the documents that triggered the Function.