### PR TITLE
Restructuring .NET isolated project template dependencies

### DIFF
--- a/Functions.Templates/ProjectTemplate_v4.x/CSharp-Isolated/.template.config/template.json
+++ b/Functions.Templates/ProjectTemplate_v4.x/CSharp-Isolated/.template.config/template.json
@@ -91,6 +91,74 @@
                 "fallbackVariableName": "FunctionsHttpPortGenerated"
             },
             "replaces": "7071"
+        },
+        "FunctionsWorkerPackageVersion": {
+            "type": "generated",
+            "generator": "switch",
+            "replaces": "FunctionsWorkerPackageVersionValue",
+            "parameters": {
+                "datatype": "string",
+                "cases": [
+                    {
+                        "condition": "FrameworkShouldUseV1Dependencies",
+                        "value": "1.23.0"
+                    },
+                    {
+                        "value": "2.0.0-preview2"
+                    }
+                ]
+            }
+        },
+        "FunctionsAspNetCorePackageVersion": {
+            "type": "generated",
+            "generator": "switch",
+            "replaces": "FunctionsAspNetCorePackageVersionValue",
+            "parameters": {
+                "datatype": "string",
+                "cases": [
+                    {
+                        "condition": "FrameworkShouldUseV1Dependencies",
+                        "value": "1.3.2"
+                    },
+                    {
+                        "value": "2.0.0-preview2"
+                    }
+                ]
+            }
+        },
+        "FunctionsSdkPackageVersion": {
+            "type": "generated",
+            "generator": "switch",
+            "replaces": "FunctionsSdkPackageVersionValue",
+            "parameters": {
+                "datatype": "string",
+                "cases": [
+                    {
+                        "condition": "FrameworkShouldUseV1Dependencies",
+                        "value": "1.17.4"
+                    },
+                    {
+                        "value": "2.0.0-preview2"
+                    }
+                ]
+            }
+        },
+        "FunctionsAppInsightsPackageVersion": {
+            "type": "generated",
+            "generator": "switch",
+            "replaces": "FunctionsAppInsightsPackageVersionValue",
+            "parameters": {
+                "datatype": "string",
+                "cases": [
+                    {
+                        "condition": "FrameworkShouldUseV1Dependencies",
+                        "value": "1.4.0"
+                    },
+                    {
+                        "value": "2.0.0-preview2"
+                    }
+                ]
+            }
         }
     },
     "sources": [
@@ -112,42 +180,6 @@
     "defaultName": "Company.FunctionApp",
     "postActions":
     [
-        {
-            "condition": "(NetCore && FrameworkShouldUseV1Dependencies)",
-            "Description": "Adding Reference to Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore Nuget package",
-            "ActionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
-            "ContinueOnError": "true",
-            "ManualInstructions": [],
-            "args": {
-                "referenceType": "package",
-                "reference": "Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore", "version": "1.3.2",
-                "projectFileExtensions": ".csproj"
-            }
-        },
-        {
-            "condition": "(NetCore && !FrameworkShouldUseV1Dependencies)",
-            "Description": "Adding Reference to Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore Nuget package",
-            "ActionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
-            "ContinueOnError": "true",
-            "ManualInstructions": [],
-            "args": {
-                "referenceType": "package",
-                "reference": "Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore", "version": "2.0.0-preview2",
-                "projectFileExtensions": ".csproj"
-            }
-        },
-        {
-            "condition": "(NetCore)",
-            "Description": "Adding Reference to Microsoft.Azure.Functions.Worker.Extensions.Http Nuget package",
-            "ActionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
-            "ContinueOnError": "true",
-            "ManualInstructions": [],
-            "args": {
-                "referenceType": "package",
-                "reference": "Microsoft.Azure.Functions.Worker.Extensions.Http", "version": "3.2.0",
-                "projectFileExtensions": ".csproj"
-            }
-        },
         {
             "description": "Restore NuGet packages required by this project.",
             "manualInstructions": [],

--- a/Functions.Templates/ProjectTemplate_v4.x/CSharp-Isolated/Company.FunctionApp.csproj
+++ b/Functions.Templates/ProjectTemplate_v4.x/CSharp-Isolated/Company.FunctionApp.csproj
@@ -13,16 +13,13 @@
   <!--#if (NetCore)-->
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   <!--#endif -->
-  <!--#if (FrameworkShouldUseV1Dependencies) -->
-    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.23.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.17.4" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="1.4.0" />
-  <!--#else-->
-    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.0.0-preview2" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.0-preview2" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="2.0.0-preview2" />
-  <!--#endif -->
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.22.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="FunctionsWorkerPackageVersionValue" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="FunctionsAppInsightsPackageVersionValue" />
+  <!--#if (NetCore)-->
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="FunctionsAspNetCorePackageVersionValue" />
+  <!--#endif -->
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="FunctionsSdkPackageVersionValue" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">


### PR DESCRIPTION
This PR addresses a few issues:
- Our package references should be baked into the project template and not left to postActions. This prevents odd interactions with subsequent item template scaffolding.
- When the ASP.NET Core integration package is present, the HTTP extension is not needed
- Reordering dependencies to alpha-sort package references