### PR TITLE
.NET V2 without Application Insights

### DIFF
--- a/Functions.Templates/ProjectTemplate_v4.x/CSharp-Isolated/.template.config/template.json
+++ b/Functions.Templates/ProjectTemplate_v4.x/CSharp-Isolated/.template.config/template.json
@@ -104,7 +104,7 @@
                         "value": "1.23.0"
                     },
                     {
-                        "value": "2.0.0-preview4"
+                        "value": "2.0.0-preview5"
                     }
                 ]
             }
@@ -155,7 +155,7 @@
                         "value": "1.4.0"
                     },
                     {
-                        "value": "2.0.0-preview4"
+                        "value": "2.0.0-preview5"
                     }
                 ]
             }

--- a/Functions.Templates/ProjectTemplate_v4.x/CSharp-Isolated/Company.FunctionApp.csproj
+++ b/Functions.Templates/ProjectTemplate_v4.x/CSharp-Isolated/Company.FunctionApp.csproj
@@ -13,9 +13,16 @@
   <!--#if (NetCore)-->
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   <!--#endif -->
+  <!--#if (FrameworkShouldUseV1Dependencies)-->
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.22.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="FunctionsWorkerPackageVersionValue" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="FunctionsAppInsightsPackageVersionValue" />
+  <!--#else -->
+    <!-- Application Insights isn't enabled by default. See https://aka.ms/AAt8mw4. -->
+    <!-- <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.22.0" /> -->
+    <!-- <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="FunctionsAppInsightsPackageVersionValue" /> -->
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="FunctionsWorkerPackageVersionValue" />
+  <!--#endif -->
   <!--#if (NetCore)-->
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="FunctionsAspNetCorePackageVersionValue" />
   <!--#endif -->

--- a/Functions.Templates/ProjectTemplate_v4.x/CSharp-Isolated/Program.cs
+++ b/Functions.Templates/ProjectTemplate_v4.x/CSharp-Isolated/Program.cs
@@ -1,8 +1,12 @@
+#if (FrameworkShouldUseV1Dependencies)
 using Microsoft.Azure.Functions.Worker;
+#endif
 #if (NetCore && !FrameworkShouldUseV1Dependencies)
 using Microsoft.Azure.Functions.Worker.Builder;
 #endif
+#if (FrameworkShouldUseV1Dependencies)
 using Microsoft.Extensions.DependencyInjection;
+#endif
 using Microsoft.Extensions.Hosting;
 
 #if NetFramework
@@ -41,9 +45,10 @@ var builder = FunctionsApplication.CreateBuilder(args);
 
 builder.ConfigureFunctionsWebApplication();
 
-builder.Services
-    .AddApplicationInsightsTelemetryWorkerService()
-    .ConfigureFunctionsApplicationInsights();
+// Application Insights isn't enabled by default. See https://aka.ms/AAt8mw4.
+// builder.Services
+//     .AddApplicationInsightsTelemetryWorkerService()
+//     .ConfigureFunctionsApplicationInsights();
 
 builder.Build().Run();
 #endif


### PR DESCRIPTION
Comment out Application Insights pieces for the V2 branch of .NET isolated templates.

Draft while we await the new package versions.