### PR TITLE
Updating isolated templates for V2 package GA

### DIFF
--- a/Functions.Templates/ProjectTemplate_v4.x/CSharp-Isolated/.template.config/template.json
+++ b/Functions.Templates/ProjectTemplate_v4.x/CSharp-Isolated/.template.config/template.json
@@ -55,7 +55,7 @@
         },
         "FrameworkShouldUseV1Dependencies": {
             "type": "computed",
-            "value": "(Framework == \"net48\" || Framework == \"net8.0\" || Framework == \"net7.0\" || Framework == \"net6.0\")"
+            "value": "(Framework == \"net48\" || Framework == \"net7.0\" || Framework == \"net6.0\")"
         },
         "StorageConnectionStringValue": {
             "description": "The connection string for your Azure WebJobs Storage.",
@@ -104,7 +104,7 @@
                         "value": "1.23.0"
                     },
                     {
-                        "value": "2.0.0-preview5"
+                        "value": "2.0.0"
                     }
                 ]
             }
@@ -121,7 +121,7 @@
                         "value": "1.3.2"
                     },
                     {
-                        "value": "2.0.0-preview4"
+                        "value": "2.0.0"
                     }
                 ]
             }
@@ -138,7 +138,7 @@
                         "value": "1.18.1"
                     },
                     {
-                        "value": "2.0.0-preview2"
+                        "value": "2.0.0"
                     }
                 ]
             }
@@ -155,7 +155,7 @@
                         "value": "1.4.0"
                     },
                     {
-                        "value": "2.0.0-preview5"
+                        "value": "2.0.0"
                     }
                 ]
             }

--- a/Functions.Templates/Templates/HttpTrigger-CSharp-Isolated/.template.config/template.json
+++ b/Functions.Templates/Templates/HttpTrigger-CSharp-Isolated/.template.config/template.json
@@ -31,7 +31,7 @@
         },
         "FrameworkShouldUseV1Dependencies": {
             "type": "computed",
-            "value": "(Framework == \"net48\" || Framework == \"net8.0\" || Framework == \"net7.0\" || Framework == \"net6.0\")"
+            "value": "(Framework == \"net48\" || Framework == \"net7.0\" || Framework == \"net6.0\")"
         },
         "namespace": {
             "description": "namespace for the generated code",
@@ -93,7 +93,7 @@
             "args": {
                 "referenceType": "package",
                 "reference": "Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore",
-                "version": "2.0.0-preview4",
+                "version": "2.0.0",
                 "projectFileExtensions": ".csproj"
             }
         },


### PR DESCRIPTION
Moving isolated worker model V2 packages to GA status, and adding .NET 8 as a valid candidate for using them.

This PR is being left as a draft at the time of opening, as the package versions in question have not yet been published.

After publishing, proper validation should occur for .NET Framework 4.8, .NET 8, and .NET 9 projects with and without HTTP triggers being added.

## Validation instructions

To validate once the packages are live, check my branch out locally and perform the following steps, starting from the repo root:

1. Change to the `Build` directory.
1. Run `npm install` and then `gulp build-all`.
1. Run the following commands to update your system to use the built templates:

    1. `dotnet new uninstall Microsoft.Azure.Functions.Worker.ProjectTemplates`
    2. ` dotnet new uninstall Microsoft.Azure.Functions.Worker.ItemTemplates`
    3. `dotnet new install <REPO_ROOT>/bin/VS/Microsoft.Azure.Functions.Worker.ItemTemplates.4.0.1.nupkg` (replacing `<REPO_ROOT>` as appropriate with an absolute path)
    4. `dotnet new install <REPO_ROOT>/bin/VS/Microsoft.Azure.Functions.Worker.ProjectTemplates.4.0.1.nupkg` (with the same replacement)
 
4.  Change to another directory where you'll scaffold out a given template.
5. Run `dotnet new func -F net9.0`, `dotnet new func -F net8.0`, `dotnet new func` (for default to 8.0), and `dotnet new func -F net48` as appropriate for the scenario being tested. All variants should be verified.
6. Confirm that there were no errors output during that operation (there will be errors here prior to the packages going live, as they cannot be found during the restore)
7. Confirm that the files were laid out correctly:

    - The `.csproj` file should include references to the right versions of Functions packages. For .NET 8 and .NET 9, these should be the `2.0.0` versions. For .NET Framework 4.8, these should be a mix of 1.x versions.
    - The `Program.cs` should use `FunctionsApplication.CreateBuilder()` for .NET 8 and .NET 9. It should use `` for .NET Framework 4.8.

8. Build the project and confirm no errors (`dotnet build`)
9. Add a function. Testing should include HTTP (`dotnet new http`) and non-HTTP triggers (e.g., `dotnet new blob`).
10. Ensure that the project remains in good standing, and that no package references have regressed to earlier versions.
11. Run the project and confirm the trigger works as expected. `func start` will work for all versions. For .NET 8 and .NET 9, we'd also expect that `dotnet run` could be used instead since the V2 SDK should be referenced.
12. For .NET 8 and .NET 9, uncomment the lines in `Program.cs` and the `.csproj` file related to Application Insights. Rebuild and rerun to confirm things still work as expected.

### Client testing
Additional testing is needed for some variant scenarios in both the Core Tools and in Visual Studio.

VS can be tested with this PR by copying the nupkgs into the right locations on disk. Assuming that the latest version of the feed has already been resolved, this would be `%LOCALAPPDATA%\AzureFunctionsTools\Releases\4.101.0\AzureFunctionsTools\Releases\net9-isolated\templates` (with appropriate adjustments for each other TFM). Do not copy the same item templates package that you used earlier; VS instead takes the specific NetCore and NetFx variants appropriate to each TGM. You will see these in the templates repo build output folder. Rename the packages to match exactly what is already there (e.g., `ItemTemplates.nupkg`). Repeat for each TFM. Then run through the new project creation flow for each scenario. Note that a preview version of VS may need to be used for .NET 9 depending on if the new version of VS has come out yet.

Core Tools can also be tested through a local build of that repo, with the NuGets copied into the right place. Because this is a messy process, it is not required for ultimate completion of this PR. It will be easiest to update the Core Tools to reference the version that gets published using the commits of this PR instead. That will be a similar battery of tests, but it should be the case that if the base testing above worked fine, then Core Tools should as well.