### PR TITLE
Revert "Add name query template on dotnet isolated. "

### DIFF
--- a/Functions.Templates/Templates/HttpTrigger-CSharp-Isolated-NetCore/HttpTriggerCSharp.cs
+++ b/Functions.Templates/Templates/HttpTrigger-CSharp-Isolated-NetCore/HttpTriggerCSharp.cs
@@ -1,4 +1,3 @@
-using System.Text.Json;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.Functions.Worker;
@@ -16,26 +15,10 @@ namespace Company.Function
         }
 
         [Function("HttpTriggerCSharp")]
-        public async Task<IActionResult> Run([HttpTrigger(AuthorizationLevel.AuthLevelValue, "get", "post", Route = null)] HttpRequest req)
+        public IActionResult Run([HttpTrigger(AuthorizationLevel.AuthLevelValue, "get", "post")] HttpRequest req)
         {
             _logger.LogInformation("C# HTTP trigger function processed a request.");
-
-            string? name = req.Query["name"];
-
-            string requestBody = await new StreamReader(req.Body).ReadToEndAsync();
-            dynamic? data = null;
-
-            if (!string.IsNullOrEmpty(requestBody))
-            {
-                data = JsonSerializer.Deserialize<dynamic>(requestBody);
-                name = name ?? data?.name;
-            }
-
-            string responseMessage = string.IsNullOrEmpty(name)
-                ? "This HTTP triggered function executed successfully. Pass a name in the query string or in the request body for a personalized response."
-                : $"Hello, {name}. This HTTP triggered function executed successfully.";
-
-            return new OkObjectResult(responseMessage);
+            return new OkObjectResult("Welcome to Azure Functions!");
         }
     }
 }

--- a/Functions.Templates/Templates/HttpTrigger-CSharp-Isolated-NetFx/HttpTriggerCSharp.cs
+++ b/Functions.Templates/Templates/HttpTrigger-CSharp-Isolated-NetFx/HttpTriggerCSharp.cs
@@ -1,46 +1,28 @@
-using System.IO;
-using System.Text.Json;
-using System.Net;
-using System.Threading.Tasks;
 using Microsoft.Azure.Functions.Worker;
-using Microsoft.Extensions.Logging;
 using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Extensions.Logging;
+using System.Net;
 
 namespace Company.Function
 {
     public class HttpTriggerCSharp
     {
-        private readonly ILogger<HttpTriggerCSharp> _logger;
+        private readonly ILogger _logger;
 
-        public HttpTriggerCSharp(ILogger<HttpTriggerCSharp> logger)
+        public HttpTriggerCSharp(ILoggerFactory loggerFactory)
         {
-            _logger = logger;
+            _logger = loggerFactory.CreateLogger<HttpTriggerCSharp>();
         }
 
         [Function("HttpTriggerCSharp")]
-        public async Task<HttpResponseData> Run([HttpTrigger(AuthorizationLevel.AuthLevelValue, "get", "post")] HttpRequestData req)
+        public HttpResponseData Run([HttpTrigger(AuthorizationLevel.AuthLevelValue, "get", "post")] HttpRequestData req)
         {
             _logger.LogInformation("C# HTTP trigger function processed a request.");
 
-            var queryParams = System.Web.HttpUtility.ParseQueryString(req.Url.Query);
-            string name = queryParams["name"];
-
-            string requestBody = await new StreamReader(req.Body).ReadToEndAsync();
-            dynamic data = null;
-
-            if (!string.IsNullOrEmpty(requestBody))
-            {
-                data = JsonSerializer.Deserialize<dynamic>(requestBody);
-                name = name ?? data?.name;
-            }
-
-            string responseMessage = string.IsNullOrEmpty(name)
-                ? "This HTTP triggered function executed successfully. Pass a name in the query string or in the request body for a personalized response."
-                : $"Hello, {name}. This HTTP triggered function executed successfully.";
-
             var response = req.CreateResponse(HttpStatusCode.OK);
             response.Headers.Add("Content-Type", "text/plain; charset=utf-8");
-            await response.WriteStringAsync(responseMessage);
+
+            response.WriteString("Welcome to Azure Functions!");
 
             return response;
         }

--- a/Functions.Templates/Templates/HttpTrigger-CSharp-Isolated/HttpTriggerCSharp.cs
+++ b/Functions.Templates/Templates/HttpTrigger-CSharp-Isolated/HttpTriggerCSharp.cs
@@ -1,9 +1,8 @@
 #if( NetCore )
-using System.Text.Json;
-using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 
 namespace Company.Function
 {
@@ -17,35 +16,16 @@ namespace Company.Function
         }
 
         [Function("HttpTriggerCSharp")]
-        public async Task<IActionResult> Run([HttpTrigger(AuthorizationLevel.AuthLevelValue, "get", "post", Route = null)] HttpRequest req)
+        public IActionResult Run([HttpTrigger(AuthorizationLevel.AuthLevelValue, "get", "post")] HttpRequest req)
         {
             _logger.LogInformation("C# HTTP trigger function processed a request.");
-
-            string? name = req.Query["name"];
-
-            string requestBody = await new StreamReader(req.Body).ReadToEndAsync();
-            dynamic? data = null;
-
-            if (!string.IsNullOrEmpty(requestBody))
-            {
-                data = JsonSerializer.Deserialize<dynamic>(requestBody);
-                name = name ?? data?.name;
-            }
-
-            string responseMessage = string.IsNullOrEmpty(name)
-                ? "This HTTP triggered function executed successfully. Pass a name in the query string or in the request body for a personalized response."
-                : $"Hello, {name}. This HTTP triggered function executed successfully.";
-
-            return new OkObjectResult(responseMessage);
+            return new OkObjectResult("Welcome to Azure Functions!");
         }
     }
 }
 #endif
 #if( NetFramework )
-using System.IO;
-using System.Text.Json;
 using System.Net;
-using System.Threading.Tasks;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 using Microsoft.Azure.Functions.Worker.Http;
@@ -62,29 +42,14 @@ namespace Company.Function
         }
 
         [Function("HttpTriggerCSharp")]
-        public async Task<HttpResponseData> Run([HttpTrigger(AuthorizationLevel.AuthLevelValue, "get", "post")] HttpRequestData req)
+        public HttpResponseData Run([HttpTrigger(AuthorizationLevel.AuthLevelValue, "get", "post")] HttpRequestData req)
         {
             _logger.LogInformation("C# HTTP trigger function processed a request.");
 
-            var queryParams = System.Web.HttpUtility.ParseQueryString(req.Url.Query);
-            string name = queryParams["name"];
-
-            string requestBody = await new StreamReader(req.Body).ReadToEndAsync();
-            dynamic data = null;
-
-            if (!string.IsNullOrEmpty(requestBody))
-            {
-                data = JsonSerializer.Deserialize<dynamic>(requestBody);
-                name = name ?? data?.name;
-            }
-
-            string responseMessage = string.IsNullOrEmpty(name)
-                ? "This HTTP triggered function executed successfully. Pass a name in the query string or in the request body for a personalized response."
-                : $"Hello, {name}. This HTTP triggered function executed successfully.";
-
             var response = req.CreateResponse(HttpStatusCode.OK);
             response.Headers.Add("Content-Type", "text/plain; charset=utf-8");
-            await response.WriteStringAsync(responseMessage);
+
+            response.WriteString("Welcome to Azure Functions!");
 
             return response;
         }


### PR DESCRIPTION
Reverts Azure/azure-functions-templates#1575

### Reason

What we have today in the isolated template is an intentional choice to move away from what we have with in-proc based on customer feedback. The in-proc template follows some problematic patterns that we want to avoid in the isolated template (e.g. use of dynamic, explicit use of the serializer, object disposal, etc.).

If we want to align the experiences, we should make sure we're addressing some of the issues with the original (in-proc) template to make sure we start customers down a good path.

This will be addressed in the future via some new work items coming in with Aspire.