### PR TITLE
Add EventGrid Blob trigger for Python v2

### DIFF
--- a/Functions.Templates/Templates-v2/EventGridBlobTrigger-Python/blueprint.py
+++ b/Functions.Templates/Templates-v2/EventGridBlobTrigger-Python/blueprint.py
@@ -1,0 +1,11 @@
+# Register this blueprint by adding the following line of code 
+# to your entry point file.  
+# app.register_functions($(BLUEPRINT_FILENAME)) 
+# 
+# Please refer to https://aka.ms/azure-functions-python-blueprints
+
+
+import azure.functions as func
+import logging
+
+$(BLUEPRINT_FILENAME) = func.Blueprint()

--- a/Functions.Templates/Templates-v2/EventGridBlobTrigger-Python/blueprint_body.py
+++ b/Functions.Templates/Templates-v2/EventGridBlobTrigger-Python/blueprint_body.py
@@ -1,0 +1,7 @@
+
+@$(BLUEPRINT_FILENAME).blob_trigger(arg_name="myblob", path="$(PATH_TO_BLOB_INPUT)", source="$(SOURCE_NAME_INPUT)",
+                               connection="$(CONNECTION_STRING_INPUT)") 
+def $(FUNCTION_NAME_INPUT)(myblob: func.InputStream):
+    logging.info(f"Python blob trigger (using Event Grid) function processed blob"
+                f"Name: {myblob.name}"
+                f"Blob Size: {myblob.length} bytes")

--- a/Functions.Templates/Templates-v2/EventGridBlobTrigger-Python/function_app.py
+++ b/Functions.Templates/Templates-v2/EventGridBlobTrigger-Python/function_app.py
@@ -1,0 +1,11 @@
+import azure.functions as func
+import logging
+
+app = func.FunctionApp()
+
+@app.blob_trigger(arg_name="myblob", path="$(PATH_TO_BLOB_INPUT)", source="$(SOURCE_NAME_INPUT)",
+                            connection="$(CONNECTION_STRING_INPUT)") 
+def $(FUNCTION_NAME_INPUT)(myblob: func.InputStream):
+    logging.info(f"Python blob trigger (using Event Grid) function processed blob"
+                f"Name: {myblob.name}"
+                f"Blob Size: {myblob.length} bytes")

--- a/Functions.Templates/Templates-v2/EventGridBlobTrigger-Python/function_body.py
+++ b/Functions.Templates/Templates-v2/EventGridBlobTrigger-Python/function_body.py
@@ -1,0 +1,7 @@
+
+@app.blob_trigger(arg_name="myblob", path="$(PATH_TO_BLOB_INPUT)", source="$(SOURCE_NAME_INPUT)",
+                               connection="$(CONNECTION_STRING_INPUT)") 
+def $(FUNCTION_NAME_INPUT)(myblob: func.InputStream):
+    logging.info(f"Python blob trigger (using Event Grid) function processed blob"
+                f"Name: {myblob.name}"
+                f"Blob Size: {myblob.length} bytes")

--- a/Functions.Templates/Templates-v2/EventGridBlobTrigger-Python/template.json
+++ b/Functions.Templates/Templates-v2/EventGridBlobTrigger-Python/template.json
@@ -1,0 +1,262 @@
+{
+    "author": "Daniel Castro (@dacastr)",
+    "name": "Blob trigger (using Event Grid)",
+    "description": "$BlobTrigger_description",
+    "programmingModel": "v2",
+    "language": "python",
+    "jobs": [
+        {
+            "name": "Create New Project with EventGridBlobTrigger function",
+            "type": "CreateNewApp",
+            "inputs": [
+                {
+                    "assignTo": "$(APP_FILENAME)",
+                    "paramId": "app-fileName",
+                    "defaultValue": "function_app.py",
+                    "required": true,
+                    "condition" : {
+                        "name": "ClientId",
+                        "values": [ "VSCode"],
+                        "operator": "IN"
+                    }
+                },
+                {
+                    "assignTo": "$(FUNCTION_NAME_INPUT)",
+                    "paramId": "trigger-functionName",
+                    "required": true,
+                    "defaultValue": "event_grid_blob_trigger"
+                },
+                {
+                    "assignTo": "$(PATH_TO_BLOB_INPUT)",
+                    "paramId": "eventGridblobTrigger-path",
+                    "required": true,
+                    "defaultValue": "blobname"
+                },
+                {
+                    "assignTo": "$(SOURCE_NAME_INPUT)",
+                    "paramId": "eventGridblobTrigger-source",
+                    "required": true,
+                    "defaultValue": "EventGrid"
+                },
+                {
+                    "assignTo": "$(CONNECTION_STRING_INPUT)",
+                    "paramId": "eventGridblobTrigger-connection",
+                    "required": true,
+                    "defaultValue": "BlobStorageConnectionString"
+                }
+            ],
+            "actions": [
+                "readFileContent_FunctionApp",
+                "writeFile_FunctionApp",
+                "showMarkdownPreview"
+            ]
+        },
+        {
+            "name": "Add EventGridBlobTrigger function to the main file",
+            "type": "AppendToFile",
+            "inputs" : [
+                {
+                    "assignTo": "$(SELECTED_FILEPATH)",
+                    "paramId": "app-selectedFileName",
+                    "defaultValue": "function_app.py",
+                    "required": true,
+                    "condition" : {
+                        "name": "ClientId",
+                        "values": [ "VSCode"],
+                        "operator": "IN"
+                    }
+                },
+                {
+                    "assignTo": "$(FUNCTION_NAME_INPUT)",
+                    "paramId": "trigger-functionName",
+                    "required": true,
+                    "defaultValue": "EventGridBlobTrigger"
+                },
+                {
+                    "assignTo": "$(PATH_TO_BLOB_INPUT)",
+                    "paramId": "eventGridblobTrigger-path",
+                    "required": true,
+                    "defaultValue": "blobname"
+                },
+                {
+                    "assignTo": "$(SOURCE_NAME_INPUT)",
+                    "paramId": "eventGridblobTrigger-source",
+                    "required": true,
+                    "defaultValue": "EventGrid"
+                },
+                {
+                    "assignTo": "$(CONNECTION_STRING_INPUT)",
+                    "paramId": "eventGridblobTrigger-connection",
+                    "required": true,
+                    "defaultValue": "BlobStorageConnectionString"
+                }
+            ],
+            "actions": [
+                "readFileContent_FunctionBody",
+                "appendFileContent_FunctionApp"
+            ]
+        },
+        {
+            "name": "Create New Blueprint file",
+            "type": "CreateNewBlueprint",
+            "inputs": [
+                {
+                    "assignTo": "$(BLUEPRINT_FILENAME)",
+                    "paramId": "blueprint-fileName",
+                    "defaultValue": "blueprint.py",
+                    "required": true,
+                    "condition" : {
+                        "name": "ClientId",
+                        "values": [ "VSCode"],
+                        "operator": "IN"
+                    }
+                },
+                {
+                    "assignTo": "$(FUNCTION_NAME_INPUT)",
+                    "paramId": "trigger-functionName",
+                    "required": true,
+                    "defaultValue": "EventGridBlobTrigger"
+                },
+                {
+                    "assignTo": "$(PATH_TO_BLOB_INPUT)",
+                    "paramId": "eventGridblobTrigger-path",
+                    "required": true,
+                    "defaultValue": "blobname"
+                },
+                {
+                    "assignTo": "$(SOURCE_NAME_INPUT)",
+                    "paramId": "eventGridblobTrigger-source",
+                    "required": true,
+                    "defaultValue": "EventGrid"
+                },
+                {
+                    "assignTo": "$(CONNECTION_STRING_INPUT)",
+                    "paramId": "eventGridblobTrigger-connection",
+                    "required": true,
+                    "defaultValue": "BlobStorageConnectionString"
+                }
+            ],
+            "actions": [
+                "readFileContent_BlueprintFile",
+                "writeFile_BlueprintFile",
+                "readFileContent_BlueprintBody",
+                "appendFileContent_BlueprintBody"
+            ]
+        },
+        {
+            "name": "Add EventGridBlobTrigger function to the Blueprint",
+            "type": "AppendToBlueprint", 
+            "inputs" : [
+                {
+                    "paramId": "blueprint-existingFileName",
+                    "required": true,
+                    "condition" : {
+                        "name": "ClientId",
+                        "values": [ "VSCode"],
+                        "operator": "IN"
+                    }
+                },
+                {
+                    "assignTo": "$(FUNCTION_NAME_INPUT)",
+                    "paramId": "trigger-functionName",
+                    "required": true,
+                    "defaultValue": "EventGridBlobTrigger"
+                },
+                {
+                    "assignTo": "$(PATH_TO_BLOB_INPUT)",
+                    "paramId": "eventGridblobTrigger-path",
+                    "required": true,
+                    "defaultValue": "blobname"
+                },
+                {
+                    "assignTo": "$(SOURCE_NAME_INPUT)",
+                    "paramId": "eventGridblobTrigger-source",
+                    "required": true,
+                    "defaultValue": "EventGrid"
+                },
+                {
+                    "assignTo": "$(CONNECTION_STRING_INPUT)",
+                    "paramId": "eventGridblobTrigger-connection",
+                    "required": true,
+                    "defaultValue": "BlobStorageConnectionString"
+                }
+            ],
+            "actions": [
+                "readFileContent_BlueprintBody",
+                "appendFileContent_BlueprintBody"
+            ]
+        }
+    ],
+    "actions": [
+        {
+            "name": "readFileContent_FunctionApp",
+            "type": "GetTemplateFileContent",
+            "assignTo": "$(FUNCTION_APP_CONTENT)",
+            "filePath": "function_app.py"
+        },
+        {
+            "name": "writeFile_FunctionApp",
+            "type": "WriteToFile",
+            "source": "$(FUNCTION_APP_CONTENT)",
+            "filePath": "$(APP_FILENAME)",
+            "continueOnError": false,
+            "errorText": "Unable to create the function app",
+            "replaceTokens": true,
+            "FileExtension": ".py"
+        },
+        {
+            "name": "readFileContent_FunctionBody",
+            "type": "GetTemplateFileContent",
+            "assignTo": "$(FUNCTION_BODY)",
+            "filePath" : "function_body.py"
+        },
+        {
+            "name": "appendFileContent_FunctionApp",
+            "type": "AppendToFile",
+            "createIfNotExists" : false,
+            "source": "$(FUNCTION_BODY)",
+            "filePath": "$(SELECTED_FILEPATH)",
+            "continueOnError" : false,
+            "replaceTokens": true,
+            "errorText" : "Unable to create blob trigger function",
+            "FileExtension": ".py"
+        },
+        {
+            "name": "ShowMarkdownPreview",
+            "type": "ShowMarkdownPreview",
+            "filePath" : "blob_trigger_template.md"
+        },
+        {
+            "name": "readFileContent_BlueprintFile",
+            "type": "GetTemplateFileContent",
+            "assignTo": "$(BLUEPRINT_CONTENT)",
+            "filePath" : "blueprint.py"
+        },
+        {
+            "name": "writeFile_BlueprintFile",
+            "type": "WriteToFile",
+            "source": "$(BLUEPRINT_CONTENT)",
+            "filePath" : "$(BLUEPRINT_FILENAME)",
+            "continueOnError" : false,
+            "errorText" : "Unable to create blueprint",
+            "replaceTokens": true,
+            "FileExtension": ".py"
+        },
+        {
+            "name": "readFileContent_BlueprintBody",
+            "type": "GetTemplateFileContent",
+            "assignTo": "$(BLUEPRINT_BODY_CONTENT)",
+            "filePath" : "blueprint_body.py"
+        },
+        {
+            "name": "appendFileContent_BlueprintBody",
+            "type": "AppendToFile",
+            "source": "$(BLUEPRINT_BODY_CONTENT)",
+            "filePath" : "$(BLUEPRINT_FILENAME)",
+            "continueOnError" : false,
+            "errorText" : "Unable to create the Blueprint",
+            "replaceTokens": true,
+            "FileExtension": ".py"
+        }
+    ]
+}


### PR DESCRIPTION
This PR is a follow-up to #1519.

In that PR, we included the Event Grid Blob trigger for Python v1, but we failed to include it for Python v2.

This PR addresses that oversight.

