### PR TITLE
Add Node.js model v4, schema v2 templates

### DIFF
--- a/Build/PackageFiles/ExtensionBundle/ExtensionBundleTemplates-3.x.nuspec
+++ b/Build/PackageFiles/ExtensionBundle/ExtensionBundleTemplates-3.x.nuspec
@@ -145,6 +145,7 @@
 
     <!-- Templates v2 -->
     <file src="../../../Functions.Templates\Bindings\userPrompts.json" target="Bindings-v2/userPrompts.json" />
+
     <file src="..\..\..\Functions.Templates\Templates-v2\HttpTrigger-Python\*.*" target="templates-v2\HttpTrigger-Python"/>
     <file src="..\..\..\Functions.Templates\Templates-v2\TimerTrigger-Python\*.*" target="templates-v2\TimerTrigger-Python"/>
     <file src="..\..\..\Functions.Templates\Templates-v2\EventHubTrigger-Python\*.*" target="templates-v2\EventHubTrigger-Python"/>
@@ -153,6 +154,28 @@
     <file src="..\..\..\Functions.Templates\Templates-v2\QueueTrigger-Python\*.*" target="templates-v2\QueueTrigger-Python"/>
     <file src="..\..\..\Functions.Templates\Templates-v2\ServiceBusQueueTrigger-Python\*.*" target="templates-v2\ServiceBusQueueTrigger-Python"/>
     <file src="..\..\..\Functions.Templates\Templates-v2\ServiceBusTopicTrigger-Python\*.*" target="templates-v2\ServiceBusTopicTrigger-Python"/>
+
+    <file src="..\..\..\Functions.Templates\Templates-v2\BlobTrigger-JavaScript\*.*" target="templates-v2\BlobTrigger-JavaScript"/>
+    <file src="..\..\..\Functions.Templates\Templates-v2\DurableFunctionsEntity-JavaScript\*.*" target="templates-v2\DurableFunctionsEntity-JavaScript"/>
+    <file src="..\..\..\Functions.Templates\Templates-v2\DurableFunctionsOrchestrator-JavaScript\*.*" target="templates-v2\DurableFunctionsOrchestrator-JavaScript"/>
+    <file src="..\..\..\Functions.Templates\Templates-v2\EventGridTrigger-JavaScript\*.*" target="templates-v2\EventGridTrigger-JavaScript"/>
+    <file src="..\..\..\Functions.Templates\Templates-v2\EventHubTrigger-JavaScript\*.*" target="templates-v2\EventHubTrigger-JavaScript"/>
+    <file src="..\..\..\Functions.Templates\Templates-v2\HttpTrigger-JavaScript\*.*" target="templates-v2\HttpTrigger-JavaScript"/>
+    <file src="..\..\..\Functions.Templates\Templates-v2\QueueTrigger-JavaScript\*.*" target="templates-v2\QueueTrigger-JavaScript"/>
+    <file src="..\..\..\Functions.Templates\Templates-v2\ServiceBusQueueTrigger-JavaScript\*.*" target="templates-v2\ServiceBusQueueTrigger-JavaScript"/>
+    <file src="..\..\..\Functions.Templates\Templates-v2\ServiceBusTopicTrigger-JavaScript\*.*" target="templates-v2\ServiceBusTopicTrigger-JavaScript"/>
+    <file src="..\..\..\Functions.Templates\Templates-v2\TimerTrigger-JavaScript\*.*" target="templates-v2\TimerTrigger-JavaScript"/>
+
+    <file src="..\..\..\Functions.Templates\Templates-v2\BlobTrigger-TypeScript\*.*" target="templates-v2\BlobTrigger-TypeScript"/>
+    <file src="..\..\..\Functions.Templates\Templates-v2\DurableFunctionsEntity-TypeScript\*.*" target="templates-v2\DurableFunctionsEntity-TypeScript"/>
+    <file src="..\..\..\Functions.Templates\Templates-v2\DurableFunctionsOrchestrator-TypeScript\*.*" target="templates-v2\DurableFunctionsOrchestrator-TypeScript"/>
+    <file src="..\..\..\Functions.Templates\Templates-v2\EventGridTrigger-TypeScript\*.*" target="templates-v2\EventGridTrigger-TypeScript"/>
+    <file src="..\..\..\Functions.Templates\Templates-v2\EventHubTrigger-TypeScript\*.*" target="templates-v2\EventHubTrigger-TypeScript"/>
+    <file src="..\..\..\Functions.Templates\Templates-v2\HttpTrigger-TypeScript\*.*" target="templates-v2\HttpTrigger-TypeScript"/>
+    <file src="..\..\..\Functions.Templates\Templates-v2\QueueTrigger-TypeScript\*.*" target="templates-v2\QueueTrigger-TypeScript"/>
+    <file src="..\..\..\Functions.Templates\Templates-v2\ServiceBusQueueTrigger-TypeScript\*.*" target="templates-v2\ServiceBusQueueTrigger-TypeScript"/>
+    <file src="..\..\..\Functions.Templates\Templates-v2\ServiceBusTopicTrigger-TypeScript\*.*" target="templates-v2\ServiceBusTopicTrigger-TypeScript"/>
+    <file src="..\..\..\Functions.Templates\Templates-v2\TimerTrigger-TypeScript\*.*" target="templates-v2\TimerTrigger-TypeScript"/>
     <!-- Templates v2 -->
 
   </files>

--- a/Build/PackageFiles/ExtensionBundle/ExtensionBundleTemplates-4.x.nuspec
+++ b/Build/PackageFiles/ExtensionBundle/ExtensionBundleTemplates-4.x.nuspec
@@ -143,6 +143,7 @@
 
   <!-- Templates v2 -->
     <file src="../../../Functions.Templates\Bindings\userPrompts.json" target="Bindings-v2/userPrompts.json" />
+
     <file src="..\..\..\Functions.Templates\Templates-v2\HttpTrigger-Python\*.*" target="templates-v2\HttpTrigger-Python"/>
     <file src="..\..\..\Functions.Templates\Templates-v2\TimerTrigger-Python\*.*" target="templates-v2\TimerTrigger-Python"/>
     <file src="..\..\..\Functions.Templates\Templates-v2\EventHubTrigger-Python\*.*" target="templates-v2\EventHubTrigger-Python"/>
@@ -152,6 +153,30 @@
     <file src="..\..\..\Functions.Templates\Templates-v2\ServiceBusQueueTrigger-Python\*.*" target="templates-v2\ServiceBusQueueTrigger-Python"/>
     <file src="..\..\..\Functions.Templates\Templates-v2\ServiceBusTopicTrigger-Python\*.*" target="templates-v2\ServiceBusTopicTrigger-Python"/>
     <file src="..\..\..\Functions.Templates\Templates-v2\CosmosDbTrigger-Python\*.*" target="templates-v2\CosmosDbTrigger-Python"/>
+
+    <file src="..\..\..\Functions.Templates\Templates-v2\BlobTrigger-JavaScript\*.*" target="templates-v2\BlobTrigger-JavaScript"/>
+    <file src="..\..\..\Functions.Templates\Templates-v2\CosmosDBTrigger-JavaScript\*.*" target="templates-v2\CosmosDBTrigger-JavaScript"/>
+    <file src="..\..\..\Functions.Templates\Templates-v2\DurableFunctionsEntity-JavaScript\*.*" target="templates-v2\DurableFunctionsEntity-JavaScript"/>
+    <file src="..\..\..\Functions.Templates\Templates-v2\DurableFunctionsOrchestrator-JavaScript\*.*" target="templates-v2\DurableFunctionsOrchestrator-JavaScript"/>
+    <file src="..\..\..\Functions.Templates\Templates-v2\EventGridTrigger-JavaScript\*.*" target="templates-v2\EventGridTrigger-JavaScript"/>
+    <file src="..\..\..\Functions.Templates\Templates-v2\EventHubTrigger-JavaScript\*.*" target="templates-v2\EventHubTrigger-JavaScript"/>
+    <file src="..\..\..\Functions.Templates\Templates-v2\HttpTrigger-JavaScript\*.*" target="templates-v2\HttpTrigger-JavaScript"/>
+    <file src="..\..\..\Functions.Templates\Templates-v2\QueueTrigger-JavaScript\*.*" target="templates-v2\QueueTrigger-JavaScript"/>
+    <file src="..\..\..\Functions.Templates\Templates-v2\ServiceBusQueueTrigger-JavaScript\*.*" target="templates-v2\ServiceBusQueueTrigger-JavaScript"/>
+    <file src="..\..\..\Functions.Templates\Templates-v2\ServiceBusTopicTrigger-JavaScript\*.*" target="templates-v2\ServiceBusTopicTrigger-JavaScript"/>
+    <file src="..\..\..\Functions.Templates\Templates-v2\TimerTrigger-JavaScript\*.*" target="templates-v2\TimerTrigger-JavaScript"/>
+
+    <file src="..\..\..\Functions.Templates\Templates-v2\BlobTrigger-TypeScript\*.*" target="templates-v2\BlobTrigger-TypeScript"/>
+    <file src="..\..\..\Functions.Templates\Templates-v2\CosmosDBTrigger-TypeScript\*.*" target="templates-v2\CosmosDBTrigger-TypeScript"/>
+    <file src="..\..\..\Functions.Templates\Templates-v2\DurableFunctionsEntity-TypeScript\*.*" target="templates-v2\DurableFunctionsEntity-TypeScript"/>
+    <file src="..\..\..\Functions.Templates\Templates-v2\DurableFunctionsOrchestrator-TypeScript\*.*" target="templates-v2\DurableFunctionsOrchestrator-TypeScript"/>
+    <file src="..\..\..\Functions.Templates\Templates-v2\EventGridTrigger-TypeScript\*.*" target="templates-v2\EventGridTrigger-TypeScript"/>
+    <file src="..\..\..\Functions.Templates\Templates-v2\EventHubTrigger-TypeScript\*.*" target="templates-v2\EventHubTrigger-TypeScript"/>
+    <file src="..\..\..\Functions.Templates\Templates-v2\HttpTrigger-TypeScript\*.*" target="templates-v2\HttpTrigger-TypeScript"/>
+    <file src="..\..\..\Functions.Templates\Templates-v2\QueueTrigger-TypeScript\*.*" target="templates-v2\QueueTrigger-TypeScript"/>
+    <file src="..\..\..\Functions.Templates\Templates-v2\ServiceBusQueueTrigger-TypeScript\*.*" target="templates-v2\ServiceBusQueueTrigger-TypeScript"/>
+    <file src="..\..\..\Functions.Templates\Templates-v2\ServiceBusTopicTrigger-TypeScript\*.*" target="templates-v2\ServiceBusTopicTrigger-TypeScript"/>
+    <file src="..\..\..\Functions.Templates\Templates-v2\TimerTrigger-TypeScript\*.*" target="templates-v2\TimerTrigger-TypeScript"/>
   <!-- // Templates v2 -->
 
     <file src="..\..\..\Functions.Templates\templates\SqlInputBinding-CSharp\*.*" target="Templates\SqlInputBinding-CSharp" exclude="**\*.cs" />

--- a/Docs/Schema/template-schema.json
+++ b/Docs/Schema/template-schema.json
@@ -20,11 +20,11 @@
         },
         "programmingModel": {
             "description": "The programming model the template applies to",
-            "enum": [ "v1", "v2" ]
+            "enum": [ "v1", "v2", "v3", "v4" ]
         },
         "language": {
             "description": "The programming language the template applies to",
-            "enum": [ "dotnet", "node", "python", "powershell" ]
+            "enum": [ "dotnet", "javascript", "typescript", "python", "powershell" ]
         },
         "jobs": {
             "description": "The list of jobs defined by the template, each corresponding to a user gesture",
@@ -41,6 +41,7 @@
                         "enum": [
                             "AppendToFile",
                             "CreateBlueprint",
+                            "CreateNewFile",
                             "CreateNewApp"
                         ]
                     },

--- a/Functions.Templates/Templates-v2/BlobTrigger-JavaScript/index.js
+++ b/Functions.Templates/Templates-v2/BlobTrigger-JavaScript/index.js
@@ -1,0 +1,9 @@
+const { app } = require('@azure/functions');
+
+app.storageBlob('$(FUNCTION_NAME_INPUT)', {
+    path: '$(PATH_INPUT)',
+    connection: '$(CONNECTION_INPUT)',
+    handler: (blob, context) => {
+        context.log(`Storage blob function processed blob "${context.triggerMetadata.name}" with size ${blob.length} bytes`);
+    }
+});

--- a/Functions.Templates/Templates-v2/BlobTrigger-JavaScript/template.json
+++ b/Functions.Templates/Templates-v2/BlobTrigger-JavaScript/template.json
@@ -1,0 +1,47 @@
+{
+    "author": "Eric Jizba",
+    "name": "Azure Blob Storage trigger",
+    "description": "$BlobTrigger_description",
+    "programmingModel": "v4",
+    "language": "JavaScript",
+    "jobs": [
+        {
+            "name": "Create New Function",
+            "type": "CreateNewApp",
+            "inputs": [
+                {
+                    "assignTo": "$(FUNCTION_NAME_INPUT)",
+                    "paramId": "functionName",
+                    "defaultValue": "storageBlobTrigger"
+                },
+                {
+                    "assignTo": "$(CONNECTION_INPUT)",
+                    "paramId": "connection"
+                },
+                {
+                    "assignTo": "$(PATH_INPUT)",
+                    "paramId": "path"
+                }
+            ],
+            "actions": [
+                "readFile",
+                "writeFile"
+            ]
+        }
+    ],
+    "actions": [
+        {
+            "name": "readFile",
+            "type": "GetTemplateFileContent",
+            "assignTo": "$(INDEX_FILE)",
+            "filePath": "index.js"
+        },
+        {
+            "name": "writeFile",
+            "type": "WriteToFile",
+            "source": "$(INDEX_FILE)",
+            "filePath": "src/functions/$(FUNCTION_NAME_INPUT).js",
+            "replaceTokens": true
+        }
+    ]
+}

--- a/Functions.Templates/Templates-v2/BlobTrigger-JavaScript/template.json
+++ b/Functions.Templates/Templates-v2/BlobTrigger-JavaScript/template.json
@@ -11,27 +11,27 @@
             "inputs": [
                 {
                     "assignTo": "$(FUNCTION_NAME_INPUT)",
-                    "paramId": "functionName",
+                    "paramId": "trigger-functionName",
                     "defaultValue": "storageBlobTrigger"
                 },
                 {
                     "assignTo": "$(CONNECTION_INPUT)",
-                    "paramId": "connection"
+                    "paramId": "blobTrigger-connection"
                 },
                 {
                     "assignTo": "$(PATH_INPUT)",
-                    "paramId": "path"
+                    "paramId": "blobTrigger-path"
                 }
             ],
             "actions": [
-                "readFile",
+                "getTemplateFile",
                 "writeFile"
             ]
         }
     ],
     "actions": [
         {
-            "name": "readFile",
+            "name": "getTemplateFile",
             "type": "GetTemplateFileContent",
             "assignTo": "$(INDEX_FILE)",
             "filePath": "index.js"

--- a/Functions.Templates/Templates-v2/BlobTrigger-JavaScript/template.json
+++ b/Functions.Templates/Templates-v2/BlobTrigger-JavaScript/template.json
@@ -7,7 +7,7 @@
     "jobs": [
         {
             "name": "Create New Function",
-            "type": "CreateNewApp",
+            "type": "CreateNewFile",
             "inputs": [
                 {
                     "assignTo": "$(FUNCTION_NAME_INPUT)",

--- a/Functions.Templates/Templates-v2/BlobTrigger-TypeScript/index.ts
+++ b/Functions.Templates/Templates-v2/BlobTrigger-TypeScript/index.ts
@@ -1,0 +1,11 @@
+import { app, InvocationContext } from "@azure/functions";
+
+export async function $(FUNCTION_NAME_INPUT)(blob: Buffer, context: InvocationContext): Promise<void> {
+    context.log(`Storage blob function processed blob "${context.triggerMetadata.name}" with size ${blob.length} bytes`);
+}
+
+app.storageBlob('$(FUNCTION_NAME_INPUT)', {
+    path: '$(PATH_INPUT)',
+    connection: '$(CONNECTION_INPUT)',
+    handler: $(FUNCTION_NAME_INPUT)
+});

--- a/Functions.Templates/Templates-v2/BlobTrigger-TypeScript/template.json
+++ b/Functions.Templates/Templates-v2/BlobTrigger-TypeScript/template.json
@@ -11,27 +11,27 @@
             "inputs": [
                 {
                     "assignTo": "$(FUNCTION_NAME_INPUT)",
-                    "paramId": "functionName",
+                    "paramId": "trigger-functionName",
                     "defaultValue": "storageBlobTrigger"
                 },
                 {
                     "assignTo": "$(CONNECTION_INPUT)",
-                    "paramId": "connection"
+                    "paramId": "blobTrigger-connection"
                 },
                 {
                     "assignTo": "$(PATH_INPUT)",
-                    "paramId": "path"
+                    "paramId": "blobTrigger-path"
                 }
             ],
             "actions": [
-                "readFile",
+                "getTemplateFile",
                 "writeFile"
             ]
         }
     ],
     "actions": [
         {
-            "name": "readFile",
+            "name": "getTemplateFile",
             "type": "GetTemplateFileContent",
             "assignTo": "$(INDEX_FILE)",
             "filePath": "index.ts"

--- a/Functions.Templates/Templates-v2/BlobTrigger-TypeScript/template.json
+++ b/Functions.Templates/Templates-v2/BlobTrigger-TypeScript/template.json
@@ -1,0 +1,47 @@
+{
+    "author": "Eric Jizba",
+    "name": "Azure Blob Storage trigger",
+    "description": "$BlobTrigger_description",
+    "programmingModel": "v4",
+    "language": "TypeScript",
+    "jobs": [
+        {
+            "name": "Create New Function",
+            "type": "CreateNewApp",
+            "inputs": [
+                {
+                    "assignTo": "$(FUNCTION_NAME_INPUT)",
+                    "paramId": "functionName",
+                    "defaultValue": "storageBlobTrigger"
+                },
+                {
+                    "assignTo": "$(CONNECTION_INPUT)",
+                    "paramId": "connection"
+                },
+                {
+                    "assignTo": "$(PATH_INPUT)",
+                    "paramId": "path"
+                }
+            ],
+            "actions": [
+                "readFile",
+                "writeFile"
+            ]
+        }
+    ],
+    "actions": [
+        {
+            "name": "readFile",
+            "type": "GetTemplateFileContent",
+            "assignTo": "$(INDEX_FILE)",
+            "filePath": "index.ts"
+        },
+        {
+            "name": "writeFile",
+            "type": "WriteToFile",
+            "source": "$(INDEX_FILE)",
+            "filePath": "src/functions/$(FUNCTION_NAME_INPUT).ts",
+            "replaceTokens": true
+        }
+    ]
+}

--- a/Functions.Templates/Templates-v2/BlobTrigger-TypeScript/template.json
+++ b/Functions.Templates/Templates-v2/BlobTrigger-TypeScript/template.json
@@ -7,7 +7,7 @@
     "jobs": [
         {
             "name": "Create New Function",
-            "type": "CreateNewApp",
+            "type": "CreateNewFile",
             "inputs": [
                 {
                     "assignTo": "$(FUNCTION_NAME_INPUT)",

--- a/Functions.Templates/Templates-v2/CosmosDBTrigger-JavaScript/index.js
+++ b/Functions.Templates/Templates-v2/CosmosDBTrigger-JavaScript/index.js
@@ -1,0 +1,11 @@
+const { app } = require('@azure/functions');
+
+app.cosmosDB('$(FUNCTION_NAME_INPUT)', {
+    connection: '$(CONNECTION_INPUT)',
+    databaseName: '$(DATABASE_NAME_INPUT)',
+    containerName: '$(CONTAINER_NAME_INPUT)',
+    createLeaseContainerIfNotExists: $(CREATE_LEASE_CONTAINER_IF_NOT_EXISTS_INPUT),
+    handler: (documents, context) => {
+        context.log(`Cosmos DB function processed ${documents.length} documents`);
+    }
+});

--- a/Functions.Templates/Templates-v2/CosmosDBTrigger-JavaScript/template.json
+++ b/Functions.Templates/Templates-v2/CosmosDBTrigger-JavaScript/template.json
@@ -1,0 +1,55 @@
+{
+    "author": "Eric Jizba",
+    "name": "Azure Cosmos DB trigger",
+    "description": "$CosmosDBTrigger_description",
+    "programmingModel": "v4",
+    "language": "JavaScript",
+    "jobs": [
+        {
+            "name": "Create New Function",
+            "type": "CreateNewApp",
+            "inputs": [
+                {
+                    "assignTo": "$(FUNCTION_NAME_INPUT)",
+                    "paramId": "functionName",
+                    "defaultValue": "cosmosDBTrigger"
+                },
+                {
+                    "assignTo": "$(CONNECTION_INPUT)",
+                    "paramId": "connection"
+                },
+                {
+                    "assignTo": "$(DATABASE_NAME_INPUT)",
+                    "paramId": "databaseName"
+                },
+                {
+                    "assignTo": "$(CONTAINER_NAME_INPUT)",
+                    "paramId": "containerName"
+                },
+                {
+                    "assignTo": "$(CREATE_LEASE_CONTAINER_IF_NOT_EXISTS_INPUT)",
+                    "paramId": "createLeaseContainerIfNotExists"
+                }
+            ],
+            "actions": [
+                "readFile",
+                "writeFile"
+            ]
+        }
+    ],
+    "actions": [
+        {
+            "name": "readFile",
+            "type": "GetTemplateFileContent",
+            "assignTo": "$(INDEX_FILE)",
+            "filePath": "index.js"
+        },
+        {
+            "name": "writeFile",
+            "type": "WriteToFile",
+            "source": "$(INDEX_FILE)",
+            "filePath": "src/functions/$(FUNCTION_NAME_INPUT).js",
+            "replaceTokens": true
+        }
+    ]
+}

--- a/Functions.Templates/Templates-v2/CosmosDBTrigger-JavaScript/template.json
+++ b/Functions.Templates/Templates-v2/CosmosDBTrigger-JavaScript/template.json
@@ -11,35 +11,35 @@
             "inputs": [
                 {
                     "assignTo": "$(FUNCTION_NAME_INPUT)",
-                    "paramId": "functionName",
+                    "paramId": "trigger-functionName",
                     "defaultValue": "cosmosDBTrigger"
                 },
                 {
                     "assignTo": "$(CONNECTION_INPUT)",
-                    "paramId": "connection"
+                    "paramId": "cosmosDBTrigger-connection"
                 },
                 {
                     "assignTo": "$(DATABASE_NAME_INPUT)",
-                    "paramId": "databaseName"
+                    "paramId": "cosmosDBTrigger-databaseName"
                 },
                 {
                     "assignTo": "$(CONTAINER_NAME_INPUT)",
-                    "paramId": "containerName"
+                    "paramId": "cosmosDBTrigger-containerName"
                 },
                 {
                     "assignTo": "$(CREATE_LEASE_CONTAINER_IF_NOT_EXISTS_INPUT)",
-                    "paramId": "createLeaseContainerIfNotExists"
+                    "paramId": "cosmosDBTrigger-createLeaseContainerIfNotExists"
                 }
             ],
             "actions": [
-                "readFile",
+                "getTemplateFile",
                 "writeFile"
             ]
         }
     ],
     "actions": [
         {
-            "name": "readFile",
+            "name": "getTemplateFile",
             "type": "GetTemplateFileContent",
             "assignTo": "$(INDEX_FILE)",
             "filePath": "index.js"

--- a/Functions.Templates/Templates-v2/CosmosDBTrigger-JavaScript/template.json
+++ b/Functions.Templates/Templates-v2/CosmosDBTrigger-JavaScript/template.json
@@ -7,7 +7,7 @@
     "jobs": [
         {
             "name": "Create New Function",
-            "type": "CreateNewApp",
+            "type": "CreateNewFile",
             "inputs": [
                 {
                     "assignTo": "$(FUNCTION_NAME_INPUT)",

--- a/Functions.Templates/Templates-v2/CosmosDBTrigger-TypeScript/index.ts
+++ b/Functions.Templates/Templates-v2/CosmosDBTrigger-TypeScript/index.ts
@@ -1,0 +1,13 @@
+import { app, InvocationContext } from "@azure/functions";
+
+export async function $(FUNCTION_NAME_INPUT)(documents: unknown[], context: InvocationContext): Promise<void> {
+    context.log(`Cosmos DB function processed ${documents.length} documents`);
+}
+
+app.cosmosDB('$(FUNCTION_NAME_INPUT)', {
+    connection: '$(CONNECTION_INPUT)',
+    databaseName: '$(DATABASE_NAME_INPUT)',
+    containerName: '$(CONTAINER_NAME_INPUT)',
+    createLeaseContainerIfNotExists: $(CREATE_LEASE_CONTAINER_IF_NOT_EXISTS_INPUT),
+    handler: $(FUNCTION_NAME_INPUT)
+});

--- a/Functions.Templates/Templates-v2/CosmosDBTrigger-TypeScript/template.json
+++ b/Functions.Templates/Templates-v2/CosmosDBTrigger-TypeScript/template.json
@@ -1,0 +1,55 @@
+{
+    "author": "Eric Jizba",
+    "name": "Azure Cosmos DB trigger",
+    "description": "$CosmosDBTrigger_description",
+    "programmingModel": "v4",
+    "language": "TypeScript",
+    "jobs": [
+        {
+            "name": "Create New Function",
+            "type": "CreateNewApp",
+            "inputs": [
+                {
+                    "assignTo": "$(FUNCTION_NAME_INPUT)",
+                    "paramId": "functionName",
+                    "defaultValue": "cosmosDBTrigger"
+                },
+                {
+                    "assignTo": "$(CONNECTION_INPUT)",
+                    "paramId": "connection"
+                },
+                {
+                    "assignTo": "$(DATABASE_NAME_INPUT)",
+                    "paramId": "databaseName"
+                },
+                {
+                    "assignTo": "$(CONTAINER_NAME_INPUT)",
+                    "paramId": "containerName"
+                },
+                {
+                    "assignTo": "$(CREATE_LEASE_CONTAINER_IF_NOT_EXISTS_INPUT)",
+                    "paramId": "createLeaseContainerIfNotExists"
+                }
+            ],
+            "actions": [
+                "readFile",
+                "writeFile"
+            ]
+        }
+    ],
+    "actions": [
+        {
+            "name": "readFile",
+            "type": "GetTemplateFileContent",
+            "assignTo": "$(INDEX_FILE)",
+            "filePath": "index.ts"
+        },
+        {
+            "name": "writeFile",
+            "type": "WriteToFile",
+            "source": "$(INDEX_FILE)",
+            "filePath": "src/functions/$(FUNCTION_NAME_INPUT).ts",
+            "replaceTokens": true
+        }
+    ]
+}

--- a/Functions.Templates/Templates-v2/CosmosDBTrigger-TypeScript/template.json
+++ b/Functions.Templates/Templates-v2/CosmosDBTrigger-TypeScript/template.json
@@ -11,35 +11,35 @@
             "inputs": [
                 {
                     "assignTo": "$(FUNCTION_NAME_INPUT)",
-                    "paramId": "functionName",
+                    "paramId": "trigger-functionName",
                     "defaultValue": "cosmosDBTrigger"
                 },
                 {
                     "assignTo": "$(CONNECTION_INPUT)",
-                    "paramId": "connection"
+                    "paramId": "cosmosDBTrigger-connection"
                 },
                 {
                     "assignTo": "$(DATABASE_NAME_INPUT)",
-                    "paramId": "databaseName"
+                    "paramId": "cosmosDBTrigger-databaseName"
                 },
                 {
                     "assignTo": "$(CONTAINER_NAME_INPUT)",
-                    "paramId": "containerName"
+                    "paramId": "cosmosDBTrigger-containerName"
                 },
                 {
                     "assignTo": "$(CREATE_LEASE_CONTAINER_IF_NOT_EXISTS_INPUT)",
-                    "paramId": "createLeaseContainerIfNotExists"
+                    "paramId": "cosmosDBTrigger-createLeaseContainerIfNotExists"
                 }
             ],
             "actions": [
-                "readFile",
+                "getTemplateFile",
                 "writeFile"
             ]
         }
     ],
     "actions": [
         {
-            "name": "readFile",
+            "name": "getTemplateFile",
             "type": "GetTemplateFileContent",
             "assignTo": "$(INDEX_FILE)",
             "filePath": "index.ts"

--- a/Functions.Templates/Templates-v2/CosmosDBTrigger-TypeScript/template.json
+++ b/Functions.Templates/Templates-v2/CosmosDBTrigger-TypeScript/template.json
@@ -7,7 +7,7 @@
     "jobs": [
         {
             "name": "Create New Function",
-            "type": "CreateNewApp",
+            "type": "CreateNewFile",
             "inputs": [
                 {
                     "assignTo": "$(FUNCTION_NAME_INPUT)",

--- a/Functions.Templates/Templates-v2/DurableFunctionsEntity-JavaScript/index.js
+++ b/Functions.Templates/Templates-v2/DurableFunctionsEntity-JavaScript/index.js
@@ -1,0 +1,41 @@
+const { app, HttpResponse } = require('@azure/functions');
+const df = require('durable-functions');
+
+const entityName = '$(FUNCTION_NAME_INPUT)';
+
+df.app.entity(entityName, (context) => {
+    const currentValue = context.df.getState(() => 0);
+    switch (context.df.operationName) {
+        case 'add':
+            const amount = context.df.getInput();
+            context.df.setState(currentValue + amount);
+            break;
+        case 'reset':
+            context.df.setState(0);
+            break;
+        case 'get':
+            context.df.return(currentValue);
+            break;
+    }
+});
+
+app.http('$(FUNCTION_NAME_INPUT)HttpStart', {
+    route: `${entityName}/{id}`,
+    extraInputs: [df.input.durableClient()],
+    handler: async (req, context) => {
+        const id = req.params.id;
+        const entityId = new df.EntityId(entityName, id);
+        const client = df.getClient(context);
+
+        if (req.method === 'POST') {
+            // increment value
+            await client.signalEntity(entityId, 'add', 1);
+        } else {
+            // read current state of entity
+            const stateResponse = await client.readEntityState(entityId);
+            return new HttpResponse({
+                jsonBody: stateResponse.entityState,
+            });
+        }
+    },
+});

--- a/Functions.Templates/Templates-v2/DurableFunctionsEntity-JavaScript/template.json
+++ b/Functions.Templates/Templates-v2/DurableFunctionsEntity-JavaScript/template.json
@@ -11,19 +11,19 @@
             "inputs": [
                 {
                     "assignTo": "$(FUNCTION_NAME_INPUT)",
-                    "paramId": "functionName",
+                    "paramId": "trigger-functionName",
                     "defaultValue": "counter"
                 }
             ],
             "actions": [
-                "readFile",
+                "getTemplateFile",
                 "writeFile"
             ]
         }
     ],
     "actions": [
         {
-            "name": "readFile",
+            "name": "getTemplateFile",
             "type": "GetTemplateFileContent",
             "assignTo": "$(INDEX_FILE)",
             "filePath": "index.js"

--- a/Functions.Templates/Templates-v2/DurableFunctionsEntity-JavaScript/template.json
+++ b/Functions.Templates/Templates-v2/DurableFunctionsEntity-JavaScript/template.json
@@ -1,0 +1,39 @@
+{
+    "author": "Eric Jizba",
+    "name": "Durable Functions entity",
+    "description": "$DurableFunctionsEntity_description",
+    "programmingModel": "v4",
+    "language": "JavaScript",
+    "jobs": [
+        {
+            "name": "Create New Function",
+            "type": "CreateNewApp",
+            "inputs": [
+                {
+                    "assignTo": "$(FUNCTION_NAME_INPUT)",
+                    "paramId": "functionName",
+                    "defaultValue": "counter"
+                }
+            ],
+            "actions": [
+                "readFile",
+                "writeFile"
+            ]
+        }
+    ],
+    "actions": [
+        {
+            "name": "readFile",
+            "type": "GetTemplateFileContent",
+            "assignTo": "$(INDEX_FILE)",
+            "filePath": "index.js"
+        },
+        {
+            "name": "writeFile",
+            "type": "WriteToFile",
+            "source": "$(INDEX_FILE)",
+            "filePath": "src/functions/$(FUNCTION_NAME_INPUT).js",
+            "replaceTokens": true
+        }
+    ]
+}

--- a/Functions.Templates/Templates-v2/DurableFunctionsEntity-JavaScript/template.json
+++ b/Functions.Templates/Templates-v2/DurableFunctionsEntity-JavaScript/template.json
@@ -7,7 +7,7 @@
     "jobs": [
         {
             "name": "Create New Function",
-            "type": "CreateNewApp",
+            "type": "CreateNewFile",
             "inputs": [
                 {
                     "assignTo": "$(FUNCTION_NAME_INPUT)",

--- a/Functions.Templates/Templates-v2/DurableFunctionsEntity-TypeScript/index.ts
+++ b/Functions.Templates/Templates-v2/DurableFunctionsEntity-TypeScript/index.ts
@@ -1,0 +1,44 @@
+import { app, HttpHandler, HttpRequest, HttpResponse, InvocationContext } from '@azure/functions';
+import * as df from 'durable-functions';
+import { EntityContext, EntityHandler } from 'durable-functions';
+
+const entityName = '$(FUNCTION_NAME_INPUT)';
+
+const $(FUNCTION_NAME_INPUT): EntityHandler<number> = (context: EntityContext<number>) => {
+    const currentValue: number = context.df.getState(() => 0);
+    switch (context.df.operationName) {
+        case 'add':
+            const amount: number = context.df.getInput();
+            context.df.setState(currentValue + amount);
+            break;
+        case 'reset':
+            context.df.setState(0);
+            break;
+        case 'get':
+            context.df.return(currentValue);
+            break;
+    }
+};
+df.app.entity(entityName, $(FUNCTION_NAME_INPUT));
+
+const $(FUNCTION_NAME_INPUT)HttpStart: HttpHandler = async (req: HttpRequest, context: InvocationContext): Promise<HttpResponse> => {
+    const id: string = req.params.id;
+    const entityId = new df.EntityId(entityName, id);
+    const client = df.getClient(context);
+
+    if (req.method === 'POST') {
+        // increment value
+        await client.signalEntity(entityId, 'add', 1);
+    } else {
+        // read current state of entity
+        const stateResponse = await client.readEntityState(entityId);
+        return new HttpResponse({
+            jsonBody: stateResponse.entityState,
+        });
+    }
+};
+app.http('$(FUNCTION_NAME_INPUT)HttpStart', {
+    route: `${entityName}/{id}`,
+    extraInputs: [df.input.durableClient()],
+    handler: $(FUNCTION_NAME_INPUT)HttpStart,
+});

--- a/Functions.Templates/Templates-v2/DurableFunctionsEntity-TypeScript/template.json
+++ b/Functions.Templates/Templates-v2/DurableFunctionsEntity-TypeScript/template.json
@@ -11,19 +11,19 @@
             "inputs": [
                 {
                     "assignTo": "$(FUNCTION_NAME_INPUT)",
-                    "paramId": "functionName",
+                    "paramId": "trigger-functionName",
                     "defaultValue": "counter"
                 }
             ],
             "actions": [
-                "readFile",
+                "getTemplateFile",
                 "writeFile"
             ]
         }
     ],
     "actions": [
         {
-            "name": "readFile",
+            "name": "getTemplateFile",
             "type": "GetTemplateFileContent",
             "assignTo": "$(INDEX_FILE)",
             "filePath": "index.ts"

--- a/Functions.Templates/Templates-v2/DurableFunctionsEntity-TypeScript/template.json
+++ b/Functions.Templates/Templates-v2/DurableFunctionsEntity-TypeScript/template.json
@@ -1,0 +1,39 @@
+{
+    "author": "Eric Jizba",
+    "name": "Durable Functions entity",
+    "description": "$DurableFunctionsEntity_description",
+    "programmingModel": "v4",
+    "language": "TypeScript",
+    "jobs": [
+        {
+            "name": "Create New Function",
+            "type": "CreateNewApp",
+            "inputs": [
+                {
+                    "assignTo": "$(FUNCTION_NAME_INPUT)",
+                    "paramId": "functionName",
+                    "defaultValue": "counter"
+                }
+            ],
+            "actions": [
+                "readFile",
+                "writeFile"
+            ]
+        }
+    ],
+    "actions": [
+        {
+            "name": "readFile",
+            "type": "GetTemplateFileContent",
+            "assignTo": "$(INDEX_FILE)",
+            "filePath": "index.ts"
+        },
+        {
+            "name": "writeFile",
+            "type": "WriteToFile",
+            "source": "$(INDEX_FILE)",
+            "filePath": "src/functions/$(FUNCTION_NAME_INPUT).ts",
+            "replaceTokens": true
+        }
+    ]
+}

--- a/Functions.Templates/Templates-v2/DurableFunctionsEntity-TypeScript/template.json
+++ b/Functions.Templates/Templates-v2/DurableFunctionsEntity-TypeScript/template.json
@@ -7,7 +7,7 @@
     "jobs": [
         {
             "name": "Create New Function",
-            "type": "CreateNewApp",
+            "type": "CreateNewFile",
             "inputs": [
                 {
                     "assignTo": "$(FUNCTION_NAME_INPUT)",

--- a/Functions.Templates/Templates-v2/DurableFunctionsOrchestrator-JavaScript/index.js
+++ b/Functions.Templates/Templates-v2/DurableFunctionsOrchestrator-JavaScript/index.js
@@ -1,0 +1,33 @@
+const { app } = require('@azure/functions');
+const df = require('durable-functions');
+
+const activityName = '$(FUNCTION_NAME_INPUT)';
+
+df.app.orchestration('$(FUNCTION_NAME_INPUT)Orchestrator', function* (context) {
+    const outputs = [];
+    outputs.push(yield context.df.callActivity(activityName, 'Tokyo'));
+    outputs.push(yield context.df.callActivity(activityName, 'Seattle'));
+    outputs.push(yield context.df.callActivity(activityName, 'Cairo'));
+
+    return outputs;
+});
+
+df.app.activity(activityName, {
+    handler: (input) => {
+        return `Hello, ${input}`;
+    },
+});
+
+app.http('$(FUNCTION_NAME_INPUT)HttpStart', {
+    route: 'orchestrators/{orchestratorName}',
+    extraInputs: [df.input.durableClient()],
+    handler: async (request, context) => {
+        const client = df.getClient(context);
+        const body = await request.text();
+        const instanceId = await client.startNew(request.params.orchestratorName, { input: body });
+
+        context.log(`Started orchestration with ID = '${instanceId}'.`);
+
+        return client.createCheckStatusResponse(request, instanceId);
+    },
+});

--- a/Functions.Templates/Templates-v2/DurableFunctionsOrchestrator-JavaScript/template.json
+++ b/Functions.Templates/Templates-v2/DurableFunctionsOrchestrator-JavaScript/template.json
@@ -1,0 +1,39 @@
+{
+    "author": "Eric Jizba",
+    "name": "Durable Functions orchestrator",
+    "description": "$DurableFunctionsOrchestrator_description",
+    "programmingModel": "v4",
+    "language": "JavaScript",
+    "jobs": [
+        {
+            "name": "Create New Function",
+            "type": "CreateNewApp",
+            "inputs": [
+                {
+                    "assignTo": "$(FUNCTION_NAME_INPUT)",
+                    "paramId": "functionName",
+                    "defaultValue": "durableHello"
+                }
+            ],
+            "actions": [
+                "readFile",
+                "writeFile"
+            ]
+        }
+    ],
+    "actions": [
+        {
+            "name": "readFile",
+            "type": "GetTemplateFileContent",
+            "assignTo": "$(INDEX_FILE)",
+            "filePath": "index.js"
+        },
+        {
+            "name": "writeFile",
+            "type": "WriteToFile",
+            "source": "$(INDEX_FILE)",
+            "filePath": "src/functions/$(FUNCTION_NAME_INPUT).js",
+            "replaceTokens": true
+        }
+    ]
+}

--- a/Functions.Templates/Templates-v2/DurableFunctionsOrchestrator-JavaScript/template.json
+++ b/Functions.Templates/Templates-v2/DurableFunctionsOrchestrator-JavaScript/template.json
@@ -11,19 +11,19 @@
             "inputs": [
                 {
                     "assignTo": "$(FUNCTION_NAME_INPUT)",
-                    "paramId": "functionName",
+                    "paramId": "trigger-functionName",
                     "defaultValue": "durableHello"
                 }
             ],
             "actions": [
-                "readFile",
+                "getTemplateFile",
                 "writeFile"
             ]
         }
     ],
     "actions": [
         {
-            "name": "readFile",
+            "name": "getTemplateFile",
             "type": "GetTemplateFileContent",
             "assignTo": "$(INDEX_FILE)",
             "filePath": "index.js"

--- a/Functions.Templates/Templates-v2/DurableFunctionsOrchestrator-JavaScript/template.json
+++ b/Functions.Templates/Templates-v2/DurableFunctionsOrchestrator-JavaScript/template.json
@@ -7,7 +7,7 @@
     "jobs": [
         {
             "name": "Create New Function",
-            "type": "CreateNewApp",
+            "type": "CreateNewFile",
             "inputs": [
                 {
                     "assignTo": "$(FUNCTION_NAME_INPUT)",

--- a/Functions.Templates/Templates-v2/DurableFunctionsOrchestrator-TypeScript/index.ts
+++ b/Functions.Templates/Templates-v2/DurableFunctionsOrchestrator-TypeScript/index.ts
@@ -1,0 +1,36 @@
+import { app, HttpHandler, HttpRequest, HttpResponse, InvocationContext } from '@azure/functions';
+import * as df from 'durable-functions';
+import { ActivityHandler, OrchestrationContext, OrchestrationHandler } from 'durable-functions';
+
+const activityName = '$(FUNCTION_NAME_INPUT)';
+
+const $(FUNCTION_NAME_INPUT)Orchestrator: OrchestrationHandler = function* (context: OrchestrationContext) {
+    const outputs = [];
+    outputs.push(yield context.df.callActivity(activityName, 'Tokyo'));
+    outputs.push(yield context.df.callActivity(activityName, 'Seattle'));
+    outputs.push(yield context.df.callActivity(activityName, 'Cairo'));
+
+    return outputs;
+};
+df.app.orchestration('$(FUNCTION_NAME_INPUT)Orchestrator', $(FUNCTION_NAME_INPUT)Orchestrator);
+
+const $(FUNCTION_NAME_INPUT): ActivityHandler = (input: string): string => {
+    return `Hello, ${input}`;
+};
+df.app.activity(activityName, { handler: $(FUNCTION_NAME_INPUT) });
+
+const $(FUNCTION_NAME_INPUT)HttpStart: HttpHandler = async (request: HttpRequest, context: InvocationContext): Promise<HttpResponse> => {
+    const client = df.getClient(context);
+    const body: unknown = await request.text();
+    const instanceId: string = await client.startNew(request.params.orchestratorName, { input: body });
+
+    context.log(`Started orchestration with ID = '${instanceId}'.`);
+
+    return client.createCheckStatusResponse(request, instanceId);
+};
+
+app.http('$(FUNCTION_NAME_INPUT)HttpStart', {
+    route: 'orchestrators/{orchestratorName}',
+    extraInputs: [df.input.durableClient()],
+    handler: $(FUNCTION_NAME_INPUT)HttpStart,
+});

--- a/Functions.Templates/Templates-v2/DurableFunctionsOrchestrator-TypeScript/template.json
+++ b/Functions.Templates/Templates-v2/DurableFunctionsOrchestrator-TypeScript/template.json
@@ -1,0 +1,39 @@
+{
+    "author": "Eric Jizba",
+    "name": "Durable Functions orchestrator",
+    "description": "$DurableFunctionsOrchestrator_description",
+    "programmingModel": "v4",
+    "language": "TypeScript",
+    "jobs": [
+        {
+            "name": "Create New Function",
+            "type": "CreateNewApp",
+            "inputs": [
+                {
+                    "assignTo": "$(FUNCTION_NAME_INPUT)",
+                    "paramId": "functionName",
+                    "defaultValue": "durableHello"
+                }
+            ],
+            "actions": [
+                "readFile",
+                "writeFile"
+            ]
+        }
+    ],
+    "actions": [
+        {
+            "name": "readFile",
+            "type": "GetTemplateFileContent",
+            "assignTo": "$(INDEX_FILE)",
+            "filePath": "index.ts"
+        },
+        {
+            "name": "writeFile",
+            "type": "WriteToFile",
+            "source": "$(INDEX_FILE)",
+            "filePath": "src/functions/$(FUNCTION_NAME_INPUT).ts",
+            "replaceTokens": true
+        }
+    ]
+}

--- a/Functions.Templates/Templates-v2/DurableFunctionsOrchestrator-TypeScript/template.json
+++ b/Functions.Templates/Templates-v2/DurableFunctionsOrchestrator-TypeScript/template.json
@@ -7,7 +7,7 @@
     "jobs": [
         {
             "name": "Create New Function",
-            "type": "CreateNewApp",
+            "type": "CreateNewFile",
             "inputs": [
                 {
                     "assignTo": "$(FUNCTION_NAME_INPUT)",

--- a/Functions.Templates/Templates-v2/DurableFunctionsOrchestrator-TypeScript/template.json
+++ b/Functions.Templates/Templates-v2/DurableFunctionsOrchestrator-TypeScript/template.json
@@ -11,19 +11,19 @@
             "inputs": [
                 {
                     "assignTo": "$(FUNCTION_NAME_INPUT)",
-                    "paramId": "functionName",
+                    "paramId": "trigger-functionName",
                     "defaultValue": "durableHello"
                 }
             ],
             "actions": [
-                "readFile",
+                "getTemplateFile",
                 "writeFile"
             ]
         }
     ],
     "actions": [
         {
-            "name": "readFile",
+            "name": "getTemplateFile",
             "type": "GetTemplateFileContent",
             "assignTo": "$(INDEX_FILE)",
             "filePath": "index.ts"

--- a/Functions.Templates/Templates-v2/EventGridTrigger-JavaScript/index.js
+++ b/Functions.Templates/Templates-v2/EventGridTrigger-JavaScript/index.js
@@ -1,0 +1,7 @@
+const { app } = require('@azure/functions');
+
+app.eventGrid('$(FUNCTION_NAME_INPUT)', {
+    handler: (event, context) => {
+        context.log('Event grid function processed event:', event);
+    }
+});

--- a/Functions.Templates/Templates-v2/EventGridTrigger-JavaScript/template.json
+++ b/Functions.Templates/Templates-v2/EventGridTrigger-JavaScript/template.json
@@ -11,19 +11,19 @@
             "inputs": [
                 {
                     "assignTo": "$(FUNCTION_NAME_INPUT)",
-                    "paramId": "functionName",
+                    "paramId": "trigger-functionName",
                     "defaultValue": "eventGridTrigger"
                 }
             ],
             "actions": [
-                "readFile",
+                "getTemplateFile",
                 "writeFile"
             ]
         }
     ],
     "actions": [
         {
-            "name": "readFile",
+            "name": "getTemplateFile",
             "type": "GetTemplateFileContent",
             "assignTo": "$(INDEX_FILE)",
             "filePath": "index.js"

--- a/Functions.Templates/Templates-v2/EventGridTrigger-JavaScript/template.json
+++ b/Functions.Templates/Templates-v2/EventGridTrigger-JavaScript/template.json
@@ -1,0 +1,39 @@
+{
+    "author": "Eric Jizba",
+    "name": "Azure Event Grid trigger",
+    "description": "$EventGridTrigger_description",
+    "programmingModel": "v4",
+    "language": "JavaScript",
+    "jobs": [
+        {
+            "name": "Create New Function",
+            "type": "CreateNewApp",
+            "inputs": [
+                {
+                    "assignTo": "$(FUNCTION_NAME_INPUT)",
+                    "paramId": "functionName",
+                    "defaultValue": "eventGridTrigger"
+                }
+            ],
+            "actions": [
+                "readFile",
+                "writeFile"
+            ]
+        }
+    ],
+    "actions": [
+        {
+            "name": "readFile",
+            "type": "GetTemplateFileContent",
+            "assignTo": "$(INDEX_FILE)",
+            "filePath": "index.js"
+        },
+        {
+            "name": "writeFile",
+            "type": "WriteToFile",
+            "source": "$(INDEX_FILE)",
+            "filePath": "src/functions/$(FUNCTION_NAME_INPUT).js",
+            "replaceTokens": true
+        }
+    ]
+}

--- a/Functions.Templates/Templates-v2/EventGridTrigger-JavaScript/template.json
+++ b/Functions.Templates/Templates-v2/EventGridTrigger-JavaScript/template.json
@@ -7,7 +7,7 @@
     "jobs": [
         {
             "name": "Create New Function",
-            "type": "CreateNewApp",
+            "type": "CreateNewFile",
             "inputs": [
                 {
                     "assignTo": "$(FUNCTION_NAME_INPUT)",

--- a/Functions.Templates/Templates-v2/EventGridTrigger-TypeScript/index.ts
+++ b/Functions.Templates/Templates-v2/EventGridTrigger-TypeScript/index.ts
@@ -1,0 +1,9 @@
+import { app, EventGridEvent, InvocationContext } from "@azure/functions";
+
+export async function $(FUNCTION_NAME_INPUT)(event: EventGridEvent, context: InvocationContext): Promise<void> {
+    context.log('Event grid function processed event:', event);
+}
+
+app.eventGrid('$(FUNCTION_NAME_INPUT)', {
+    handler: $(FUNCTION_NAME_INPUT)
+});

--- a/Functions.Templates/Templates-v2/EventGridTrigger-TypeScript/template.json
+++ b/Functions.Templates/Templates-v2/EventGridTrigger-TypeScript/template.json
@@ -1,0 +1,39 @@
+{
+    "author": "Eric Jizba",
+    "name": "Azure Event Grid trigger",
+    "description": "$EventGridTrigger_description",
+    "programmingModel": "v4",
+    "language": "TypeScript",
+    "jobs": [
+        {
+            "name": "Create New Function",
+            "type": "CreateNewApp",
+            "inputs": [
+                {
+                    "assignTo": "$(FUNCTION_NAME_INPUT)",
+                    "paramId": "functionName",
+                    "defaultValue": "eventGridTrigger"
+                }
+            ],
+            "actions": [
+                "readFile",
+                "writeFile"
+            ]
+        }
+    ],
+    "actions": [
+        {
+            "name": "readFile",
+            "type": "GetTemplateFileContent",
+            "assignTo": "$(INDEX_FILE)",
+            "filePath": "index.ts"
+        },
+        {
+            "name": "writeFile",
+            "type": "WriteToFile",
+            "source": "$(INDEX_FILE)",
+            "filePath": "src/functions/$(FUNCTION_NAME_INPUT).ts",
+            "replaceTokens": true
+        }
+    ]
+}

--- a/Functions.Templates/Templates-v2/EventGridTrigger-TypeScript/template.json
+++ b/Functions.Templates/Templates-v2/EventGridTrigger-TypeScript/template.json
@@ -11,19 +11,19 @@
             "inputs": [
                 {
                     "assignTo": "$(FUNCTION_NAME_INPUT)",
-                    "paramId": "functionName",
+                    "paramId": "trigger-functionName",
                     "defaultValue": "eventGridTrigger"
                 }
             ],
             "actions": [
-                "readFile",
+                "getTemplateFile",
                 "writeFile"
             ]
         }
     ],
     "actions": [
         {
-            "name": "readFile",
+            "name": "getTemplateFile",
             "type": "GetTemplateFileContent",
             "assignTo": "$(INDEX_FILE)",
             "filePath": "index.ts"

--- a/Functions.Templates/Templates-v2/EventGridTrigger-TypeScript/template.json
+++ b/Functions.Templates/Templates-v2/EventGridTrigger-TypeScript/template.json
@@ -7,7 +7,7 @@
     "jobs": [
         {
             "name": "Create New Function",
-            "type": "CreateNewApp",
+            "type": "CreateNewFile",
             "inputs": [
                 {
                     "assignTo": "$(FUNCTION_NAME_INPUT)",

--- a/Functions.Templates/Templates-v2/EventHubTrigger-JavaScript/index.js
+++ b/Functions.Templates/Templates-v2/EventHubTrigger-JavaScript/index.js
@@ -1,0 +1,17 @@
+const { app } = require('@azure/functions');
+
+app.eventHub('$(FUNCTION_NAME_INPUT)', {
+    connection: '$(CONNECTION_INPUT)',
+    eventHubName: '$(EVENT_HUB_NAME_INPUT)',
+    cardinality: 'many',
+    handler: (messages, context) => {
+        if (Array.isArray(messages)) {
+            context.log(`Event hub function processed ${messages.length} messages`);
+            for (const message of messages) {
+                context.log('Event hub message:', message);
+            }
+        } else {
+            context.log('Event hub function processed message:', messages);
+        }
+    }
+});

--- a/Functions.Templates/Templates-v2/EventHubTrigger-JavaScript/template.json
+++ b/Functions.Templates/Templates-v2/EventHubTrigger-JavaScript/template.json
@@ -1,0 +1,47 @@
+{
+    "author": "Eric Jizba",
+    "name": "Azure Event Hub trigger",
+    "description": "$EventHubTrigger_description",
+    "programmingModel": "v4",
+    "language": "JavaScript",
+    "jobs": [
+        {
+            "name": "Create New Function",
+            "type": "CreateNewApp",
+            "inputs": [
+                {
+                    "assignTo": "$(FUNCTION_NAME_INPUT)",
+                    "paramId": "functionName",
+                    "defaultValue": "eventHubTrigger"
+                },
+                {
+                    "assignTo": "$(CONNECTION_INPUT)",
+                    "paramId": "connection"
+                },
+                {
+                    "assignTo": "$(EVENT_HUB_NAME_INPUT)",
+                    "paramId": "eventHubName"
+                }
+            ],
+            "actions": [
+                "readFile",
+                "writeFile"
+            ]
+        }
+    ],
+    "actions": [
+        {
+            "name": "readFile",
+            "type": "GetTemplateFileContent",
+            "assignTo": "$(INDEX_FILE)",
+            "filePath": "index.js"
+        },
+        {
+            "name": "writeFile",
+            "type": "WriteToFile",
+            "source": "$(INDEX_FILE)",
+            "filePath": "src/functions/$(FUNCTION_NAME_INPUT).js",
+            "replaceTokens": true
+        }
+    ]
+}

--- a/Functions.Templates/Templates-v2/EventHubTrigger-JavaScript/template.json
+++ b/Functions.Templates/Templates-v2/EventHubTrigger-JavaScript/template.json
@@ -11,27 +11,27 @@
             "inputs": [
                 {
                     "assignTo": "$(FUNCTION_NAME_INPUT)",
-                    "paramId": "functionName",
+                    "paramId": "trigger-functionName",
                     "defaultValue": "eventHubTrigger"
                 },
                 {
                     "assignTo": "$(CONNECTION_INPUT)",
-                    "paramId": "connection"
+                    "paramId": "eventHubTrigger-connection"
                 },
                 {
                     "assignTo": "$(EVENT_HUB_NAME_INPUT)",
-                    "paramId": "eventHubName"
+                    "paramId": "eventHubTrigger-eventHubName"
                 }
             ],
             "actions": [
-                "readFile",
+                "getTemplateFile",
                 "writeFile"
             ]
         }
     ],
     "actions": [
         {
-            "name": "readFile",
+            "name": "getTemplateFile",
             "type": "GetTemplateFileContent",
             "assignTo": "$(INDEX_FILE)",
             "filePath": "index.js"

--- a/Functions.Templates/Templates-v2/EventHubTrigger-JavaScript/template.json
+++ b/Functions.Templates/Templates-v2/EventHubTrigger-JavaScript/template.json
@@ -7,7 +7,7 @@
     "jobs": [
         {
             "name": "Create New Function",
-            "type": "CreateNewApp",
+            "type": "CreateNewFile",
             "inputs": [
                 {
                     "assignTo": "$(FUNCTION_NAME_INPUT)",

--- a/Functions.Templates/Templates-v2/EventHubTrigger-TypeScript/index.ts
+++ b/Functions.Templates/Templates-v2/EventHubTrigger-TypeScript/index.ts
@@ -1,0 +1,19 @@
+import { app, InvocationContext } from "@azure/functions";
+
+export async function $(FUNCTION_NAME_INPUT)(messages: unknown | unknown[], context: InvocationContext): Promise<void> {
+    if (Array.isArray(messages)) {
+        context.log(`Event hub function processed ${messages.length} messages`);
+        for (const message of messages) {
+            context.log('Event hub message:', message);
+        }
+    } else {
+        context.log('Event hub function processed message:', messages);
+    }
+}
+
+app.eventHub('$(FUNCTION_NAME_INPUT)', {
+    connection: '$(CONNECTION_INPUT)',
+    eventHubName: '$(EVENT_HUB_NAME_INPUT)',
+    cardinality: 'many',
+    handler: $(FUNCTION_NAME_INPUT)
+});

--- a/Functions.Templates/Templates-v2/EventHubTrigger-TypeScript/template.json
+++ b/Functions.Templates/Templates-v2/EventHubTrigger-TypeScript/template.json
@@ -1,0 +1,47 @@
+{
+    "author": "Eric Jizba",
+    "name": "Azure Event Hub trigger",
+    "description": "$EventHubTrigger_description",
+    "programmingModel": "v4",
+    "language": "TypeScript",
+    "jobs": [
+        {
+            "name": "Create New Function",
+            "type": "CreateNewApp",
+            "inputs": [
+                {
+                    "assignTo": "$(FUNCTION_NAME_INPUT)",
+                    "paramId": "functionName",
+                    "defaultValue": "eventHubTrigger"
+                },
+                {
+                    "assignTo": "$(CONNECTION_INPUT)",
+                    "paramId": "connection"
+                },
+                {
+                    "assignTo": "$(EVENT_HUB_NAME_INPUT)",
+                    "paramId": "eventHubName"
+                }
+            ],
+            "actions": [
+                "readFile",
+                "writeFile"
+            ]
+        }
+    ],
+    "actions": [
+        {
+            "name": "readFile",
+            "type": "GetTemplateFileContent",
+            "assignTo": "$(INDEX_FILE)",
+            "filePath": "index.ts"
+        },
+        {
+            "name": "writeFile",
+            "type": "WriteToFile",
+            "source": "$(INDEX_FILE)",
+            "filePath": "src/functions/$(FUNCTION_NAME_INPUT).ts",
+            "replaceTokens": true
+        }
+    ]
+}

--- a/Functions.Templates/Templates-v2/EventHubTrigger-TypeScript/template.json
+++ b/Functions.Templates/Templates-v2/EventHubTrigger-TypeScript/template.json
@@ -11,27 +11,27 @@
             "inputs": [
                 {
                     "assignTo": "$(FUNCTION_NAME_INPUT)",
-                    "paramId": "functionName",
+                    "paramId": "trigger-functionName",
                     "defaultValue": "eventHubTrigger"
                 },
                 {
                     "assignTo": "$(CONNECTION_INPUT)",
-                    "paramId": "connection"
+                    "paramId": "eventHubTrigger-connection"
                 },
                 {
                     "assignTo": "$(EVENT_HUB_NAME_INPUT)",
-                    "paramId": "eventHubName"
+                    "paramId": "eventHubTrigger-eventHubName"
                 }
             ],
             "actions": [
-                "readFile",
+                "getTemplateFile",
                 "writeFile"
             ]
         }
     ],
     "actions": [
         {
-            "name": "readFile",
+            "name": "getTemplateFile",
             "type": "GetTemplateFileContent",
             "assignTo": "$(INDEX_FILE)",
             "filePath": "index.ts"

--- a/Functions.Templates/Templates-v2/EventHubTrigger-TypeScript/template.json
+++ b/Functions.Templates/Templates-v2/EventHubTrigger-TypeScript/template.json
@@ -7,7 +7,7 @@
     "jobs": [
         {
             "name": "Create New Function",
-            "type": "CreateNewApp",
+            "type": "CreateNewFile",
             "inputs": [
                 {
                     "assignTo": "$(FUNCTION_NAME_INPUT)",

--- a/Functions.Templates/Templates-v2/HttpTrigger-JavaScript/index.js
+++ b/Functions.Templates/Templates-v2/HttpTrigger-JavaScript/index.js
@@ -1,0 +1,13 @@
+const { app } = require('@azure/functions');
+
+app.http('$(FUNCTION_NAME_INPUT)', {
+    methods: ['GET', 'POST'],
+    authLevel: 'anonymous',
+    handler: async (request, context) => {
+        context.log(`Http function processed request for url "${request.url}"`);
+
+        const name = request.query.get('name') || await request.text() || 'world';
+
+        return { body: `Hello, ${name}!` };
+    }
+});

--- a/Functions.Templates/Templates-v2/HttpTrigger-JavaScript/template.json
+++ b/Functions.Templates/Templates-v2/HttpTrigger-JavaScript/template.json
@@ -1,0 +1,39 @@
+{
+    "author": "Eric Jizba",
+    "name": "HTTP trigger",
+    "description": "$HttpTrigger_description",
+    "programmingModel": "v4",
+    "language": "JavaScript",
+    "jobs": [
+        {
+            "name": "Create New Function",
+            "type": "CreateNewApp",
+            "inputs": [
+                {
+                    "assignTo": "$(FUNCTION_NAME_INPUT)",
+                    "paramId": "functionName",
+                    "defaultValue": "httpTrigger"
+                }
+            ],
+            "actions": [
+                "readFile",
+                "writeFile"
+            ]
+        }
+    ],
+    "actions": [
+        {
+            "name": "readFile",
+            "type": "GetTemplateFileContent",
+            "assignTo": "$(INDEX_FILE)",
+            "filePath": "index.js"
+        },
+        {
+            "name": "writeFile",
+            "type": "WriteToFile",
+            "source": "$(INDEX_FILE)",
+            "filePath": "src/functions/$(FUNCTION_NAME_INPUT).js",
+            "replaceTokens": true
+        }
+    ]
+}

--- a/Functions.Templates/Templates-v2/HttpTrigger-JavaScript/template.json
+++ b/Functions.Templates/Templates-v2/HttpTrigger-JavaScript/template.json
@@ -11,19 +11,19 @@
             "inputs": [
                 {
                     "assignTo": "$(FUNCTION_NAME_INPUT)",
-                    "paramId": "functionName",
+                    "paramId": "trigger-functionName",
                     "defaultValue": "httpTrigger"
                 }
             ],
             "actions": [
-                "readFile",
+                "getTemplateFile",
                 "writeFile"
             ]
         }
     ],
     "actions": [
         {
-            "name": "readFile",
+            "name": "getTemplateFile",
             "type": "GetTemplateFileContent",
             "assignTo": "$(INDEX_FILE)",
             "filePath": "index.js"

--- a/Functions.Templates/Templates-v2/HttpTrigger-JavaScript/template.json
+++ b/Functions.Templates/Templates-v2/HttpTrigger-JavaScript/template.json
@@ -7,7 +7,7 @@
     "jobs": [
         {
             "name": "Create New Function",
-            "type": "CreateNewApp",
+            "type": "CreateNewFile",
             "inputs": [
                 {
                     "assignTo": "$(FUNCTION_NAME_INPUT)",

--- a/Functions.Templates/Templates-v2/HttpTrigger-TypeScript/index.ts
+++ b/Functions.Templates/Templates-v2/HttpTrigger-TypeScript/index.ts
@@ -1,0 +1,15 @@
+import { app, HttpRequest, HttpResponseInit, InvocationContext } from "@azure/functions";
+
+export async function $(FUNCTION_NAME_INPUT)(request: HttpRequest, context: InvocationContext): Promise<HttpResponseInit> {
+    context.log(`Http function processed request for url "${request.url}"`);
+
+    const name = request.query.get('name') || await request.text() || 'world';
+
+    return { body: `Hello, ${name}!` };
+};
+
+app.http('$(FUNCTION_NAME_INPUT)', {
+    methods: ['GET', 'POST'],
+    authLevel: 'anonymous',
+    handler: $(FUNCTION_NAME_INPUT)
+});

--- a/Functions.Templates/Templates-v2/HttpTrigger-TypeScript/template.json
+++ b/Functions.Templates/Templates-v2/HttpTrigger-TypeScript/template.json
@@ -1,0 +1,39 @@
+{
+    "author": "Eric Jizba",
+    "name": "HTTP trigger",
+    "description": "$HttpTrigger_description",
+    "programmingModel": "v4",
+    "language": "TypeScript",
+    "jobs": [
+        {
+            "name": "Create New Function",
+            "type": "CreateNewApp",
+            "inputs": [
+                {
+                    "assignTo": "$(FUNCTION_NAME_INPUT)",
+                    "paramId": "functionName",
+                    "defaultValue": "httpTrigger"
+                }
+            ],
+            "actions": [
+                "readFile",
+                "writeFile"
+            ]
+        }
+    ],
+    "actions": [
+        {
+            "name": "readFile",
+            "type": "GetTemplateFileContent",
+            "assignTo": "$(INDEX_FILE)",
+            "filePath": "index.ts"
+        },
+        {
+            "name": "writeFile",
+            "type": "WriteToFile",
+            "source": "$(INDEX_FILE)",
+            "filePath": "src/functions/$(FUNCTION_NAME_INPUT).ts",
+            "replaceTokens": true
+        }
+    ]
+}

--- a/Functions.Templates/Templates-v2/HttpTrigger-TypeScript/template.json
+++ b/Functions.Templates/Templates-v2/HttpTrigger-TypeScript/template.json
@@ -11,19 +11,19 @@
             "inputs": [
                 {
                     "assignTo": "$(FUNCTION_NAME_INPUT)",
-                    "paramId": "functionName",
+                    "paramId": "trigger-functionName",
                     "defaultValue": "httpTrigger"
                 }
             ],
             "actions": [
-                "readFile",
+                "getTemplateFile",
                 "writeFile"
             ]
         }
     ],
     "actions": [
         {
-            "name": "readFile",
+            "name": "getTemplateFile",
             "type": "GetTemplateFileContent",
             "assignTo": "$(INDEX_FILE)",
             "filePath": "index.ts"

--- a/Functions.Templates/Templates-v2/HttpTrigger-TypeScript/template.json
+++ b/Functions.Templates/Templates-v2/HttpTrigger-TypeScript/template.json
@@ -7,7 +7,7 @@
     "jobs": [
         {
             "name": "Create New Function",
-            "type": "CreateNewApp",
+            "type": "CreateNewFile",
             "inputs": [
                 {
                     "assignTo": "$(FUNCTION_NAME_INPUT)",

--- a/Functions.Templates/Templates-v2/QueueTrigger-JavaScript/index.js
+++ b/Functions.Templates/Templates-v2/QueueTrigger-JavaScript/index.js
@@ -1,0 +1,9 @@
+const { app } = require('@azure/functions');
+
+app.storageQueue('$(FUNCTION_NAME_INPUT)', {
+    queueName: '$(QUEUE_NAME_INPUT)',
+    connection: '$(CONNECTION_INPUT)',
+    handler: (queueItem, context) => {
+        context.log('Storage queue function processed work item:', queueItem);
+    }
+});

--- a/Functions.Templates/Templates-v2/QueueTrigger-JavaScript/template.json
+++ b/Functions.Templates/Templates-v2/QueueTrigger-JavaScript/template.json
@@ -11,27 +11,27 @@
             "inputs": [
                 {
                     "assignTo": "$(FUNCTION_NAME_INPUT)",
-                    "paramId": "functionName",
+                    "paramId": "trigger-functionName",
                     "defaultValue": "storageQueueTrigger"
                 },
                 {
                     "assignTo": "$(CONNECTION_INPUT)",
-                    "paramId": "connection"
+                    "paramId": "queueTrigger-connection"
                 },
                 {
                     "assignTo": "$(QUEUE_NAME_INPUT)",
-                    "paramId": "queueName"
+                    "paramId": "queueTrigger-queueName"
                 }
             ],
             "actions": [
-                "readFile",
+                "getTemplateFile",
                 "writeFile"
             ]
         }
     ],
     "actions": [
         {
-            "name": "readFile",
+            "name": "getTemplateFile",
             "type": "GetTemplateFileContent",
             "assignTo": "$(INDEX_FILE)",
             "filePath": "index.js"

--- a/Functions.Templates/Templates-v2/QueueTrigger-JavaScript/template.json
+++ b/Functions.Templates/Templates-v2/QueueTrigger-JavaScript/template.json
@@ -1,0 +1,47 @@
+{
+    "author": "Eric Jizba",
+    "name": "Azure Queue Storage trigger",
+    "description": "$QueueTrigger_description",
+    "programmingModel": "v4",
+    "language": "JavaScript",
+    "jobs": [
+        {
+            "name": "Create New Function",
+            "type": "CreateNewApp",
+            "inputs": [
+                {
+                    "assignTo": "$(FUNCTION_NAME_INPUT)",
+                    "paramId": "functionName",
+                    "defaultValue": "storageQueueTrigger"
+                },
+                {
+                    "assignTo": "$(CONNECTION_INPUT)",
+                    "paramId": "connection"
+                },
+                {
+                    "assignTo": "$(QUEUE_NAME_INPUT)",
+                    "paramId": "queueName"
+                }
+            ],
+            "actions": [
+                "readFile",
+                "writeFile"
+            ]
+        }
+    ],
+    "actions": [
+        {
+            "name": "readFile",
+            "type": "GetTemplateFileContent",
+            "assignTo": "$(INDEX_FILE)",
+            "filePath": "index.js"
+        },
+        {
+            "name": "writeFile",
+            "type": "WriteToFile",
+            "source": "$(INDEX_FILE)",
+            "filePath": "src/functions/$(FUNCTION_NAME_INPUT).js",
+            "replaceTokens": true
+        }
+    ]
+}

--- a/Functions.Templates/Templates-v2/QueueTrigger-JavaScript/template.json
+++ b/Functions.Templates/Templates-v2/QueueTrigger-JavaScript/template.json
@@ -7,7 +7,7 @@
     "jobs": [
         {
             "name": "Create New Function",
-            "type": "CreateNewApp",
+            "type": "CreateNewFile",
             "inputs": [
                 {
                     "assignTo": "$(FUNCTION_NAME_INPUT)",

--- a/Functions.Templates/Templates-v2/QueueTrigger-TypeScript/index.ts
+++ b/Functions.Templates/Templates-v2/QueueTrigger-TypeScript/index.ts
@@ -1,0 +1,11 @@
+import { app, InvocationContext } from "@azure/functions";
+
+export async function $(FUNCTION_NAME_INPUT)(queueItem: unknown, context: InvocationContext): Promise<void> {
+    context.log('Storage queue function processed work item:', queueItem);
+}
+
+app.storageQueue('$(FUNCTION_NAME_INPUT)', {
+    queueName: '$(QUEUE_NAME_INPUT)',
+    connection: '$(CONNECTION_INPUT)',
+    handler: $(FUNCTION_NAME_INPUT)
+});

--- a/Functions.Templates/Templates-v2/QueueTrigger-TypeScript/template.json
+++ b/Functions.Templates/Templates-v2/QueueTrigger-TypeScript/template.json
@@ -1,0 +1,47 @@
+{
+    "author": "Eric Jizba",
+    "name": "Azure Queue Storage trigger",
+    "description": "$QueueTrigger_description",
+    "programmingModel": "v4",
+    "language": "TypeScript",
+    "jobs": [
+        {
+            "name": "Create New Function",
+            "type": "CreateNewApp",
+            "inputs": [
+                {
+                    "assignTo": "$(FUNCTION_NAME_INPUT)",
+                    "paramId": "functionName",
+                    "defaultValue": "storageQueueTrigger"
+                },
+                {
+                    "assignTo": "$(CONNECTION_INPUT)",
+                    "paramId": "connection"
+                },
+                {
+                    "assignTo": "$(QUEUE_NAME_INPUT)",
+                    "paramId": "queueName"
+                }
+            ],
+            "actions": [
+                "readFile",
+                "writeFile"
+            ]
+        }
+    ],
+    "actions": [
+        {
+            "name": "readFile",
+            "type": "GetTemplateFileContent",
+            "assignTo": "$(INDEX_FILE)",
+            "filePath": "index.ts"
+        },
+        {
+            "name": "writeFile",
+            "type": "WriteToFile",
+            "source": "$(INDEX_FILE)",
+            "filePath": "src/functions/$(FUNCTION_NAME_INPUT).ts",
+            "replaceTokens": true
+        }
+    ]
+}

--- a/Functions.Templates/Templates-v2/QueueTrigger-TypeScript/template.json
+++ b/Functions.Templates/Templates-v2/QueueTrigger-TypeScript/template.json
@@ -11,27 +11,27 @@
             "inputs": [
                 {
                     "assignTo": "$(FUNCTION_NAME_INPUT)",
-                    "paramId": "functionName",
+                    "paramId": "trigger-functionName",
                     "defaultValue": "storageQueueTrigger"
                 },
                 {
                     "assignTo": "$(CONNECTION_INPUT)",
-                    "paramId": "connection"
+                    "paramId": "queueTrigger-connection"
                 },
                 {
                     "assignTo": "$(QUEUE_NAME_INPUT)",
-                    "paramId": "queueName"
+                    "paramId": "queueTrigger-queueName"
                 }
             ],
             "actions": [
-                "readFile",
+                "getTemplateFile",
                 "writeFile"
             ]
         }
     ],
     "actions": [
         {
-            "name": "readFile",
+            "name": "getTemplateFile",
             "type": "GetTemplateFileContent",
             "assignTo": "$(INDEX_FILE)",
             "filePath": "index.ts"

--- a/Functions.Templates/Templates-v2/QueueTrigger-TypeScript/template.json
+++ b/Functions.Templates/Templates-v2/QueueTrigger-TypeScript/template.json
@@ -7,7 +7,7 @@
     "jobs": [
         {
             "name": "Create New Function",
-            "type": "CreateNewApp",
+            "type": "CreateNewFile",
             "inputs": [
                 {
                     "assignTo": "$(FUNCTION_NAME_INPUT)",

--- a/Functions.Templates/Templates-v2/ServiceBusQueueTrigger-JavaScript/index.js
+++ b/Functions.Templates/Templates-v2/ServiceBusQueueTrigger-JavaScript/index.js
@@ -1,0 +1,9 @@
+const { app } = require('@azure/functions');
+
+app.serviceBusQueue('$(FUNCTION_NAME_INPUT)', {
+    connection: '$(CONNECTION_INPUT)',
+    queueName: '$(QUEUE_NAME_INPUT)',
+    handler: (message, context) => {
+        context.log('Service bus queue function processed message:', message);
+    }
+});

--- a/Functions.Templates/Templates-v2/ServiceBusQueueTrigger-JavaScript/template.json
+++ b/Functions.Templates/Templates-v2/ServiceBusQueueTrigger-JavaScript/template.json
@@ -11,27 +11,27 @@
             "inputs": [
                 {
                     "assignTo": "$(FUNCTION_NAME_INPUT)",
-                    "paramId": "functionName",
+                    "paramId": "trigger-functionName",
                     "defaultValue": "serviceBusQueueTrigger"
                 },
                 {
                     "assignTo": "$(CONNECTION_INPUT)",
-                    "paramId": "connection"
+                    "paramId": "serviceBusTrigger-connection"
                 },
                 {
                     "assignTo": "$(QUEUE_NAME_INPUT)",
-                    "paramId": "queueName"
+                    "paramId": "serviceBusTrigger-queueName"
                 }
             ],
             "actions": [
-                "readFile",
+                "getTemplateFile",
                 "writeFile"
             ]
         }
     ],
     "actions": [
         {
-            "name": "readFile",
+            "name": "getTemplateFile",
             "type": "GetTemplateFileContent",
             "assignTo": "$(INDEX_FILE)",
             "filePath": "index.js"

--- a/Functions.Templates/Templates-v2/ServiceBusQueueTrigger-JavaScript/template.json
+++ b/Functions.Templates/Templates-v2/ServiceBusQueueTrigger-JavaScript/template.json
@@ -1,0 +1,47 @@
+{
+    "author": "Eric Jizba",
+    "name": "Azure Service Bus Queue trigger",
+    "description": "$ServiceBusQueueTrigger_description",
+    "programmingModel": "v4",
+    "language": "JavaScript",
+    "jobs": [
+        {
+            "name": "Create New Function",
+            "type": "CreateNewApp",
+            "inputs": [
+                {
+                    "assignTo": "$(FUNCTION_NAME_INPUT)",
+                    "paramId": "functionName",
+                    "defaultValue": "serviceBusQueueTrigger"
+                },
+                {
+                    "assignTo": "$(CONNECTION_INPUT)",
+                    "paramId": "connection"
+                },
+                {
+                    "assignTo": "$(QUEUE_NAME_INPUT)",
+                    "paramId": "queueName"
+                }
+            ],
+            "actions": [
+                "readFile",
+                "writeFile"
+            ]
+        }
+    ],
+    "actions": [
+        {
+            "name": "readFile",
+            "type": "GetTemplateFileContent",
+            "assignTo": "$(INDEX_FILE)",
+            "filePath": "index.js"
+        },
+        {
+            "name": "writeFile",
+            "type": "WriteToFile",
+            "source": "$(INDEX_FILE)",
+            "filePath": "src/functions/$(FUNCTION_NAME_INPUT).js",
+            "replaceTokens": true
+        }
+    ]
+}

--- a/Functions.Templates/Templates-v2/ServiceBusQueueTrigger-JavaScript/template.json
+++ b/Functions.Templates/Templates-v2/ServiceBusQueueTrigger-JavaScript/template.json
@@ -7,7 +7,7 @@
     "jobs": [
         {
             "name": "Create New Function",
-            "type": "CreateNewApp",
+            "type": "CreateNewFile",
             "inputs": [
                 {
                     "assignTo": "$(FUNCTION_NAME_INPUT)",

--- a/Functions.Templates/Templates-v2/ServiceBusQueueTrigger-TypeScript/index.ts
+++ b/Functions.Templates/Templates-v2/ServiceBusQueueTrigger-TypeScript/index.ts
@@ -1,0 +1,11 @@
+import { app, InvocationContext } from "@azure/functions";
+
+export async function $(FUNCTION_NAME_INPUT)(message: unknown, context: InvocationContext): Promise<void> {
+    context.log('Service bus queue function processed message:', message);
+}
+
+app.serviceBusQueue('$(FUNCTION_NAME_INPUT)', {
+    connection: '$(CONNECTION_INPUT)',
+    queueName: '$(QUEUE_NAME_INPUT)',
+    handler: $(FUNCTION_NAME_INPUT)
+});

--- a/Functions.Templates/Templates-v2/ServiceBusQueueTrigger-TypeScript/template.json
+++ b/Functions.Templates/Templates-v2/ServiceBusQueueTrigger-TypeScript/template.json
@@ -11,27 +11,27 @@
             "inputs": [
                 {
                     "assignTo": "$(FUNCTION_NAME_INPUT)",
-                    "paramId": "functionName",
+                    "paramId": "trigger-functionName",
                     "defaultValue": "serviceBusQueueTrigger"
                 },
                 {
                     "assignTo": "$(CONNECTION_INPUT)",
-                    "paramId": "connection"
+                    "paramId": "serviceBusTrigger-connection"
                 },
                 {
                     "assignTo": "$(QUEUE_NAME_INPUT)",
-                    "paramId": "queueName"
+                    "paramId": "serviceBusTrigger-queueName"
                 }
             ],
             "actions": [
-                "readFile",
+                "getTemplateFile",
                 "writeFile"
             ]
         }
     ],
     "actions": [
         {
-            "name": "readFile",
+            "name": "getTemplateFile",
             "type": "GetTemplateFileContent",
             "assignTo": "$(INDEX_FILE)",
             "filePath": "index.ts"

--- a/Functions.Templates/Templates-v2/ServiceBusQueueTrigger-TypeScript/template.json
+++ b/Functions.Templates/Templates-v2/ServiceBusQueueTrigger-TypeScript/template.json
@@ -1,0 +1,47 @@
+{
+    "author": "Eric Jizba",
+    "name": "Azure Service Bus Queue trigger",
+    "description": "$ServiceBusQueueTrigger_description",
+    "programmingModel": "v4",
+    "language": "TypeScript",
+    "jobs": [
+        {
+            "name": "Create New Function",
+            "type": "CreateNewApp",
+            "inputs": [
+                {
+                    "assignTo": "$(FUNCTION_NAME_INPUT)",
+                    "paramId": "functionName",
+                    "defaultValue": "serviceBusQueueTrigger"
+                },
+                {
+                    "assignTo": "$(CONNECTION_INPUT)",
+                    "paramId": "connection"
+                },
+                {
+                    "assignTo": "$(QUEUE_NAME_INPUT)",
+                    "paramId": "queueName"
+                }
+            ],
+            "actions": [
+                "readFile",
+                "writeFile"
+            ]
+        }
+    ],
+    "actions": [
+        {
+            "name": "readFile",
+            "type": "GetTemplateFileContent",
+            "assignTo": "$(INDEX_FILE)",
+            "filePath": "index.ts"
+        },
+        {
+            "name": "writeFile",
+            "type": "WriteToFile",
+            "source": "$(INDEX_FILE)",
+            "filePath": "src/functions/$(FUNCTION_NAME_INPUT).ts",
+            "replaceTokens": true
+        }
+    ]
+}

--- a/Functions.Templates/Templates-v2/ServiceBusQueueTrigger-TypeScript/template.json
+++ b/Functions.Templates/Templates-v2/ServiceBusQueueTrigger-TypeScript/template.json
@@ -7,7 +7,7 @@
     "jobs": [
         {
             "name": "Create New Function",
-            "type": "CreateNewApp",
+            "type": "CreateNewFile",
             "inputs": [
                 {
                     "assignTo": "$(FUNCTION_NAME_INPUT)",

--- a/Functions.Templates/Templates-v2/ServiceBusTopicTrigger-JavaScript/index.js
+++ b/Functions.Templates/Templates-v2/ServiceBusTopicTrigger-JavaScript/index.js
@@ -1,0 +1,10 @@
+const { app } = require('@azure/functions');
+
+app.serviceBusTopic('$(FUNCTION_NAME_INPUT)', {
+    connection: '$(CONNECTION_INPUT)',
+    topicName: '$(TOPIC_NAME_INPUT)',
+    subscriptionName: '$(SUBSCRIPTION_NAME_INPUT)',
+    handler: (message, context) => {
+        context.log('Service bus topic function processed message:', message);
+    }
+});

--- a/Functions.Templates/Templates-v2/ServiceBusTopicTrigger-JavaScript/template.json
+++ b/Functions.Templates/Templates-v2/ServiceBusTopicTrigger-JavaScript/template.json
@@ -11,31 +11,31 @@
             "inputs": [
                 {
                     "assignTo": "$(FUNCTION_NAME_INPUT)",
-                    "paramId": "functionName",
+                    "paramId": "trigger-functionName",
                     "defaultValue": "serviceBusTopicTrigger"
                 },
                 {
                     "assignTo": "$(CONNECTION_INPUT)",
-                    "paramId": "connection"
+                    "paramId": "serviceBusTrigger-connection"
                 },
                 {
                     "assignTo": "$(TOPIC_NAME_INPUT)",
-                    "paramId": "topicName"
+                    "paramId": "serviceBusTrigger-topicName"
                 },
                 {
                     "assignTo": "$(SUBSCRIPTION_NAME_INPUT)",
-                    "paramId": "subscriptionName"
+                    "paramId": "serviceBusTrigger-subscriptionName"
                 }
             ],
             "actions": [
-                "readFile",
+                "getTemplateFile",
                 "writeFile"
             ]
         }
     ],
     "actions": [
         {
-            "name": "readFile",
+            "name": "getTemplateFile",
             "type": "GetTemplateFileContent",
             "assignTo": "$(INDEX_FILE)",
             "filePath": "index.js"

--- a/Functions.Templates/Templates-v2/ServiceBusTopicTrigger-JavaScript/template.json
+++ b/Functions.Templates/Templates-v2/ServiceBusTopicTrigger-JavaScript/template.json
@@ -1,0 +1,51 @@
+{
+    "author": "Eric Jizba",
+    "name": "Azure Service Bus Topic trigger",
+    "description": "$ServiceBusTopicTrigger_description",
+    "programmingModel": "v4",
+    "language": "JavaScript",
+    "jobs": [
+        {
+            "name": "Create New Function",
+            "type": "CreateNewApp",
+            "inputs": [
+                {
+                    "assignTo": "$(FUNCTION_NAME_INPUT)",
+                    "paramId": "functionName",
+                    "defaultValue": "serviceBusTopicTrigger"
+                },
+                {
+                    "assignTo": "$(CONNECTION_INPUT)",
+                    "paramId": "connection"
+                },
+                {
+                    "assignTo": "$(TOPIC_NAME_INPUT)",
+                    "paramId": "topicName"
+                },
+                {
+                    "assignTo": "$(SUBSCRIPTION_NAME_INPUT)",
+                    "paramId": "subscriptionName"
+                }
+            ],
+            "actions": [
+                "readFile",
+                "writeFile"
+            ]
+        }
+    ],
+    "actions": [
+        {
+            "name": "readFile",
+            "type": "GetTemplateFileContent",
+            "assignTo": "$(INDEX_FILE)",
+            "filePath": "index.js"
+        },
+        {
+            "name": "writeFile",
+            "type": "WriteToFile",
+            "source": "$(INDEX_FILE)",
+            "filePath": "src/functions/$(FUNCTION_NAME_INPUT).js",
+            "replaceTokens": true
+        }
+    ]
+}

--- a/Functions.Templates/Templates-v2/ServiceBusTopicTrigger-JavaScript/template.json
+++ b/Functions.Templates/Templates-v2/ServiceBusTopicTrigger-JavaScript/template.json
@@ -7,7 +7,7 @@
     "jobs": [
         {
             "name": "Create New Function",
-            "type": "CreateNewApp",
+            "type": "CreateNewFile",
             "inputs": [
                 {
                     "assignTo": "$(FUNCTION_NAME_INPUT)",

--- a/Functions.Templates/Templates-v2/ServiceBusTopicTrigger-TypeScript/index.ts
+++ b/Functions.Templates/Templates-v2/ServiceBusTopicTrigger-TypeScript/index.ts
@@ -1,0 +1,12 @@
+import { app, InvocationContext } from "@azure/functions";
+
+export async function $(FUNCTION_NAME_INPUT)(message: unknown, context: InvocationContext): Promise<void> {
+    context.log('Service bus topic function processed message:', message);
+}
+
+app.serviceBusTopic('$(FUNCTION_NAME_INPUT)', {
+    connection: '$(CONNECTION_INPUT)',
+    topicName: '$(TOPIC_NAME_INPUT)',
+    subscriptionName: '$(SUBSCRIPTION_NAME_INPUT)',
+    handler: $(FUNCTION_NAME_INPUT)
+});

--- a/Functions.Templates/Templates-v2/ServiceBusTopicTrigger-TypeScript/template.json
+++ b/Functions.Templates/Templates-v2/ServiceBusTopicTrigger-TypeScript/template.json
@@ -1,0 +1,51 @@
+{
+    "author": "Eric Jizba",
+    "name": "Azure Service Bus Topic trigger",
+    "description": "$ServiceBusTopicTrigger_description",
+    "programmingModel": "v4",
+    "language": "TypeScript",
+    "jobs": [
+        {
+            "name": "Create New Function",
+            "type": "CreateNewApp",
+            "inputs": [
+                {
+                    "assignTo": "$(FUNCTION_NAME_INPUT)",
+                    "paramId": "functionName",
+                    "defaultValue": "serviceBusTopicTrigger"
+                },
+                {
+                    "assignTo": "$(CONNECTION_INPUT)",
+                    "paramId": "connection"
+                },
+                {
+                    "assignTo": "$(TOPIC_NAME_INPUT)",
+                    "paramId": "topicName"
+                },
+                {
+                    "assignTo": "$(SUBSCRIPTION_NAME_INPUT)",
+                    "paramId": "subscriptionName"
+                }
+            ],
+            "actions": [
+                "readFile",
+                "writeFile"
+            ]
+        }
+    ],
+    "actions": [
+        {
+            "name": "readFile",
+            "type": "GetTemplateFileContent",
+            "assignTo": "$(INDEX_FILE)",
+            "filePath": "index.ts"
+        },
+        {
+            "name": "writeFile",
+            "type": "WriteToFile",
+            "source": "$(INDEX_FILE)",
+            "filePath": "src/functions/$(FUNCTION_NAME_INPUT).ts",
+            "replaceTokens": true
+        }
+    ]
+}

--- a/Functions.Templates/Templates-v2/ServiceBusTopicTrigger-TypeScript/template.json
+++ b/Functions.Templates/Templates-v2/ServiceBusTopicTrigger-TypeScript/template.json
@@ -11,31 +11,31 @@
             "inputs": [
                 {
                     "assignTo": "$(FUNCTION_NAME_INPUT)",
-                    "paramId": "functionName",
+                    "paramId": "trigger-functionName",
                     "defaultValue": "serviceBusTopicTrigger"
                 },
                 {
                     "assignTo": "$(CONNECTION_INPUT)",
-                    "paramId": "connection"
+                    "paramId": "serviceBusTrigger-connection"
                 },
                 {
                     "assignTo": "$(TOPIC_NAME_INPUT)",
-                    "paramId": "topicName"
+                    "paramId": "serviceBusTrigger-topicName"
                 },
                 {
                     "assignTo": "$(SUBSCRIPTION_NAME_INPUT)",
-                    "paramId": "subscriptionName"
+                    "paramId": "serviceBusTrigger-subscriptionName"
                 }
             ],
             "actions": [
-                "readFile",
+                "getTemplateFile",
                 "writeFile"
             ]
         }
     ],
     "actions": [
         {
-            "name": "readFile",
+            "name": "getTemplateFile",
             "type": "GetTemplateFileContent",
             "assignTo": "$(INDEX_FILE)",
             "filePath": "index.ts"

--- a/Functions.Templates/Templates-v2/ServiceBusTopicTrigger-TypeScript/template.json
+++ b/Functions.Templates/Templates-v2/ServiceBusTopicTrigger-TypeScript/template.json
@@ -7,7 +7,7 @@
     "jobs": [
         {
             "name": "Create New Function",
-            "type": "CreateNewApp",
+            "type": "CreateNewFile",
             "inputs": [
                 {
                     "assignTo": "$(FUNCTION_NAME_INPUT)",

--- a/Functions.Templates/Templates-v2/TimerTrigger-JavaScript/index.js
+++ b/Functions.Templates/Templates-v2/TimerTrigger-JavaScript/index.js
@@ -1,0 +1,8 @@
+const { app } = require('@azure/functions');
+
+app.timer('$(FUNCTION_NAME_INPUT)', {
+    schedule: '$(SCHEDULE_INPUT)',
+    handler: (myTimer, context) => {
+        context.log('Timer function processed request.');
+    }
+});

--- a/Functions.Templates/Templates-v2/TimerTrigger-JavaScript/template.json
+++ b/Functions.Templates/Templates-v2/TimerTrigger-JavaScript/template.json
@@ -11,23 +11,23 @@
             "inputs": [
                 {
                     "assignTo": "$(FUNCTION_NAME_INPUT)",
-                    "paramId": "functionName",
+                    "paramId": "trigger-functionName",
                     "defaultValue": "timerTrigger"
                 },
                 {
                     "assignTo": "$(SCHEDULE_INPUT)",
-                    "paramId": "schedule"
+                    "paramId": "timerTrigger-schedule"
                 }
             ],
             "actions": [
-                "readFile",
+                "getTemplateFile",
                 "writeFile"
             ]
         }
     ],
     "actions": [
         {
-            "name": "readFile",
+            "name": "getTemplateFile",
             "type": "GetTemplateFileContent",
             "assignTo": "$(INDEX_FILE)",
             "filePath": "index.js"

--- a/Functions.Templates/Templates-v2/TimerTrigger-JavaScript/template.json
+++ b/Functions.Templates/Templates-v2/TimerTrigger-JavaScript/template.json
@@ -1,0 +1,43 @@
+{
+    "author": "Eric Jizba",
+    "name": "Timer trigger",
+    "description": "$TimerTrigger_description",
+    "programmingModel": "v4",
+    "language": "JavaScript",
+    "jobs": [
+        {
+            "name": "Create New Function",
+            "type": "CreateNewApp",
+            "inputs": [
+                {
+                    "assignTo": "$(FUNCTION_NAME_INPUT)",
+                    "paramId": "functionName",
+                    "defaultValue": "timerTrigger"
+                },
+                {
+                    "assignTo": "$(SCHEDULE_INPUT)",
+                    "paramId": "schedule"
+                }
+            ],
+            "actions": [
+                "readFile",
+                "writeFile"
+            ]
+        }
+    ],
+    "actions": [
+        {
+            "name": "readFile",
+            "type": "GetTemplateFileContent",
+            "assignTo": "$(INDEX_FILE)",
+            "filePath": "index.js"
+        },
+        {
+            "name": "writeFile",
+            "type": "WriteToFile",
+            "source": "$(INDEX_FILE)",
+            "filePath": "src/functions/$(FUNCTION_NAME_INPUT).js",
+            "replaceTokens": true
+        }
+    ]
+}

--- a/Functions.Templates/Templates-v2/TimerTrigger-JavaScript/template.json
+++ b/Functions.Templates/Templates-v2/TimerTrigger-JavaScript/template.json
@@ -7,7 +7,7 @@
     "jobs": [
         {
             "name": "Create New Function",
-            "type": "CreateNewApp",
+            "type": "CreateNewFile",
             "inputs": [
                 {
                     "assignTo": "$(FUNCTION_NAME_INPUT)",

--- a/Functions.Templates/Templates-v2/TimerTrigger-TypeScript/index.ts
+++ b/Functions.Templates/Templates-v2/TimerTrigger-TypeScript/index.ts
@@ -1,0 +1,10 @@
+import { app, InvocationContext, Timer } from "@azure/functions";
+
+export async function $(FUNCTION_NAME_INPUT)(myTimer: Timer, context: InvocationContext): Promise<void> {
+    context.log('Timer function processed request.');
+}
+
+app.timer('$(FUNCTION_NAME_INPUT)', {
+    schedule: '$(SCHEDULE_INPUT)',
+    handler: $(FUNCTION_NAME_INPUT)
+});

--- a/Functions.Templates/Templates-v2/TimerTrigger-TypeScript/template.json
+++ b/Functions.Templates/Templates-v2/TimerTrigger-TypeScript/template.json
@@ -1,0 +1,43 @@
+{
+    "author": "Eric Jizba",
+    "name": "Timer trigger",
+    "description": "$TimerTrigger_description",
+    "programmingModel": "v4",
+    "language": "TypeScript",
+    "jobs": [
+        {
+            "name": "Create New Function",
+            "type": "CreateNewApp",
+            "inputs": [
+                {
+                    "assignTo": "$(FUNCTION_NAME_INPUT)",
+                    "paramId": "functionName",
+                    "defaultValue": "timerTrigger"
+                },
+                {
+                    "assignTo": "$(SCHEDULE_INPUT)",
+                    "paramId": "schedule"
+                }
+            ],
+            "actions": [
+                "readFile",
+                "writeFile"
+            ]
+        }
+    ],
+    "actions": [
+        {
+            "name": "readFile",
+            "type": "GetTemplateFileContent",
+            "assignTo": "$(INDEX_FILE)",
+            "filePath": "index.ts"
+        },
+        {
+            "name": "writeFile",
+            "type": "WriteToFile",
+            "source": "$(INDEX_FILE)",
+            "filePath": "src/functions/$(FUNCTION_NAME_INPUT).ts",
+            "replaceTokens": true
+        }
+    ]
+}

--- a/Functions.Templates/Templates-v2/TimerTrigger-TypeScript/template.json
+++ b/Functions.Templates/Templates-v2/TimerTrigger-TypeScript/template.json
@@ -11,23 +11,23 @@
             "inputs": [
                 {
                     "assignTo": "$(FUNCTION_NAME_INPUT)",
-                    "paramId": "functionName",
+                    "paramId": "trigger-functionName",
                     "defaultValue": "timerTrigger"
                 },
                 {
                     "assignTo": "$(SCHEDULE_INPUT)",
-                    "paramId": "schedule"
+                    "paramId": "timerTrigger-schedule"
                 }
             ],
             "actions": [
-                "readFile",
+                "getTemplateFile",
                 "writeFile"
             ]
         }
     ],
     "actions": [
         {
-            "name": "readFile",
+            "name": "getTemplateFile",
             "type": "GetTemplateFileContent",
             "assignTo": "$(INDEX_FILE)",
             "filePath": "index.ts"

--- a/Functions.Templates/Templates-v2/TimerTrigger-TypeScript/template.json
+++ b/Functions.Templates/Templates-v2/TimerTrigger-TypeScript/template.json
@@ -7,7 +7,7 @@
     "jobs": [
         {
             "name": "Create New Function",
-            "type": "CreateNewApp",
+            "type": "CreateNewFile",
             "inputs": [
                 {
                     "assignTo": "$(FUNCTION_NAME_INPUT)",


### PR DESCRIPTION
These should be identical to the templates we used for preview, just using the new v2 schema. I modeled these after the python new model templates, the schema [here](https://github.com/Azure/azure-functions-templates/tree/dev/Docs), and the docs [here](https://eng.ms/docs/cloud-ai-platform/devdiv/serverless-paas-balam/serverless-paas-benbyrd/app-service-web-apps/app-service-team-documents/functionteamdocs/design/templateexperience/templateschemav2). I was not able to get a full end-to-end test with these in any of our tooling because the tooling just doesn't seem ready yet. I did some _super rough_ testing in VS Code (with @nturinski's help), and it seemed to be on the right track. cc @khkh-ms for core tools and @shimedh for portal.

Here's the full templates-v2.json if any of the tooling folks want to do their own testing:
https://gist.github.com/ejizba/d41313bd36818ded13452b8f70ce406b