### PR TITLE
`skipBuildTagsForGitHubPullRequests` when the PR is a fork

### DIFF
--- a/eng/public-build.yml
+++ b/eng/public-build.yml
@@ -25,6 +25,10 @@ extends:
       image: 1es-windows-2022
       os: windows
 
+    settings:
+      # PR's from forks do not have sufficient permissions to set tags.
+      skipBuildTagsForGitHubPullRequests: ${{ variables['System.PullRequest.IsFork'] }}
+
     stages:
     - stage: Build
       dependsOn: []


### PR DESCRIPTION
`skipBuildTagsForGitHubPullRequests` when the PR is a fork as they do not have sufficient permissions