### PR TITLE
update bindings.json settings for sql extension

### DIFF
--- a/Functions.Templates/Bindings/bindings-bundle-v4.json
+++ b/Functions.Templates/Bindings/bindings-bundle-v4.json
@@ -1887,7 +1887,7 @@
         {
           "name": "commandText",
           "value": "string",
-          "defaultValue": "Select * from object",
+          "defaultValue": "SELECT * FROM Products",
           "required": true,
           "label": "$sqlIn_commandText_label",
           "help": "$sqlIn_commandText_help"

--- a/Functions.Templates/Bindings/bindings-bundle-v4.json
+++ b/Functions.Templates/Bindings/bindings-bundle-v4.json
@@ -1867,7 +1867,7 @@
       "enabledInTryMode": false,
       "documentation": "$content=Documentation\\sqlIn.md",
       "extension": {
-        "id": "Microsoft.Azure.WebJobs.Extensions.Sql", "version": "1.0.122-preview"
+        "id": "Microsoft.Azure.WebJobs.Extensions.Sql", "version": "2.0.144"
       },
       "settings": [
         {
@@ -1936,7 +1936,7 @@
       "enabledInTryMode": false,
       "documentation": "$content=Documentation\\sqlOut.md",
       "extension": {
-        "id": "Microsoft.Azure.WebJobs.Extensions.Sql", "version": "1.0.122-preview"
+        "id": "Microsoft.Azure.WebJobs.Extensions.Sql", "version": "2.0.144"
       },
       "settings": [
         {

--- a/Functions.Templates/Bindings/bindings-bundle-v4.json
+++ b/Functions.Templates/Bindings/bindings-bundle-v4.json
@@ -1905,8 +1905,8 @@
           "value": "string",
           "defaultValue": "SqlConnectionString",
           "required": true,
-          "label": "$sqlIn_connection_label",
-          "help": "$sqlIn_connection_help",
+          "label": "$sql_connection_label",
+          "help": "$sql_connection_help",
           "placeholder": "[variables('selectConnection')]"
         },
         {
@@ -1964,8 +1964,8 @@
           "value": "string",
           "defaultValue": "SqlConnectionString",
           "required": true,
-          "label": "$sqlOut_connection_label",
-          "help": "$sqlOut_connection_help",
+          "label": "$sql_connection_label",
+          "help": "$sql_connection_help",
           "placeholder": "[variables('selectConnection')]"
         }
       ]

--- a/Functions.Templates/Bindings/bindings-bundle-v4.json
+++ b/Functions.Templates/Bindings/bindings-bundle-v4.json
@@ -1859,6 +1859,116 @@
           "help": "$signalROut_connectionString_help"
         }
       ]
+    },
+    {
+      "type": "sql",
+      "displayName": "$sqlIn_displayName",
+      "direction": "in",
+      "enabledInTryMode": false,
+      "documentation": "$content=Documentation\\sqlIn.md",
+      "extension": {
+        "id": "Microsoft.Azure.WebJobs.Extensions.Sql", "version": "1.0.122-preview"
+      },
+      "settings": [
+        {
+          "name": "name",
+          "value": "string",
+          "defaultValue": "object",
+          "required": true,
+          "label": "$sqlIn_name_label",
+          "help": "$sqlIn_name_help",
+          "validators": [
+            {
+              "expression": "^[a-zA-Z][a-zA-Z0-9]{0,127}$",
+              "errorText": "[variables('parameterName')]"
+            }
+          ]
+        },
+        {
+          "name": "commandText",
+          "value": "string",
+          "defaultValue": "Select * from object",
+          "required": true,
+          "label": "$sqlIn_commandText_label",
+          "help": "$sqlIn_commandText_help"
+        },
+        {
+          "name": "commandType",
+          "value": "string",
+          "defaultValue": "Text",
+          "required": false,
+          "label": "$sqlIn_commandType_label",
+          "help": "$sqlIn_commandType_help"
+        },
+        {
+          "name": "connectionStringSetting",
+          "value": "string",
+          "defaultValue": "SqlConnectionString",
+          "required": true,
+          "label": "$sqlIn_connection_label",
+          "help": "$sqlIn_connection_help",
+          "placeholder": "[variables('selectConnection')]"
+        },
+        {
+          "name": "parameters",
+          "value": "string",
+          "defaultValue": "",
+          "required": false,
+          "label": "$sqlIn_parameters_label",
+          "help": "$sqlIn_parameters_help"
+        }
+      ]
+    },
+    {
+      "type": "sql",
+      "displayName": "$sqlOut_displayName",
+      "direction": "out",
+      "enabledInTryMode": false,
+      "documentation": "$content=Documentation\\sqlOut.md",
+      "extension": {
+        "id": "Microsoft.Azure.WebJobs.Extensions.Sql", "version": "1.0.122-preview"
+      },
+      "settings": [
+        {
+          "name": "name",
+          "value": "string",
+          "defaultValue": "object",
+          "required": true,
+          "label": "$sqlOut_name_label",
+          "help": "$sqlOut_name_help",
+          "validators": [
+            {
+              "expression": "^[a-zA-Z][a-zA-Z0-9]{0,127}$",
+              "errorText": "[variables('parameterName')]"
+            }
+          ]
+        },
+        {
+          "name": "commandText",
+          "value": "string",
+          "defaultValue": "object",
+          "required": true,
+          "label": "$sqlOut_commandText_label",
+          "help": "$sqlOut_commandText_help"
+        },
+        {
+          "name": "commandType",
+          "value": "string",
+          "defaultValue": "Text",
+          "required": false,
+          "label": "$sqlOut_commandType_label",
+          "help": "$sqlOut_commandType_help"
+        },
+        {
+          "name": "connectionStringSetting",
+          "value": "string",
+          "defaultValue": "SqlConnectionString",
+          "required": true,
+          "label": "$sqlOut_connection_label",
+          "help": "$sqlOut_connection_help",
+          "placeholder": "[variables('selectConnection')]"
+        }
+      ]
     }
   ]
 }

--- a/Functions.Templates/Bindings/bindings-bundle-v4.json
+++ b/Functions.Templates/Bindings/bindings-bundle-v4.json
@@ -1952,14 +1952,6 @@
           "help": "$sqlOut_commandText_help"
         },
         {
-          "name": "commandType",
-          "value": "string",
-          "defaultValue": "Text",
-          "required": false,
-          "label": "$sqlOut_commandType_label",
-          "help": "$sqlOut_commandType_help"
-        },
-        {
           "name": "connectionStringSetting",
           "value": "string",
           "defaultValue": "SqlConnectionString",

--- a/Functions.Templates/Bindings/bindings-bundle-v4.json
+++ b/Functions.Templates/Bindings/bindings-bundle-v4.json
@@ -1894,9 +1894,19 @@
         },
         {
           "name": "commandType",
-          "value": "string",
-          "defaultValue": "Text",
+          "value": "enum",
           "required": false,
+          "defaultValue":"Text",
+          "enum": [
+            {
+              "value": "Text",
+              "display": "Text"
+            },
+            {
+              "value": "StoredProcedure",
+              "display": "StoredProcedure"
+            }
+          ],
           "label": "$sqlIn_commandType_label",
           "help": "$sqlIn_commandType_help"
         },

--- a/Functions.Templates/Documentation/sqlIn.md
+++ b/Functions.Templates/Documentation/sqlIn.md
@@ -1,0 +1,42 @@
+#### Settings for a sql input binding
+
+See [Input Binding Overview](https://github.com/Azure/azure-functions-sql-extension/blob/main/docs/BindingsOverview.md#input-binding) for general information about the Azure SQL Input binding.
+
+The settings for a Sql input binding specifies the following properties:
+
+- `type` : Must be set to *sql*.
+- `name` : The name of the variable that represents the query results in function code.
+- `direction` : Must be set to *in*.
+- `commandText` : The Transact-SQL query command or name of the stored procedure executed by the binding.
+- `connectionStringSetting` : The name of an app setting that contains the connection string for the database against which the query or stored procedure is being executed. This value isn't the actual connection string and must instead resolve to an environment variable name.  Optional keywords in the connection string value are [available to refine SQL bindings connectivity](https://aka.ms/sqlbindings#sql-connection-string).
+- `commandType` : A [CommandType](https://learn.microsoft.com/dotnet/api/system.data.commandtype) value, which is [Text](https://learn.microsoft.com/dotnet/api/system.data.commandtype#fields) for a query and [StoredProcedure](https://learn.microsoft.com/dotnet/api/system.data.commandtype#fields) for a stored procedure.
+- `parameters` : *optional*. Zero or more parameter values passed to the command during execution as a single string. Must follow the format `@param1=param1,@param2=param2`. Neither the parameter name nor the parameter value can contain a comma (`,`) or an equals sign (`=`).
+
+#### Sql input C# code example
+
+This C# code example copies a blob whose name is received in a queue message.
+
+```csharp
+[FunctionName("GetProducts")]
+  public static IActionResult Run(
+      [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "getproducts/{cost}")]
+      HttpRequest req,
+      [Sql("select * from Products where Cost = @Cost",
+          "SqlConnectionString",
+          parameters: "@Cost={cost}")]
+      IEnumerable<Product> products)
+  {
+      return (ActionResult)new OkObjectResult(products);
+  }
+```
+
+#### Sql input JavaScript example
+
+```JavaScript
+ module.exports = async function (context, req, product) {
+        return {
+            status: 200,
+            body: product
+        };
+}
+```

--- a/Functions.Templates/Documentation/sqlIn.md
+++ b/Functions.Templates/Documentation/sqlIn.md
@@ -14,7 +14,7 @@ The settings for a SQL input binding specifies the following properties:
 
 #### SQL input C# code example
 
-This C# code example copies a blob whose name is received in a queue message.
+This C# code example for getting data from Products table. Please refer to our [InputBinding C# Samples](https://github.com/Azure/azure-functions-sql-extension/tree/main/samples/samples-csharpscript/InputBindingSamples) for more examples.
 
 ```csharp
 [FunctionName("GetProducts")]
@@ -31,6 +31,8 @@ This C# code example copies a blob whose name is received in a queue message.
 ```
 
 #### SQL input JavaScript example
+
+ You can browse here for more [JavaScript Samples](https://github.com/Azure/azure-functions-sql-extension/tree/main/samples/samples-js).
 
 ```JavaScript
  module.exports = async function (context, req, product) {

--- a/Functions.Templates/Documentation/sqlIn.md
+++ b/Functions.Templates/Documentation/sqlIn.md
@@ -1,4 +1,4 @@
-#### Settings for a Azure SQL input binding
+#### Settings for an Azure SQL input binding
 
 See [Input Binding Overview](https://github.com/Azure/azure-functions-sql-extension/blob/main/docs/BindingsOverview.md#input-binding) for general information about the Azure SQL Input binding.
 

--- a/Functions.Templates/Documentation/sqlIn.md
+++ b/Functions.Templates/Documentation/sqlIn.md
@@ -1,8 +1,8 @@
-#### Settings for a sql input binding
+#### Settings for a Azure SQL input binding
 
 See [Input Binding Overview](https://github.com/Azure/azure-functions-sql-extension/blob/main/docs/BindingsOverview.md#input-binding) for general information about the Azure SQL Input binding.
 
-The settings for a Sql input binding specifies the following properties:
+The settings for a SQL input binding specifies the following properties:
 
 - `type` : Must be set to *sql*.
 - `name` : The name of the variable that represents the query results in function code.
@@ -12,7 +12,7 @@ The settings for a Sql input binding specifies the following properties:
 - `commandType` : A [CommandType](https://learn.microsoft.com/dotnet/api/system.data.commandtype) value, which is [Text](https://learn.microsoft.com/dotnet/api/system.data.commandtype#fields) for a query and [StoredProcedure](https://learn.microsoft.com/dotnet/api/system.data.commandtype#fields) for a stored procedure.
 - `parameters` : *optional*. Zero or more parameter values passed to the command during execution as a single string. Must follow the format `@param1=param1,@param2=param2`. Neither the parameter name nor the parameter value can contain a comma (`,`) or an equals sign (`=`).
 
-#### Sql input C# code example
+#### SQL input C# code example
 
 This C# code example copies a blob whose name is received in a queue message.
 
@@ -30,7 +30,7 @@ This C# code example copies a blob whose name is received in a queue message.
   }
 ```
 
-#### Sql input JavaScript example
+#### SQL input JavaScript example
 
 ```JavaScript
  module.exports = async function (context, req, product) {

--- a/Functions.Templates/Documentation/sqlOut.md
+++ b/Functions.Templates/Documentation/sqlOut.md
@@ -1,8 +1,8 @@
-#### Settings for a sql output binding
+#### Settings for a Azure SQL output binding
 
 See [Output Binding Overview](https://github.com/Azure/azure-functions-sql-extension/blob/main/docs/BindingsOverview.md#output-binding) for general information about the Azure SQL output binding.
 
-The settings for a Sql output binding specifies the following properties:
+The settings for a SQL output binding specifies the following properties:
 
 - `type` : Must be set to *sql*.
 - `name` : The name of the variable that represents the entity in function code.
@@ -10,7 +10,7 @@ The settings for a Sql output binding specifies the following properties:
 - `commandText` : The name of the table being written to by the binding.
 - `connectionStringSetting` : The name of an app setting that contains the connection string for the database to which data is being written. This isn't the actual connection string and must instead resolve to an environment variable. Optional keywords in the connection string value are [available to refine SQL bindings connectivity](https://aka.ms/sqlbindings#sql-connection-string).
 
-#### Sql output C# code example
+#### SQL output C# code example
 
 This C# code example upserts employees to Employees table.
 
@@ -45,7 +45,7 @@ public static IActionResult Run(
     }
 ```
 
-#### Sql output JavaScript example
+#### SQL output JavaScript example
 
 ```JavaScript
  module.exports = async function (context, req) {

--- a/Functions.Templates/Documentation/sqlOut.md
+++ b/Functions.Templates/Documentation/sqlOut.md
@@ -16,7 +16,7 @@ This C# code example upserts employees to Employees table.
 
 ```csharp
 public static IActionResult Run(
-        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "addemployees-array")]
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "addemployees")]
         HttpRequest req, ILogger log,
         [Sql("dbo.Employees", "SqlConnectionString")]
         out Employee[] output)
@@ -41,7 +41,7 @@ public static IActionResult Run(
                 },
             };
 
-        return new CreatedResult($"/api/addemployees-array", output);
+        return new CreatedResult($"/api/addemployees", output);
     }
 ```
 

--- a/Functions.Templates/Documentation/sqlOut.md
+++ b/Functions.Templates/Documentation/sqlOut.md
@@ -1,4 +1,4 @@
-#### Settings for a Azure SQL output binding
+#### Settings for an Azure SQL output binding
 
 See [Output Binding Overview](https://github.com/Azure/azure-functions-sql-extension/blob/main/docs/BindingsOverview.md#output-binding) for general information about the Azure SQL output binding.
 

--- a/Functions.Templates/Documentation/sqlOut.md
+++ b/Functions.Templates/Documentation/sqlOut.md
@@ -1,0 +1,75 @@
+#### Settings for a sql output binding
+
+See [Output Binding Overview](https://github.com/Azure/azure-functions-sql-extension/blob/main/docs/BindingsOverview.md#output-binding) for general information about the Azure SQL output binding.
+
+The settings for a Sql output binding specifies the following properties:
+
+- `type` : Must be set to *sql*.
+- `name` : The name of the variable that represents the entity in function code.
+- `direction` : Must be set to *out*.
+- `commandText` : The name of the table being written to by the binding.
+- `connectionStringSetting` : The name of an app setting that contains the connection string for the database to which data is being written. This isn't the actual connection string and must instead resolve to an environment variable. Optional keywords in the connection string value are [available to refine SQL bindings connectivity](https://aka.ms/sqlbindings#sql-connection-string).
+
+#### Sql output C# code example
+
+This C# code example upserts employees to Employees table.
+
+```csharp
+public static IActionResult Run(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "addemployees-array")]
+        HttpRequest req, ILogger log,
+        [Sql("dbo.Employees", "SqlConnectionString")]
+        out Employee[] output)
+    {
+        output = new Employee[]
+            {
+                new Employee
+                {
+                    EmployeeId = 1,
+                    FirstName = "Hello",
+                    LastName = "World",
+                    Company = "Microsoft",
+                    Team = "Functions"
+                },
+                new Employee
+                {
+                    EmployeeId = 2,
+                    FirstName = "Hi",
+                    LastName = "SQLupdate",
+                    Company = "Microsoft",
+                    Team = "Functions"
+                },
+            };
+
+        return new CreatedResult($"/api/addemployees-array", output);
+    }
+```
+
+#### Sql output JavaScript example
+
+```JavaScript
+ module.exports = async function (context, req) {
+        const employees = [
+            {
+                EmployeeId : 1,
+                FirstName : "Hello",
+                LastName : "World",
+                Company : "Microsoft",
+                Team : "Functions"
+            },
+            {
+                EmployeeId : 2,
+                FirstName : "Hi",
+                LastName : "SQLupdate",
+                Company : "Microsoft",
+                Team : "Functions"
+            }
+        ];
+        context.bindings.employee = employees;
+
+        return {
+            status: 201,
+            body: employees
+        };
+    }
+```

--- a/Functions.Templates/Documentation/sqlOut.md
+++ b/Functions.Templates/Documentation/sqlOut.md
@@ -12,7 +12,7 @@ The settings for a SQL output binding specifies the following properties:
 
 #### SQL output C# code example
 
-This C# code example upserts employees to Employees table.
+This C# code example upserts employees to Employees table. Please refer to our [OutputBinding C# Samples](https://github.com/Azure/azure-functions-sql-extension/tree/main/samples/samples-csharpscript/OutputBindingSamples) for more examples.
 
 ```csharp
 public static IActionResult Run(
@@ -46,6 +46,8 @@ public static IActionResult Run(
 ```
 
 #### SQL output JavaScript example
+
+You can browse here for more [JavaScript Samples](https://github.com/Azure/azure-functions-sql-extension/tree/main/samples/samples-js).
 
 ```JavaScript
  module.exports = async function (context, req) {

--- a/Functions.Templates/Resources/Resources.resx
+++ b/Functions.Templates/Resources/Resources.resx
@@ -1945,4 +1945,52 @@ function app.</value>
   <data name="authenticationEvent_trigger_IssuanceStartVer_help" xml:space="preserve">
     <value>API Schema Version for OnTokenIssuanceStart Event</value>
   </data>
+  <data name="sqlIn_displayName" xml:space="preserve">
+    <value>Azure Sql Input Binding</value>
+  </data>
+  <data name="sqlIn_name_label" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="sqlIn_name_help" xml:space="preserve">
+    <value>The name used to identify this binding in your code.</value>
+  </data>
+  <data name="sqlIn_commandText_label" xml:space="preserve">
+    <value>Sql Command Text</value>
+  </data>
+  <data name="sqlIn_commandText_help" xml:space="preserve">
+    <value>The Transact-SQL query command or name of the stored procedure executed by the binding.</value>
+  </data>
+  <data name="sqlIn_commandType_label" xml:space="preserve">
+    <value>Text or StoredProcedure</value>
+  </data>
+  <data name="sqlIn_commandType_help" xml:space="preserve">
+    <value>The Transact-SQL query type which is either Text or StoredProcedure executed by the binding.</value>
+  </data>
+  <data name="sqlIn_parameters_label" xml:space="preserve">
+    <value>Parameters</value>
+  </data>
+  <data name="sqlIn_parameters_help" xml:space="preserve">
+    <value>Parameter values passed to the command during execution as a single string. Must follow the format `@param1=param1,@param2=param2`.</value>
+  </data>
+  <data name="sql_connection_label" xml:space="preserve">
+    <value>Sql Connection string setting</value>
+  </data>
+  <data name="sql_connection_help" xml:space="preserve">
+    <value>The name of the app setting containing your Sql binding connection string.</value>
+  </data>
+  <data name="sqlOut_displayName" xml:space="preserve">
+    <value>Azure Sql Output Binding</value>
+  </data>
+  <data name="sqlOut_name_label" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="sqlOut_name_help" xml:space="preserve">
+    <value>The name of the variable that represents the entity in function code.</value>
+  </data>
+  <data name="sqlOut_commandText_label" xml:space="preserve">
+    <value>Sql Table Name</value>
+  </data>
+  <data name="sqlOut_commandText_help" xml:space="preserve">
+    <value>The name of the table being written to by the binding.</value>
+  </data>
 </root>

--- a/Functions.Templates/Resources/Resources.resx
+++ b/Functions.Templates/Resources/Resources.resx
@@ -1964,7 +1964,7 @@ function app.</value>
     <value>Text or StoredProcedure</value>
   </data>
   <data name="sqlIn_commandType_help" xml:space="preserve">
-    <value>The Transact-SQL query type which is either Text or StoredProcedure executed by the binding.</value>
+    <value>The command type used to identify what type of value commandText is, either Text for a T-SQL query or StoredProcedure for a stored procedure.</value>
   </data>
   <data name="sqlIn_parameters_label" xml:space="preserve">
     <value>Parameters</value>
@@ -1988,7 +1988,7 @@ function app.</value>
     <value>The name of the variable that represents the entity in function code.</value>
   </data>
   <data name="sqlOut_commandText_label" xml:space="preserve">
-    <value>SQL Table Name</value>
+    <value>Table Name</value>
   </data>
   <data name="sqlOut_commandText_help" xml:space="preserve">
     <value>The name of the table being upserted to by the binding.</value>

--- a/Functions.Templates/Resources/Resources.resx
+++ b/Functions.Templates/Resources/Resources.resx
@@ -1946,7 +1946,7 @@ function app.</value>
     <value>API Schema Version for OnTokenIssuanceStart Event</value>
   </data>
   <data name="sqlIn_displayName" xml:space="preserve">
-    <value>Azure Sql Input Binding</value>
+    <value>Azure SQL Input Binding</value>
   </data>
   <data name="sqlIn_name_label" xml:space="preserve">
     <value>Name</value>
@@ -1973,13 +1973,13 @@ function app.</value>
     <value>Parameter values passed to the command during execution as a single string. Must follow the format `@param1=param1,@param2=param2`.</value>
   </data>
   <data name="sql_connection_label" xml:space="preserve">
-    <value>Sql Connection string setting</value>
+    <value>SQL Connection string setting</value>
   </data>
   <data name="sql_connection_help" xml:space="preserve">
     <value>The name of the app setting containing your Azure SQL binding connection string.</value>
   </data>
   <data name="sqlOut_displayName" xml:space="preserve">
-    <value>Azure Sql Output Binding</value>
+    <value>Azure SQL Output Binding</value>
   </data>
   <data name="sqlOut_name_label" xml:space="preserve">
     <value>Name</value>

--- a/Functions.Templates/Resources/Resources.resx
+++ b/Functions.Templates/Resources/Resources.resx
@@ -1955,7 +1955,7 @@ function app.</value>
     <value>The name used to identify this binding in your code.</value>
   </data>
   <data name="sqlIn_commandText_label" xml:space="preserve">
-    <value>Sql Command Text</value>
+    <value>SQL Command Text</value>
   </data>
   <data name="sqlIn_commandText_help" xml:space="preserve">
     <value>The Transact-SQL query command or name of the stored procedure executed by the binding.</value>
@@ -1976,7 +1976,7 @@ function app.</value>
     <value>Sql Connection string setting</value>
   </data>
   <data name="sql_connection_help" xml:space="preserve">
-    <value>The name of the app setting containing your Sql binding connection string.</value>
+    <value>The name of the app setting containing your Azure SQL binding connection string.</value>
   </data>
   <data name="sqlOut_displayName" xml:space="preserve">
     <value>Azure Sql Output Binding</value>
@@ -1988,9 +1988,9 @@ function app.</value>
     <value>The name of the variable that represents the entity in function code.</value>
   </data>
   <data name="sqlOut_commandText_label" xml:space="preserve">
-    <value>Sql Table Name</value>
+    <value>SQL Table Name</value>
   </data>
   <data name="sqlOut_commandText_help" xml:space="preserve">
-    <value>The name of the table being written to by the binding.</value>
+    <value>The name of the table being upserted to by the binding.</value>
   </data>
 </root>

--- a/Functions.Templates/Templates/SqlInputBinding-CSharp/.template.config/template.json
+++ b/Functions.Templates/Templates/SqlInputBinding-CSharp/.template.config/template.json
@@ -47,7 +47,7 @@
           "ManualInstructions": [],
           "args": {
             "referenceType": "package",
-            "reference": "Microsoft.Azure.WebJobs.Extensions.Sql", "version": "1.0.122-preview",
+            "reference": "Microsoft.Azure.WebJobs.Extensions.Sql", "version": "2.0.144",
             "projectFileExtensions": ".csproj"
           }
         },


### PR DESCRIPTION
Added the functions.json settings for non dotnet languages for Sql extension. (Below is the list of attributes added)
{
      "name": "products",
      "type": "sql",
      "direction": "in/out",
      "commandText": "select * from Products where Cost = @Cost",
      "commandType": "Text",
      "parameters": "@Cost={cost}",
      "connectionStringSetting": "SqlConnectionString"
   }
