### PR TITLE
Use IHostApplicationBuilder for .NET Worker V2 SDK

### DIFF
--- a/Functions.Templates/ProjectTemplate_v4.x/CSharp-Isolated/.template.config/template.json
+++ b/Functions.Templates/ProjectTemplate_v4.x/CSharp-Isolated/.template.config/template.json
@@ -51,7 +51,11 @@
         },
         "NetCore": {
             "type": "computed",
-            "value": "(Framework == \"net9.0\" || Framework == \"net8.0\"|| Framework == \"net7.0\" || Framework == \"net6.0\")"
+            "value": "(Framework == \"net9.0\" || Framework == \"net8.0\" || Framework == \"net7.0\" || Framework == \"net6.0\")"
+        },
+        "FrameworkShouldUseV1Dependencies": {
+            "type": "computed",
+            "value": "(Framework == \"net48\" || Framework == \"net8.0\" || Framework == \"net7.0\" || Framework == \"net6.0\")"
         },
         "StorageConnectionStringValue": {
             "description": "The connection string for your Azure WebJobs Storage.",
@@ -109,14 +113,26 @@
     "postActions":
     [
         {
-            "condition": "(NetCore)",
+            "condition": "(NetCore && FrameworkShouldUseV1Dependencies)",
             "Description": "Adding Reference to Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore Nuget package",
             "ActionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
             "ContinueOnError": "true",
             "ManualInstructions": [],
             "args": {
                 "referenceType": "package",
-                "reference": "Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore", "version": "1.2.0",
+                "reference": "Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore", "version": "1.3.2",
+                "projectFileExtensions": ".csproj"
+            }
+        },
+        {
+            "condition": "(NetCore && !FrameworkShouldUseV1Dependencies)",
+            "Description": "Adding Reference to Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore Nuget package",
+            "ActionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
+            "ContinueOnError": "true",
+            "ManualInstructions": [],
+            "args": {
+                "referenceType": "package",
+                "reference": "Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore", "version": "2.0.0-preview2",
                 "projectFileExtensions": ".csproj"
             }
         },
@@ -128,7 +144,7 @@
             "ManualInstructions": [],
             "args": {
                 "referenceType": "package",
-                "reference": "Microsoft.Azure.Functions.Worker.Extensions.Http", "version": "3.1.0",
+                "reference": "Microsoft.Azure.Functions.Worker.Extensions.Http", "version": "3.2.0",
                 "projectFileExtensions": ".csproj"
             }
         },

--- a/Functions.Templates/ProjectTemplate_v4.x/CSharp-Isolated/Company.FunctionApp.csproj
+++ b/Functions.Templates/ProjectTemplate_v4.x/CSharp-Isolated/Company.FunctionApp.csproj
@@ -13,15 +13,16 @@
   <!--#if (NetCore)-->
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   <!--#endif -->
-  <!--#if (Framework == "net9.0") -->
-    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.0.0-preview1" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.0-preview1" />
-  <!--#else-->
+  <!--#if (FrameworkShouldUseV1Dependencies) -->
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.23.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.17.4" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="1.4.0" />
+  <!--#else-->
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.0.0-preview2" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.0-preview2" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="2.0.0-preview2" />
   <!--#endif -->
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.22.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="1.2.0" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/Functions.Templates/ProjectTemplate_v4.x/CSharp-Isolated/Program.cs
+++ b/Functions.Templates/ProjectTemplate_v4.x/CSharp-Isolated/Program.cs
@@ -1,8 +1,11 @@
-#if NetFramework
 using Microsoft.Azure.Functions.Worker;
-using Microsoft.Extensions.Hosting;
+#if (NetCore && !FrameworkShouldUseV1Dependencies)
+using Microsoft.Azure.Functions.Worker.Builder;
+#endif
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 
+#if NetFramework
 namespace Company.FunctionApp
 {
     internal class Program
@@ -23,12 +26,7 @@ namespace Company.FunctionApp
         }
     }
 }
-#endif
-#if NetCore
-using Microsoft.Azure.Functions.Worker;
-using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.DependencyInjection;
-
+#elseif FrameworkShouldUseV1Dependencies
 var host = new HostBuilder()
     .ConfigureFunctionsWebApplication()
     .ConfigureServices(services => {
@@ -38,4 +36,14 @@ var host = new HostBuilder()
     .Build();
 
 host.Run();
+#else
+var builder = FunctionsApplication.CreateBuilder(args);
+
+builder.ConfigureFunctionsWebApplication();
+
+builder.Services
+    .AddApplicationInsightsTelemetryWorkerService()
+    .ConfigureFunctionsApplicationInsights();
+
+builder.Build().Run();
 #endif

--- a/Functions.Templates/ProjectTemplate_v4.x/FSharp-Isolated/.template.config/template.json
+++ b/Functions.Templates/ProjectTemplate_v4.x/FSharp-Isolated/.template.config/template.json
@@ -45,6 +45,10 @@
             "type": "computed",
             "value": "(Framework == \"net9.0\" || Framework == \"net8.0\" || Framework == \"net7.0\" || Framework == \"net6.0\")"
         },
+        "FrameworkShouldUseV1Dependencies": {
+            "type": "computed",
+            "value": "(Framework == \"net8.0\" || Framework == \"net7.0\" || Framework == \"net6.0\")"
+        },
         "StorageConnectionStringValue": {
             "description": "The connection string for your Azure WebJobs Storage.",
             "type": "parameter",
@@ -75,5 +79,53 @@
             "path": "Company.FunctionApp.fsproj"
         }
     ],
-    "defaultName": "Company.FunctionApp"
+    "defaultName": "Company.FunctionApp",
+    "postActions":
+    [
+        {
+            "condition": "(NetCore && FrameworkShouldUseV1Dependencies)",
+            "Description": "Adding Reference to Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore Nuget package",
+            "ActionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
+            "ContinueOnError": "true",
+            "ManualInstructions": [],
+            "args": {
+                "referenceType": "package",
+                "reference": "Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore",
+                "version": "1.3.2",
+                "projectFileExtensions": ".fsproj"
+            }
+        },
+        {
+            "condition": "(NetCore && !FrameworkShouldUseV1Dependencies)",
+            "Description": "Adding Reference to Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore Nuget package",
+            "ActionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
+            "ContinueOnError": "true",
+            "ManualInstructions": [],
+            "args": {
+                "referenceType": "package",
+                "reference": "Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore",
+                "version": "2.0.0-preview2",
+                "projectFileExtensions": ".fsproj"
+            }
+        },
+        {
+            "condition": "(NetCore)",
+            "Description": "Adding Reference to Microsoft.Azure.Functions.Worker.Extensions.Http Nuget package",
+            "ActionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
+            "ContinueOnError": "true",
+            "ManualInstructions": [],
+            "args": {
+                "referenceType": "package",
+                "reference": "Microsoft.Azure.Functions.Worker.Extensions.Http",
+                "version": "3.2.0",
+                "projectFileExtensions": ".fsproj"
+            }
+        },
+        {
+            "description": "Restore NuGet packages required by this project.",
+            "manualInstructions": [],
+            "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+            "continueOnError": true
+        }
+    ]
 }

--- a/Functions.Templates/ProjectTemplate_v4.x/FSharp-Isolated/Company.FunctionApp.fsproj
+++ b/Functions.Templates/ProjectTemplate_v4.x/FSharp-Isolated/Company.FunctionApp.fsproj
@@ -11,15 +11,16 @@
   <!--#if (NetCore)-->
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   <!--#endif -->
-  <!--#if (Framework == "net9.0") -->
-    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.0.0-preview1" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.0-preview1" />
-  <!--#else-->
+  <!--#if (FrameworkShouldUseV1Dependencies) -->
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.23.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.17.4" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="1.4.0" />
+  <!--#else-->
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.0.0-preview2" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.0-preview2" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="2.0.0-preview2" />
   <!--#endif -->
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.22.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="1.2.0" />
   </ItemGroup>
   <ItemGroup>
     <None Include="host.json">

--- a/Functions.Templates/ProjectTemplate_v4.x/FSharp-Isolated/Program.fs
+++ b/Functions.Templates/ProjectTemplate_v4.x/FSharp-Isolated/Program.fs
@@ -1,12 +1,16 @@
-open Microsoft.Extensions.Hosting
 open Microsoft.Azure.Functions.Worker
+#if (!FrameworkShouldUseV1Dependencies)
+open Microsoft.Azure.Functions.Worker.Builder
+#endif
 open Microsoft.Extensions.DependencyInjection
+open Microsoft.Extensions.Hosting
 
+#if (FrameworkShouldUseV1Dependencies)
 [<EntryPoint>]
 let main args =
     let host =
         HostBuilder()
-            .ConfigureFunctionsWorkerDefaults()
+            .ConfigureFunctionsWebApplication()
             .ConfigureServices(fun services ->
                 services.AddApplicationInsightsTelemetryWorkerService()
                 |> ignore
@@ -14,9 +18,9 @@ let main args =
                 services.ConfigureFunctionsApplicationInsights() |> ignore)
             .Build()
 
-    // If using the Cosmos, Blob or Tables extension, you will need configure the extensions manually using the extension methods below.
+    // If using the Cosmos DB, Blob or Tables extension, you need to configure the extensions manually using the extension methods below.
     // Learn more about this here: https://go.microsoft.com/fwlink/?linkid=2245587
-    // ConfigureFunctionsWorkerDefaults(fun (context: HostBuilderContext) (appBuilder: IFunctionsWorkerApplicationBuilder) ->
+    // ConfigureFunctionsWebApplication(fun (context: HostBuilderContext) (appBuilder: IFunctionsWorkerApplicationBuilder) ->
     //     appBuilder.ConfigureCosmosDBExtension() |> ignore
     //     appBuilder.ConfigureBlobStorageExtension() |> ignore
     //     appBuilder.ConfigureTablesExtension() |> ignore
@@ -24,3 +28,24 @@ let main args =
 
     host.Run()
     0
+#else
+[<EntryPoint>]
+let main args =
+    let builder = FunctionsApplication.CreateBuilder(args)
+
+    builder.ConfigureFunctionsWebApplication() |> ignore
+
+    builder.Services
+        .AddApplicationInsightsTelemetryWorkerService()
+        .ConfigureFunctionsApplicationInsights() 
+    |> ignore
+            
+    // If using the Cosmos DB, Blob or Tables extension, you need to configure the extensions manually using the extension methods below.
+    // Learn more about this here: https://go.microsoft.com/fwlink/?linkid=2245587
+    // builder.ConfigureCosmosDBExtension() |> ignore
+    // builder.ConfigureBlobStorageExtension() |> ignore
+    // builder.ConfigureTablesExtension() |> ignore
+
+    builder.Build().Run()
+    0
+#endif

--- a/Functions.Templates/Templates/HttpTrigger-CSharp-Isolated-NetCore/.template.config/template.json
+++ b/Functions.Templates/Templates/HttpTrigger-CSharp-Isolated-NetCore/.template.config/template.json
@@ -73,7 +73,6 @@
             "args": {
                 "referenceType": "package",
                 "reference": "Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore",
-                "version": "1.3.2",
                 "projectFileExtensions": ".csproj"
             }
         },

--- a/Functions.Templates/Templates/HttpTrigger-CSharp-Isolated/.template.config/template.json
+++ b/Functions.Templates/Templates/HttpTrigger-CSharp-Isolated/.template.config/template.json
@@ -18,7 +18,7 @@
         "Framework": {
             "type": "bind",
             "binding": "msbuild:TargetFramework",
-            "defaultValue": "net6.0"
+            "defaultValue": "net8.0"
         },
         "NetFramework": {
             "type": "computed",
@@ -27,8 +27,11 @@
         },
         "NetCore": {
             "type": "computed",
-            "datatype": "bool",
-            "value": "(Framework == \"net6.0\" || Framework == \"net7.0\" || Framework == \"net8.0\" || Framework == \"net9.0\")"
+            "value": "(Framework == \"net9.0\" || Framework == \"net8.0\" || Framework == \"net7.0\" || Framework == \"net6.0\")"
+        },
+        "FrameworkShouldUseV1Dependencies": {
+            "type": "computed",
+            "value": "(Framework == \"net48\" || Framework == \"net8.0\" || Framework == \"net7.0\" || Framework == \"net6.0\")"
         },
         "namespace": {
             "description": "namespace for the generated code",
@@ -69,7 +72,7 @@
     "defaultName": "HttpTriggerCSharp",
     "postActions": [
         {
-            "condition": "(NetCore)",
+            "condition": "(NetCore && FrameworkShouldUseV1Dependencies)",
             "Description": "Adding Reference to Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore Nuget package",
             "ActionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
             "ContinueOnError": "true",
@@ -78,6 +81,18 @@
                 "referenceType": "package",
                 "reference": "Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore",
                 "version": "1.3.2",
+                "projectFileExtensions": ".csproj"
+            }
+        },
+        {
+            "condition": "(NetCore && !FrameworkShouldUseV1Dependencies)",
+            "Description": "Adding Reference to Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore Nuget package",
+            "ActionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
+            "ContinueOnError": "true",
+            "ManualInstructions": [],
+            "args": {
+                "referenceType": "package",
+                "reference": "Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore", "version": "2.0.0-preview2",
                 "projectFileExtensions": ".csproj"
             }
         },


### PR DESCRIPTION
Resolves #1573

Draft PR as the versions which supply the `IHostApplicationBuilder` support are not yet available. The current version reflects my current understanding of the surface area that will be exposed.

The approach taken here is to add a `FrameworkShouldUseV1Sdk` condition over the existing content. If that condition is failed, we instead use the V2 versions. Since V2 is in preview, only .NET 9 (also preview) is excluded from `FrameworkShouldUseV1Sdk`. When V2 is GA'd, .NET 8 and .NET Framework should be removed from `FrameworkShouldUseV1Sdk`, and for .NET Framework, additional changes will need to be made for to its section in `Program.cs`.