### PR TITLE
Remove redundant project config, add file-scoped namespaces

### DIFF
--- a/Functions.Templates/ProjectTemplate_v4.x/CSharp-Isolated/Company.FunctionApp.csproj
+++ b/Functions.Templates/ProjectTemplate_v4.x/CSharp-Isolated/Company.FunctionApp.csproj
@@ -28,9 +28,4 @@
   <!--#endif -->
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="FunctionsSdkPackageVersionValue" />
   </ItemGroup>
-<!--#if (NetFramework)-->
-  <ItemGroup>
-    <Folder Include="Properties\" />
-  </ItemGroup>
-<!--#endif -->
 </Project>

--- a/Functions.Templates/ProjectTemplate_v4.x/CSharp-Isolated/Company.FunctionApp.csproj
+++ b/Functions.Templates/ProjectTemplate_v4.x/CSharp-Isolated/Company.FunctionApp.csproj
@@ -28,20 +28,6 @@
   <!--#endif -->
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="FunctionsSdkPackageVersionValue" />
   </ItemGroup>
-  <ItemGroup>
-    <None Update="host.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="local.settings.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
-    </None>
-  </ItemGroup>
-<!--#if (NetCore)-->
-  <ItemGroup>
-    <Using Include="System.Threading.ExecutionContext" Alias="ExecutionContext"/>
-  </ItemGroup>
-<!--#endif -->
 <!--#if (NetFramework)-->
   <ItemGroup>
     <Folder Include="Properties\" />

--- a/Functions.Templates/Templates/BlobTrigger-CSharp-Isolated/BlobTriggerCSharp.cs
+++ b/Functions.Templates/Templates/BlobTrigger-CSharp-Isolated/BlobTriggerCSharp.cs
@@ -19,6 +19,6 @@ public class BlobTriggerCSharp
     {
         using var blobStreamReader = new StreamReader(stream);
         var content = await blobStreamReader.ReadToEndAsync();
-        _logger.LogInformation($"C# Blob trigger function Processed blob\n Name: {name} \n Data: {content}");
+        _logger.LogInformation("C# Blob trigger function Processed blob\n Name: {name} \n Data: {content}", name, content);
     }
 }

--- a/Functions.Templates/Templates/BlobTrigger-CSharp-Isolated/BlobTriggerCSharp.cs
+++ b/Functions.Templates/Templates/BlobTrigger-CSharp-Isolated/BlobTriggerCSharp.cs
@@ -3,23 +3,22 @@ using System.Threading.Tasks;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 
-namespace Company.Function
+namespace Company.Function;
+
+public class BlobTriggerCSharp
 {
-    public class BlobTriggerCSharp
+    private readonly ILogger<BlobTriggerCSharp> _logger;
+
+    public BlobTriggerCSharp(ILogger<BlobTriggerCSharp> logger)
     {
-        private readonly ILogger<BlobTriggerCSharp> _logger;
+        _logger = logger;
+    }
 
-        public BlobTriggerCSharp(ILogger<BlobTriggerCSharp> logger)
-        {
-            _logger = logger;
-        }
-
-        [Function(nameof(BlobTriggerCSharp))]
-        public async Task Run([BlobTrigger("PathValue/{name}", Connection = "ConnectionValue")] Stream stream, string name)
-        {
-            using var blobStreamReader = new StreamReader(stream);
-            var content = await blobStreamReader.ReadToEndAsync();
-            _logger.LogInformation($"C# Blob trigger function Processed blob\n Name: {name} \n Data: {content}");
-        }
+    [Function(nameof(BlobTriggerCSharp))]
+    public async Task Run([BlobTrigger("PathValue/{name}", Connection = "ConnectionValue")] Stream stream, string name)
+    {
+        using var blobStreamReader = new StreamReader(stream);
+        var content = await blobStreamReader.ReadToEndAsync();
+        _logger.LogInformation($"C# Blob trigger function Processed blob\n Name: {name} \n Data: {content}");
     }
 }

--- a/Functions.Templates/Templates/CosmosDBTrigger-CSharp-Isolated/CosmosDBTriggerCSharp.cs
+++ b/Functions.Templates/Templates/CosmosDBTrigger-CSharp-Isolated/CosmosDBTriggerCSharp.cs
@@ -7,11 +7,11 @@ namespace Company.Function;
 
 public class CosmosDBTriggerCSharp
 {
-    private readonly ILogger _logger;
+    private readonly ILogger<CosmosDBTriggerCSharp> _logger;
 
-    public CosmosDBTriggerCSharp(ILoggerFactory loggerFactory)
+    public CosmosDBTriggerCSharp(ILogger<CosmosDBTriggerCSharp> logger)
     {
-        _logger = loggerFactory.CreateLogger<CosmosDBTriggerCSharp>();
+        _logger = logger;
     }
 
     [Function("CosmosDBTriggerCSharp")]

--- a/Functions.Templates/Templates/CosmosDBTrigger-CSharp-Isolated/CosmosDBTriggerCSharp.cs
+++ b/Functions.Templates/Templates/CosmosDBTrigger-CSharp-Isolated/CosmosDBTriggerCSharp.cs
@@ -3,41 +3,40 @@ using System.Collections.Generic;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 
-namespace Company.Function
+namespace Company.Function;
+
+public class CosmosDBTriggerCSharp
 {
-    public class CosmosDBTriggerCSharp
+    private readonly ILogger _logger;
+
+    public CosmosDBTriggerCSharp(ILoggerFactory loggerFactory)
     {
-        private readonly ILogger _logger;
-
-        public CosmosDBTriggerCSharp(ILoggerFactory loggerFactory)
-        {
-            _logger = loggerFactory.CreateLogger<CosmosDBTriggerCSharp>();
-        }
-
-        [Function("CosmosDBTriggerCSharp")]
-        public void Run([CosmosDBTrigger(
-            databaseName: "DatabaseValue",
-            containerName: "ContainerValue",
-            Connection = "ConnectionValue",
-            LeaseContainerName = "leases",
-            CreateLeaseContainerIfNotExists = true)] IReadOnlyList<MyDocument> input)
-        {
-            if (input != null && input.Count > 0)
-            {
-                _logger.LogInformation("Documents modified: " + input.Count);
-                _logger.LogInformation("First document Id: " + input[0].id);
-            }
-        }
+        _logger = loggerFactory.CreateLogger<CosmosDBTriggerCSharp>();
     }
 
-    public class MyDocument
+    [Function("CosmosDBTriggerCSharp")]
+    public void Run([CosmosDBTrigger(
+        databaseName: "DatabaseValue",
+        containerName: "ContainerValue",
+        Connection = "ConnectionValue",
+        LeaseContainerName = "leases",
+        CreateLeaseContainerIfNotExists = true)] IReadOnlyList<MyDocument> input)
     {
-        public string id { get; set; }
-
-        public string Text { get; set; }
-
-        public int Number { get; set; }
-
-        public bool Boolean { get; set; }
+        if (input != null && input.Count > 0)
+        {
+            _logger.LogInformation("Documents modified: " + input.Count);
+            _logger.LogInformation("First document Id: " + input[0].id);
+        }
     }
+}
+
+public class MyDocument
+{
+    public string id { get; set; }
+
+    public string Text { get; set; }
+
+    public int Number { get; set; }
+
+    public bool Boolean { get; set; }
 }

--- a/Functions.Templates/Templates/DurableFunctionsOrchestration-CSharp-Isolated/DurableFunctionsOrchestrationCSharp.cs
+++ b/Functions.Templates/Templates/DurableFunctionsOrchestration-CSharp-Isolated/DurableFunctionsOrchestrationCSharp.cs
@@ -4,52 +4,51 @@ using Microsoft.DurableTask;
 using Microsoft.DurableTask.Client;
 using Microsoft.Extensions.Logging;
 
-namespace Company.Function
+namespace Company.Function;
+
+public static class DurableFunctionsOrchestrationCSharp
 {
-    public static class DurableFunctionsOrchestrationCSharp
+    [Function(nameof(DurableFunctionsOrchestrationCSharp))]
+    public static async Task<List<string>> RunOrchestrator(
+        [OrchestrationTrigger] TaskOrchestrationContext context)
     {
-        [Function(nameof(DurableFunctionsOrchestrationCSharp))]
-        public static async Task<List<string>> RunOrchestrator(
-            [OrchestrationTrigger] TaskOrchestrationContext context)
-        {
-            ILogger logger = context.CreateReplaySafeLogger(nameof(DurableFunctionsOrchestrationCSharp));
-            logger.LogInformation("Saying hello.");
-            var outputs = new List<string>();
+        ILogger logger = context.CreateReplaySafeLogger(nameof(DurableFunctionsOrchestrationCSharp));
+        logger.LogInformation("Saying hello.");
+        var outputs = new List<string>();
 
-            // Replace name and input with values relevant for your Durable Functions Activity
-            outputs.Add(await context.CallActivityAsync<string>(nameof(SayHello), "Tokyo"));
-            outputs.Add(await context.CallActivityAsync<string>(nameof(SayHello), "Seattle"));
-            outputs.Add(await context.CallActivityAsync<string>(nameof(SayHello), "London"));
+        // Replace name and input with values relevant for your Durable Functions Activity
+        outputs.Add(await context.CallActivityAsync<string>(nameof(SayHello), "Tokyo"));
+        outputs.Add(await context.CallActivityAsync<string>(nameof(SayHello), "Seattle"));
+        outputs.Add(await context.CallActivityAsync<string>(nameof(SayHello), "London"));
 
-            // returns ["Hello Tokyo!", "Hello Seattle!", "Hello London!"]
-            return outputs;
-        }
+        // returns ["Hello Tokyo!", "Hello Seattle!", "Hello London!"]
+        return outputs;
+    }
 
-        [Function(nameof(SayHello))]
-        public static string SayHello([ActivityTrigger] string name, FunctionContext executionContext)
-        {
-            ILogger logger = executionContext.GetLogger("SayHello");
-            logger.LogInformation("Saying hello to {name}.", name);
-            return $"Hello {name}!";
-        }
+    [Function(nameof(SayHello))]
+    public static string SayHello([ActivityTrigger] string name, FunctionContext executionContext)
+    {
+        ILogger logger = executionContext.GetLogger("SayHello");
+        logger.LogInformation("Saying hello to {name}.", name);
+        return $"Hello {name}!";
+    }
 
-        [Function("DurableFunctionsOrchestrationCSharp_HttpStart")]
-        public static async Task<HttpResponseData> HttpStart(
-            [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post")] HttpRequestData req,
-            [DurableClient] DurableTaskClient client,
-            FunctionContext executionContext)
-        {
-            ILogger logger = executionContext.GetLogger("DurableFunctionsOrchestrationCSharp_HttpStart");
+    [Function("DurableFunctionsOrchestrationCSharp_HttpStart")]
+    public static async Task<HttpResponseData> HttpStart(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post")] HttpRequestData req,
+        [DurableClient] DurableTaskClient client,
+        FunctionContext executionContext)
+    {
+        ILogger logger = executionContext.GetLogger("DurableFunctionsOrchestrationCSharp_HttpStart");
 
-            // Function input comes from the request content.
-            string instanceId = await client.ScheduleNewOrchestrationInstanceAsync(
-                nameof(DurableFunctionsOrchestrationCSharp));
+        // Function input comes from the request content.
+        string instanceId = await client.ScheduleNewOrchestrationInstanceAsync(
+            nameof(DurableFunctionsOrchestrationCSharp));
 
-            logger.LogInformation("Started orchestration with ID = '{instanceId}'.", instanceId);
+        logger.LogInformation("Started orchestration with ID = '{instanceId}'.", instanceId);
 
-            // Returns an HTTP 202 response with an instance management payload.
-            // See https://learn.microsoft.com/azure/azure-functions/durable/durable-functions-http-api#start-orchestration
-            return await client.CreateCheckStatusResponseAsync(req, instanceId);
-        }
+        // Returns an HTTP 202 response with an instance management payload.
+        // See https://learn.microsoft.com/azure/azure-functions/durable/durable-functions-http-api#start-orchestration
+        return await client.CreateCheckStatusResponseAsync(req, instanceId);
     }
 }

--- a/Functions.Templates/Templates/EventGridBlobTrigger-CSharp-Isolated-6.x/EventGridBlobTriggerCSharp.cs
+++ b/Functions.Templates/Templates/EventGridBlobTrigger-CSharp-Isolated-6.x/EventGridBlobTriggerCSharp.cs
@@ -19,6 +19,6 @@ public class EventGridBlobTriggerCSharp
     {
         using var blobStreamReader = new StreamReader(stream);
         var content = await blobStreamReader.ReadToEndAsync();
-        _logger.LogInformation($"C# Blob Trigger (using Event Grid) processed blob\n Name: {name} \n Data: {content}");
+        _logger.LogInformation("C# Blob Trigger (using Event Grid) processed blob\n Name: {name} \n Data: {content}", name, content);
     }
 }

--- a/Functions.Templates/Templates/EventGridBlobTrigger-CSharp-Isolated-6.x/EventGridBlobTriggerCSharp.cs
+++ b/Functions.Templates/Templates/EventGridBlobTrigger-CSharp-Isolated-6.x/EventGridBlobTriggerCSharp.cs
@@ -3,23 +3,22 @@ using System.Threading.Tasks;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 
-namespace Company.Function
+namespace Company.Function;
+
+public class EventGridBlobTriggerCSharp
 {
-    public class EventGridBlobTriggerCSharp
+    private readonly ILogger<EventGridBlobTriggerCSharp> _logger;
+
+    public EventGridBlobTriggerCSharp(ILogger<EventGridBlobTriggerCSharp> logger)
     {
-        private readonly ILogger<EventGridBlobTriggerCSharp> _logger;
+        _logger = logger;
+    }
 
-        public EventGridBlobTriggerCSharp(ILogger<EventGridBlobTriggerCSharp> logger)
-        {
-            _logger = logger;
-        }
-
-        [Function(nameof(EventGridBlobTriggerCSharp))]
-        public async Task Run([BlobTrigger("PathValue/{name}", Source = BlobTriggerSource.EventGrid, Connection = "ConnectionValue")] Stream stream, string name)
-        {
-            using var blobStreamReader = new StreamReader(stream);
-            var content = await blobStreamReader.ReadToEndAsync();
-            _logger.LogInformation($"C# Blob Trigger (using Event Grid) processed blob\n Name: {name} \n Data: {content}");
-        }
+    [Function(nameof(EventGridBlobTriggerCSharp))]
+    public async Task Run([BlobTrigger("PathValue/{name}", Source = BlobTriggerSource.EventGrid, Connection = "ConnectionValue")] Stream stream, string name)
+    {
+        using var blobStreamReader = new StreamReader(stream);
+        var content = await blobStreamReader.ReadToEndAsync();
+        _logger.LogInformation($"C# Blob Trigger (using Event Grid) processed blob\n Name: {name} \n Data: {content}");
     }
 }

--- a/Functions.Templates/Templates/EventGridTrigger-CSharp-Isolated/EventGridTriggerCSharp.cs
+++ b/Functions.Templates/Templates/EventGridTrigger-CSharp-Isolated/EventGridTriggerCSharp.cs
@@ -6,21 +6,20 @@ using Azure.Messaging;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 
-namespace Company.Function
+namespace Company.Function;
+
+public class EventGridTriggerCSharp
 {
-    public class EventGridTriggerCSharp
+    private readonly ILogger<EventGridTriggerCSharp> _logger;
+
+    public EventGridTriggerCSharp(ILogger<EventGridTriggerCSharp> logger)
     {
-        private readonly ILogger<EventGridTriggerCSharp> _logger;
+        _logger = logger;
+    }
 
-        public EventGridTriggerCSharp(ILogger<EventGridTriggerCSharp> logger)
-        {
-            _logger = logger;
-        }
-
-        [Function(nameof(EventGridTriggerCSharp))]
-        public void Run([EventGridTrigger] CloudEvent cloudEvent)
-        {
-            _logger.LogInformation("Event type: {type}, Event subject: {subject}", cloudEvent.Type, cloudEvent.Subject);
-        }
+    [Function(nameof(EventGridTriggerCSharp))]
+    public void Run([EventGridTrigger] CloudEvent cloudEvent)
+    {
+        _logger.LogInformation("Event type: {type}, Event subject: {subject}", cloudEvent.Type, cloudEvent.Subject);
     }
 }

--- a/Functions.Templates/Templates/EventHubTrigger-CSharp-Isolated/EventHubTriggerCSharp.cs
+++ b/Functions.Templates/Templates/EventHubTrigger-CSharp-Isolated/EventHubTriggerCSharp.cs
@@ -3,25 +3,23 @@ using Azure.Messaging.EventHubs;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 
-namespace Company.Function
+namespace Company.Function;
+public class EventHubTriggerCSharp
 {
-    public class EventHubTriggerCSharp
+    private readonly ILogger<EventHubTriggerCSharp> _logger;
+
+    public EventHubTriggerCSharp(ILogger<EventHubTriggerCSharp> logger)
     {
-        private readonly ILogger<EventHubTriggerCSharp> _logger;
+        _logger = logger;
+    }
 
-        public EventHubTriggerCSharp(ILogger<EventHubTriggerCSharp> logger)
+    [Function(nameof(EventHubTriggerCSharp))]
+    public void Run([EventHubTrigger("eventHubNameValue", Connection = "ConnectionValue")] EventData[] events)
+    {
+        foreach (EventData @event in events)
         {
-            _logger = logger;
-        }
-
-        [Function(nameof(EventHubTriggerCSharp))]
-        public void Run([EventHubTrigger("eventHubNameValue", Connection = "ConnectionValue")] EventData[] events)
-        {
-            foreach (EventData @event in events)
-            {
-                _logger.LogInformation("Event Body: {body}", @event.Body);
-                _logger.LogInformation("Event Content-Type: {contentType}", @event.ContentType);
-            }
+            _logger.LogInformation("Event Body: {body}", @event.Body);
+            _logger.LogInformation("Event Content-Type: {contentType}", @event.ContentType);
         }
     }
 }

--- a/Functions.Templates/Templates/HttpTrigger-CSharp-Isolated-NetCore/.template.config/template.json
+++ b/Functions.Templates/Templates/HttpTrigger-CSharp-Isolated-NetCore/.template.config/template.json
@@ -54,18 +54,6 @@
     "defaultName": "HttpTriggerCSharp",
     "postActions": [
         {
-            "Description": "Adding Reference to Microsoft.Azure.Functions.Worker.Extensions.Http Nuget package",
-            "ActionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
-            "ContinueOnError": "true",
-            "ManualInstructions": [],
-            "args": {
-                "referenceType": "package",
-                "reference": "Microsoft.Azure.Functions.Worker.Extensions.Http",
-                "version": "3.2.0",
-                "projectFileExtensions": ".csproj"
-            }
-        },
-        {
             "Description": "Adding Reference to Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore Nuget package",
             "ActionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
             "ContinueOnError": "true",

--- a/Functions.Templates/Templates/HttpTrigger-CSharp-Isolated-NetCore/HttpTriggerCSharp.cs
+++ b/Functions.Templates/Templates/HttpTrigger-CSharp-Isolated-NetCore/HttpTriggerCSharp.cs
@@ -3,22 +3,21 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 
-namespace Company.Function
+namespace Company.Function;
+
+public class HttpTriggerCSharp
 {
-    public class HttpTriggerCSharp
+    private readonly ILogger<HttpTriggerCSharp> _logger;
+
+    public HttpTriggerCSharp(ILogger<HttpTriggerCSharp> logger)
     {
-        private readonly ILogger<HttpTriggerCSharp> _logger;
+        _logger = logger;
+    }
 
-        public HttpTriggerCSharp(ILogger<HttpTriggerCSharp> logger)
-        {
-            _logger = logger;
-        }
-
-        [Function("HttpTriggerCSharp")]
-        public IActionResult Run([HttpTrigger(AuthorizationLevel.AuthLevelValue, "get", "post")] HttpRequest req)
-        {
-            _logger.LogInformation("C# HTTP trigger function processed a request.");
-            return new OkObjectResult("Welcome to Azure Functions!");
-        }
+    [Function("HttpTriggerCSharp")]
+    public IActionResult Run([HttpTrigger(AuthorizationLevel.AuthLevelValue, "get", "post")] HttpRequest req)
+    {
+        _logger.LogInformation("C# HTTP trigger function processed a request.");
+        return new OkObjectResult("Welcome to Azure Functions!");
     }
 }

--- a/Functions.Templates/Templates/HttpTrigger-CSharp-Isolated/.template.config/template.json
+++ b/Functions.Templates/Templates/HttpTrigger-CSharp-Isolated/.template.config/template.json
@@ -98,6 +98,7 @@
             }
         },
         {
+            "condition": "(NetFramework)",
             "Description": "Adding Reference to Microsoft.Azure.Functions.Worker.Extensions.Http Nuget package",
             "ActionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
             "ContinueOnError": "true",

--- a/Functions.Templates/Templates/HttpTrigger-CSharp-Isolated/HttpTriggerCSharp.cs
+++ b/Functions.Templates/Templates/HttpTrigger-CSharp-Isolated/HttpTriggerCSharp.cs
@@ -4,23 +4,22 @@ using Microsoft.Extensions.Logging;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
-namespace Company.Function
+namespace Company.Function;
+
+public class HttpTriggerCSharp
 {
-    public class HttpTriggerCSharp
+    private readonly ILogger<HttpTriggerCSharp> _logger;
+
+    public HttpTriggerCSharp(ILogger<HttpTriggerCSharp> logger)
     {
-        private readonly ILogger<HttpTriggerCSharp> _logger;
+        _logger = logger;
+    }
 
-        public HttpTriggerCSharp(ILogger<HttpTriggerCSharp> logger)
-        {
-            _logger = logger;
-        }
-
-        [Function("HttpTriggerCSharp")]
-        public IActionResult Run([HttpTrigger(AuthorizationLevel.AuthLevelValue, "get", "post")] HttpRequest req)
-        {
-            _logger.LogInformation("C# HTTP trigger function processed a request.");
-            return new OkObjectResult("Welcome to Azure Functions!");
-        }
+    [Function("HttpTriggerCSharp")]
+    public IActionResult Run([HttpTrigger(AuthorizationLevel.AuthLevelValue, "get", "post")] HttpRequest req)
+    {
+        _logger.LogInformation("C# HTTP trigger function processed a request.");
+        return new OkObjectResult("Welcome to Azure Functions!");
     }
 }
 #endif

--- a/Functions.Templates/Templates/KustoInputBinding-CSharp-Isolated/KustoInputBindingIsolated.cs
+++ b/Functions.Templates/Templates/KustoInputBinding-CSharp-Isolated/KustoInputBindingIsolated.cs
@@ -5,32 +5,30 @@ using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Azure.Functions.Worker.Extensions.Kusto;
 using Microsoft.Extensions.Logging;
 
+namespace Company.Function;
 
-namespace Company.Function
+// Visit https://github.com/Azure/Webjobs.Extensions.Kusto/tree/main/samples/samples-outofproc/InputBindingSamples
+// KustoInputBinding sample 
+// Execute queries against the ADX cluster.
+// Add `KustoConnectionString` to the local.settings.json
+public class KustoInputBindingIsolated
 {
-    // Visit https://github.com/Azure/Webjobs.Extensions.Kusto/tree/main/samples/samples-outofproc/InputBindingSamples
-    // KustoInputBinding sample 
-    // Execute queries against the ADX cluster.
-    // Add `KustoConnectionString` to the local.settings.json
-    public class KustoInputBindingIsolated
+    private readonly ILogger _logger;
+
+    public KustoInputBindingIsolated(ILoggerFactory loggerFactory)
     {
-        private readonly ILogger _logger;
+        _logger = loggerFactory.CreateLogger<KustoInputBindingIsolated>();
+    }
 
-        public KustoInputBindingIsolated(ILoggerFactory loggerFactory)
-        {
-            _logger = loggerFactory.CreateLogger<KustoInputBindingIsolated>();
-        }
-
-        [Function("KustoInputBindingIsolated")]
-        public IEnumerable<Object> Run(
-            [HttpTrigger(AuthorizationLevel.Function, "get", Route = null)] HttpRequestData req,
-            [KustoInput(Database: "DB",
-              KqlCommand = "Table", // KQL to execute : declare query_parameters (records:int);Table | take records
-              KqlParameters = "", // Parameters to bind : @records={records}
-              Connection = "KustoConnectionString")] IEnumerable<Object> result)
-        {
-            _logger.LogInformation("C# HTTP trigger with Kusto Input Binding function processed a request.");
-            return result;
-        }
+    [Function("KustoInputBindingIsolated")]
+    public IEnumerable<Object> Run(
+        [HttpTrigger(AuthorizationLevel.Function, "get", Route = null)] HttpRequestData req,
+        [KustoInput(Database: "DB",
+            KqlCommand = "Table", // KQL to execute : declare query_parameters (records:int);Table | take records
+            KqlParameters = "", // Parameters to bind : @records={records}
+            Connection = "KustoConnectionString")] IEnumerable<Object> result)
+    {
+        _logger.LogInformation("C# HTTP trigger with Kusto Input Binding function processed a request.");
+        return result;
     }
 }

--- a/Functions.Templates/Templates/KustoOutputBinding-CSharp-Isolated/KustoOutputBindingIsolated.cs
+++ b/Functions.Templates/Templates/KustoOutputBinding-CSharp-Isolated/KustoOutputBindingIsolated.cs
@@ -5,43 +5,42 @@ using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Azure.Functions.Worker.Extensions.Kusto;
 using Microsoft.Extensions.Logging;
 
-namespace Company.Function
+namespace Company.Function;
+
+public class KustoOutputBindingIsolated
 {
-    public class KustoOutputBindingIsolated
+    private readonly ILogger _logger;
+
+    public KustoOutputBindingIsolated(ILoggerFactory loggerFactory)
     {
-        private readonly ILogger _logger;
-
-        public KustoOutputBindingIsolated(ILoggerFactory loggerFactory)
-        {
-            _logger = loggerFactory.CreateLogger<KustoOutputBindingIsolated>();
-        }
-
-        // Visit https://github.com/Azure/Webjobs.Extensions.Kusto/tree/main/samples/samples-outofproc/OutputBindingSamples 
-        // KustoOutputBinding sample 
-        // Execute queries against the ADX cluster.
-        // Add `KustoConnectionString` to the local.settings.json
-        [Function("KustoOutputBindingIsolated")]
-        [KustoOutput(Database: "DB", // The database to ingest the data into , e.g. functionsdb
-            TableName = "TargetTable", // Table to ingest data into, e.g. Storms
-            Connection = "KustoConnectionString")]
-        public async Task<ToDoItem> Run(
-            [HttpTrigger(AuthorizationLevel.Function, "post", Route = null)] HttpRequestData req)
-        {
-            _logger.LogInformation("C# HTTP trigger with Kusto Output Binding function processed a request.");
-            ToDoItem todoitem = await req.ReadFromJsonAsync<ToDoItem>() ?? new ToDoItem
-                {
-                    Id = "1",
-                    Priority = 1,
-                    Description = "Hello World"
-                };
-            return todoitem;
-        }
+        _logger = loggerFactory.CreateLogger<KustoOutputBindingIsolated>();
     }
 
-    public class ToDoItem
+    // Visit https://github.com/Azure/Webjobs.Extensions.Kusto/tree/main/samples/samples-outofproc/OutputBindingSamples 
+    // KustoOutputBinding sample 
+    // Execute queries against the ADX cluster.
+    // Add `KustoConnectionString` to the local.settings.json
+    [Function("KustoOutputBindingIsolated")]
+    [KustoOutput(Database: "DB", // The database to ingest the data into , e.g. functionsdb
+        TableName = "TargetTable", // Table to ingest data into, e.g. Storms
+        Connection = "KustoConnectionString")]
+    public async Task<ToDoItem> Run(
+        [HttpTrigger(AuthorizationLevel.Function, "post", Route = null)] HttpRequestData req)
     {
-        public string Id { get; set; }
-        public int Priority { get; set; }
-        public string Description { get; set; }
+        _logger.LogInformation("C# HTTP trigger with Kusto Output Binding function processed a request.");
+        ToDoItem todoitem = await req.ReadFromJsonAsync<ToDoItem>() ?? new ToDoItem
+            {
+                Id = "1",
+                Priority = 1,
+                Description = "Hello World"
+            };
+        return todoitem;
     }
+}
+
+public class ToDoItem
+{
+    public string Id { get; set; }
+    public int Priority { get; set; }
+    public string Description { get; set; }
 }

--- a/Functions.Templates/Templates/MySqlInputBinding-CSharp-Isolated/MySqlInputBindingHttpTriggerCSharp.cs
+++ b/Functions.Templates/Templates/MySqlInputBinding-CSharp-Isolated/MySqlInputBindingHttpTriggerCSharp.cs
@@ -5,26 +5,25 @@ using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Azure.Functions.Worker.Extensions.MySql;
 using Microsoft.Extensions.Logging;
 
-namespace Company.Function
+namespace Company.Function;
+
+public class MySqlInputBindingHttpTriggerCSharp
 {
-    public class MySqlInputBindingHttpTriggerCSharp
+    private readonly ILogger _logger;
+
+    public MySqlInputBindingHttpTriggerCSharp(ILoggerFactory loggerFactory)
     {
-        private readonly ILogger _logger;
+        _logger = loggerFactory.CreateLogger<MySqlInputBindingHttpTriggerCSharp>();
+    }
 
-        public MySqlInputBindingHttpTriggerCSharp(ILoggerFactory loggerFactory)
-        {
-            _logger = loggerFactory.CreateLogger<MySqlInputBindingHttpTriggerCSharp>();
-        }
+    [Function("MySqlInputBindingHttpTriggerCSharp")]
+    public IEnumerable<Object> Run(
+        [HttpTrigger(AuthorizationLevel.Function, "get", Route = null)] HttpRequestData req,
+        [MySqlInput("SELECT * FROM object",
+        "MySqlConnectionString")] IEnumerable<Object> result)
+    {
+        _logger.LogInformation("C# HTTP trigger with MySQL Input Binding function processed a request.");
 
-        [Function("MySqlInputBindingHttpTriggerCSharp")]
-        public IEnumerable<Object> Run(
-            [HttpTrigger(AuthorizationLevel.Function, "get", Route = null)] HttpRequestData req,
-            [MySqlInput("SELECT * FROM object",
-            "MySqlConnectionString")] IEnumerable<Object> result)
-        {
-            _logger.LogInformation("C# HTTP trigger with MySQL Input Binding function processed a request.");
-
-            return result;
-        }
+        return result;
     }
 }

--- a/Functions.Templates/Templates/MySqlOutputBinding-CSharp-Isolated/MySqlOutputBindingHttpTriggerCSharp.cs
+++ b/Functions.Templates/Templates/MySqlOutputBinding-CSharp-Isolated/MySqlOutputBindingHttpTriggerCSharp.cs
@@ -5,38 +5,37 @@ using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Azure.Functions.Worker.Extensions.MySql;
 using Microsoft.Extensions.Logging;
 
-namespace Company.Function
+namespace Company.Function;
+
+public class MySqlOutputBindingHttpTriggerCSharp
 {
-    public class MySqlOutputBindingHttpTriggerCSharp
+    private readonly ILogger _logger;
+
+    public MySqlOutputBindingHttpTriggerCSharp(ILoggerFactory loggerFactory)
     {
-        private readonly ILogger _logger;
-
-        public MySqlOutputBindingHttpTriggerCSharp(ILoggerFactory loggerFactory)
-        {
-            _logger = loggerFactory.CreateLogger<MySqlOutputBindingHttpTriggerCSharp>();
-        }
-
-        [Function("MySqlOutputBindingHttpTriggerCSharp")]
-        [MySqlOutput("table", "MySqlConnectionString")]
-        public async Task<ToDoItem> Run(
-            [HttpTrigger(AuthorizationLevel.Function, "post", Route = null)] HttpRequestData req)
-        {
-            _logger.LogInformation("C# HTTP trigger with MySql Output Binding function processed a request.");
-
-            ToDoItem todoitem = await req.ReadFromJsonAsync<ToDoItem>() ?? new ToDoItem
-                {
-                    Id = "1",
-                    Priority = 1,
-                    Description = "Hello World"
-                };
-            return todoitem;
-        }
+        _logger = loggerFactory.CreateLogger<MySqlOutputBindingHttpTriggerCSharp>();
     }
 
-    public class ToDoItem
+    [Function("MySqlOutputBindingHttpTriggerCSharp")]
+    [MySqlOutput("table", "MySqlConnectionString")]
+    public async Task<ToDoItem> Run(
+        [HttpTrigger(AuthorizationLevel.Function, "post", Route = null)] HttpRequestData req)
     {
-        public string Id { get; set; }
-        public int Priority { get; set; }
-        public string Description { get; set; }
+        _logger.LogInformation("C# HTTP trigger with MySql Output Binding function processed a request.");
+
+        ToDoItem todoitem = await req.ReadFromJsonAsync<ToDoItem>() ?? new ToDoItem
+            {
+                Id = "1",
+                Priority = 1,
+                Description = "Hello World"
+            };
+        return todoitem;
     }
+}
+
+public class ToDoItem
+{
+    public string Id { get; set; }
+    public int Priority { get; set; }
+    public string Description { get; set; }
 }

--- a/Functions.Templates/Templates/MySqlTrigger-CSharp-Isolated/MySqlTriggerBindingCSharp.cs
+++ b/Functions.Templates/Templates/MySqlTrigger-CSharp-Isolated/MySqlTriggerBindingCSharp.cs
@@ -5,31 +5,30 @@ using Microsoft.Azure.Functions.Worker.Extensions.MySql;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 
-namespace Company.Function
+namespace Company.Function;
+
+public class MySqlTriggerBindingCSharp
 {
-    public class MySqlTriggerBindingCSharp
+    private readonly ILogger _logger;
+
+    public MySqlTriggerBindingCSharp(ILoggerFactory loggerFactory)
     {
-        private readonly ILogger _logger;
-
-        public MySqlTriggerBindingCSharp(ILoggerFactory loggerFactory)
-        {
-            _logger = loggerFactory.CreateLogger<MySqlTriggerBindingCSharp>();
-        }
-
-        [Function("MySqlTriggerBindingCSharp")]
-        public void Run(
-            [MySqlTrigger("table", "MySqlConnectionString")] IReadOnlyList<MySqlChange<ToDoItem>> changes,
-                FunctionContext context)
-        {
-            _logger.LogInformation("MySql Changes: " + JsonConvert.SerializeObject(changes));
-
-        }
+        _logger = loggerFactory.CreateLogger<MySqlTriggerBindingCSharp>();
     }
 
-    public class ToDoItem
+    [Function("MySqlTriggerBindingCSharp")]
+    public void Run(
+        [MySqlTrigger("table", "MySqlConnectionString")] IReadOnlyList<MySqlChange<ToDoItem>> changes,
+            FunctionContext context)
     {
-        public string Id { get; set; }
-        public int Priority { get; set; }
-        public string Description { get; set; }
+        _logger.LogInformation("MySql Changes: " + JsonConvert.SerializeObject(changes));
+
     }
+}
+
+public class ToDoItem
+{
+    public string Id { get; set; }
+    public int Priority { get; set; }
+    public string Description { get; set; }
 }

--- a/Functions.Templates/Templates/QueueTrigger-CSharp-Isolated/QueueTriggerCSharp.cs
+++ b/Functions.Templates/Templates/QueueTrigger-CSharp-Isolated/QueueTriggerCSharp.cs
@@ -3,21 +3,20 @@ using Azure.Storage.Queues.Models;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 
-namespace Company.Function
+namespace Company.Function;
+
+public class QueueTriggerCSharp
 {
-    public class QueueTriggerCSharp
+    private readonly ILogger<QueueTriggerCSharp> _logger;
+
+    public QueueTriggerCSharp(ILogger<QueueTriggerCSharp> logger)
     {
-        private readonly ILogger<QueueTriggerCSharp> _logger;
+        _logger = logger;
+    }
 
-        public QueueTriggerCSharp(ILogger<QueueTriggerCSharp> logger)
-        {
-            _logger = logger;
-        }
-
-        [Function(nameof(QueueTriggerCSharp))]
-        public void Run([QueueTrigger("PathValue", Connection = "ConnectionValue")] QueueMessage message)
-        {
-            _logger.LogInformation($"C# Queue trigger function processed: {message.MessageText}");
-        }
+    [Function(nameof(QueueTriggerCSharp))]
+    public void Run([QueueTrigger("PathValue", Connection = "ConnectionValue")] QueueMessage message)
+    {
+        _logger.LogInformation($"C# Queue trigger function processed: {message.MessageText}");
     }
 }

--- a/Functions.Templates/Templates/QueueTrigger-CSharp-Isolated/QueueTriggerCSharp.cs
+++ b/Functions.Templates/Templates/QueueTrigger-CSharp-Isolated/QueueTriggerCSharp.cs
@@ -17,6 +17,6 @@ public class QueueTriggerCSharp
     [Function(nameof(QueueTriggerCSharp))]
     public void Run([QueueTrigger("PathValue", Connection = "ConnectionValue")] QueueMessage message)
     {
-        _logger.LogInformation($"C# Queue trigger function processed: {message.MessageText}");
+        _logger.LogInformation("C# Queue trigger function processed: {messageText}", message.MessageText);
     }
 }

--- a/Functions.Templates/Templates/RabbitMQTrigger-CSharp-Isolated/RabbitMQTriggerCSharp.cs
+++ b/Functions.Templates/Templates/RabbitMQTrigger-CSharp-Isolated/RabbitMQTriggerCSharp.cs
@@ -2,21 +2,20 @@ using System;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 
-namespace Company.Function
+namespace Company.Function;
+
+public class RabbitMQTriggerCSharp
 {
-    public class RabbitMQTriggerCSharp
+    private readonly ILogger _logger;
+
+    public RabbitMQTriggerCSharp(ILoggerFactory loggerFactory)
     {
-        private readonly ILogger _logger;
+        _logger = loggerFactory.CreateLogger<RabbitMQTriggerCSharp>();
+    }
 
-        public RabbitMQTriggerCSharp(ILoggerFactory loggerFactory)
-        {
-            _logger = loggerFactory.CreateLogger<RabbitMQTriggerCSharp>();
-        }
-
-        [Function("RabbitMQTriggerCSharp")]
-        public void Run([RabbitMQTrigger("NameOfQueue", ConnectionStringSetting = "ConnectionValue")] string myQueueItem)
-        {
-            _logger.LogInformation($"C# Queue trigger function processed: {myQueueItem}");
-        }
+    [Function("RabbitMQTriggerCSharp")]
+    public void Run([RabbitMQTrigger("NameOfQueue", ConnectionStringSetting = "ConnectionValue")] string myQueueItem)
+    {
+        _logger.LogInformation($"C# Queue trigger function processed: {myQueueItem}");
     }
 }

--- a/Functions.Templates/Templates/RabbitMQTrigger-CSharp-Isolated/RabbitMQTriggerCSharp.cs
+++ b/Functions.Templates/Templates/RabbitMQTrigger-CSharp-Isolated/RabbitMQTriggerCSharp.cs
@@ -16,6 +16,6 @@ public class RabbitMQTriggerCSharp
     [Function("RabbitMQTriggerCSharp")]
     public void Run([RabbitMQTrigger("NameOfQueue", ConnectionStringSetting = "ConnectionValue")] string myQueueItem)
     {
-        _logger.LogInformation($"C# Queue trigger function processed: {myQueueItem}");
+        _logger.LogInformation("C# Queue trigger function processed: {item}", myQueueItem);
     }
 }

--- a/Functions.Templates/Templates/ServiceBusQueueTrigger-CSharp-Isolated/ServiceBusQueueTriggerCSharp.cs
+++ b/Functions.Templates/Templates/ServiceBusQueueTrigger-CSharp-Isolated/ServiceBusQueueTriggerCSharp.cs
@@ -4,29 +4,28 @@ using Azure.Messaging.ServiceBus;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 
-namespace Company.Function
+namespace Company.Function;
+
+public class ServiceBusQueueTriggerCSharp
 {
-    public class ServiceBusQueueTriggerCSharp
+    private readonly ILogger<ServiceBusQueueTriggerCSharp> _logger;
+
+    public ServiceBusQueueTriggerCSharp(ILogger<ServiceBusQueueTriggerCSharp> logger)
     {
-        private readonly ILogger<ServiceBusQueueTriggerCSharp> _logger;
+        _logger = logger;
+    }
 
-        public ServiceBusQueueTriggerCSharp(ILogger<ServiceBusQueueTriggerCSharp> logger)
-        {
-            _logger = logger;
-        }
+    [Function(nameof(ServiceBusQueueTriggerCSharp))]
+    public async Task Run(
+        [ServiceBusTrigger("QueueNameValue", Connection = "ConnectionValue")]
+        ServiceBusReceivedMessage message,
+        ServiceBusMessageActions messageActions)
+    {
+        _logger.LogInformation("Message ID: {id}", message.MessageId);
+        _logger.LogInformation("Message Body: {body}", message.Body);
+        _logger.LogInformation("Message Content-Type: {contentType}", message.ContentType);
 
-        [Function(nameof(ServiceBusQueueTriggerCSharp))]
-        public async Task Run(
-            [ServiceBusTrigger("QueueNameValue", Connection = "ConnectionValue")]
-            ServiceBusReceivedMessage message,
-            ServiceBusMessageActions messageActions)
-        {
-            _logger.LogInformation("Message ID: {id}", message.MessageId);
-            _logger.LogInformation("Message Body: {body}", message.Body);
-            _logger.LogInformation("Message Content-Type: {contentType}", message.ContentType);
-
-            // Complete the message
-            await messageActions.CompleteMessageAsync(message);
-        }
+        // Complete the message
+        await messageActions.CompleteMessageAsync(message);
     }
 }

--- a/Functions.Templates/Templates/ServiceBusTopicTrigger-CSharp-Isolated/ServiceBusTopicTriggerCSharp.cs
+++ b/Functions.Templates/Templates/ServiceBusTopicTrigger-CSharp-Isolated/ServiceBusTopicTriggerCSharp.cs
@@ -4,29 +4,28 @@ using Azure.Messaging.ServiceBus;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 
-namespace Company.Function
+namespace Company.Function;
+
+public class ServiceBusTopicTriggerCSharp
 {
-    public class ServiceBusTopicTriggerCSharp
+    private readonly ILogger<ServiceBusTopicTriggerCSharp> _logger;
+
+    public ServiceBusTopicTriggerCSharp(ILogger<ServiceBusTopicTriggerCSharp> logger)
     {
-        private readonly ILogger<ServiceBusTopicTriggerCSharp> _logger;
+        _logger = logger;
+    }
 
-        public ServiceBusTopicTriggerCSharp(ILogger<ServiceBusTopicTriggerCSharp> logger)
-        {
-            _logger = logger;
-        }
+    [Function(nameof(ServiceBusTopicTriggerCSharp))]
+    public async Task Run(
+        [ServiceBusTrigger("TopicNameValue", "SubscriptionNameValue", Connection = "ConnectionValue")]
+        ServiceBusReceivedMessage message,
+        ServiceBusMessageActions messageActions)
+    {
+        _logger.LogInformation("Message ID: {id}", message.MessageId);
+        _logger.LogInformation("Message Body: {body}", message.Body);
+        _logger.LogInformation("Message Content-Type: {contentType}", message.ContentType);
 
-        [Function(nameof(ServiceBusTopicTriggerCSharp))]
-        public async Task Run(
-            [ServiceBusTrigger("TopicNameValue", "SubscriptionNameValue", Connection = "ConnectionValue")]
-            ServiceBusReceivedMessage message,
-            ServiceBusMessageActions messageActions)
-        {
-            _logger.LogInformation("Message ID: {id}", message.MessageId);
-            _logger.LogInformation("Message Body: {body}", message.Body);
-            _logger.LogInformation("Message Content-Type: {contentType}", message.ContentType);
-
-             // Complete the message
-            await messageActions.CompleteMessageAsync(message);
-        }
+            // Complete the message
+        await messageActions.CompleteMessageAsync(message);
     }
 }

--- a/Functions.Templates/Templates/ServiceBusTopicTrigger-CSharp/ServiceBusTopicTriggerCSharp.cs
+++ b/Functions.Templates/Templates/ServiceBusTopicTrigger-CSharp/ServiceBusTopicTriggerCSharp.cs
@@ -10,7 +10,7 @@ namespace Company.Function
         [FunctionName("ServiceBusTopicTriggerCSharp")]
         public void Run([ServiceBusTrigger("TopicNameValue", "SubscriptionNameValue", Connection = "ConnectionValue")]string mySbMsg, ILogger _logger)
         {
-            _logger.LogInformation($"C# ServiceBus topic trigger function processed message: {mySbMsg}");
+            _logger.LogInformation("C# ServiceBus topic trigger function processed message: {message}", mySbMsg);
         }
     }
 }

--- a/Functions.Templates/Templates/SignalRConnectionInfoHttpTrigger-CSharp-Isolated/SignalRConnectionInfoHttpTriggerCSharp.cs
+++ b/Functions.Templates/Templates/SignalRConnectionInfoHttpTrigger-CSharp-Isolated/SignalRConnectionInfoHttpTriggerCSharp.cs
@@ -4,36 +4,35 @@ using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Extensions.Logging;
 
-namespace Company.Function
+namespace Company.Function;
+
+public class SignalRConnectionInfoHttpTriggerCSharp
 {
-    public class SignalRConnectionInfoHttpTriggerCSharp
+    private readonly ILogger _logger;
+
+    public SignalRConnectionInfoHttpTriggerCSharp(ILoggerFactory loggerFactory)
     {
-        private readonly ILogger _logger;
-
-        public SignalRConnectionInfoHttpTriggerCSharp(ILoggerFactory loggerFactory)
-        {
-            _logger = loggerFactory.CreateLogger("negotiate");
-        }
-
-        [Function("negotiate")]
-        public HttpResponseData Negotiate(
-            [HttpTrigger(AuthorizationLevel.AuthLevelValue, "post")] HttpRequestData req,
-            [SignalRConnectionInfoInput(HubName = "HubValue")] MyConnectionInfo connectionInfo)
-        {
-            _logger.LogInformation($"SignalR Connection URL = '{connectionInfo.Url}'");
-
-            var response = req.CreateResponse(HttpStatusCode.OK);
-            response.Headers.Add("Content-Type", "text/plain; charset=utf-8");
-            response.WriteString($"Connection URL = '{connectionInfo.Url}'");
-            
-            return response;
-        }
+        _logger = loggerFactory.CreateLogger("negotiate");
     }
 
-    public class MyConnectionInfo
+    [Function("negotiate")]
+    public HttpResponseData Negotiate(
+        [HttpTrigger(AuthorizationLevel.AuthLevelValue, "post")] HttpRequestData req,
+        [SignalRConnectionInfoInput(HubName = "HubValue")] MyConnectionInfo connectionInfo)
     {
-        public string Url { get; set; }
+        _logger.LogInformation($"SignalR Connection URL = '{connectionInfo.Url}'");
 
-        public string AccessToken { get; set; }
+        var response = req.CreateResponse(HttpStatusCode.OK);
+        response.Headers.Add("Content-Type", "text/plain; charset=utf-8");
+        response.WriteString($"Connection URL = '{connectionInfo.Url}'");
+        
+        return response;
     }
+}
+
+public class MyConnectionInfo
+{
+    public string Url { get; set; }
+
+    public string AccessToken { get; set; }
 }

--- a/Functions.Templates/Templates/SignalRConnectionInfoHttpTrigger-CSharp-Isolated/SignalRConnectionInfoHttpTriggerCSharp.cs
+++ b/Functions.Templates/Templates/SignalRConnectionInfoHttpTrigger-CSharp-Isolated/SignalRConnectionInfoHttpTriggerCSharp.cs
@@ -20,7 +20,7 @@ public class SignalRConnectionInfoHttpTriggerCSharp
         [HttpTrigger(AuthorizationLevel.AuthLevelValue, "post")] HttpRequestData req,
         [SignalRConnectionInfoInput(HubName = "HubValue")] MyConnectionInfo connectionInfo)
     {
-        _logger.LogInformation($"SignalR Connection URL = '{connectionInfo.Url}'");
+        _logger.LogInformation("SignalR Connection URL = '{url}'", connectionInfo.Url);
 
         var response = req.CreateResponse(HttpStatusCode.OK);
         response.Headers.Add("Content-Type", "text/plain; charset=utf-8");

--- a/Functions.Templates/Templates/SqlInputBinding-CSharp-Isolated/SqlInputBindingHttpTriggerCSharp.cs
+++ b/Functions.Templates/Templates/SqlInputBinding-CSharp-Isolated/SqlInputBindingHttpTriggerCSharp.cs
@@ -5,26 +5,25 @@ using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Azure.Functions.Worker.Extensions.Sql;
 using Microsoft.Extensions.Logging;
 
-namespace Company.Function
+namespace Company.Function;
+
+public class SqlInputBindingHttpTriggerCSharp
 {
-    public class SqlInputBindingHttpTriggerCSharp
+    private readonly ILogger _logger;
+
+    public SqlInputBindingHttpTriggerCSharp(ILoggerFactory loggerFactory)
     {
-        private readonly ILogger _logger;
+        _logger = loggerFactory.CreateLogger<SqlInputBindingHttpTriggerCSharp>();
+    }
 
-        public SqlInputBindingHttpTriggerCSharp(ILoggerFactory loggerFactory)
-        {
-            _logger = loggerFactory.CreateLogger<SqlInputBindingHttpTriggerCSharp>();
-        }
+    [Function("SqlInputBindingHttpTriggerCSharp")]
+    public IEnumerable<Object> Run(
+        [HttpTrigger(AuthorizationLevel.Function, "get", Route = null)] HttpRequestData req,
+        [SqlInput("SELECT * FROM object",
+        "SqlConnectionString")] IEnumerable<Object> result)
+    {
+        _logger.LogInformation("C# HTTP trigger with SQL Input Binding function processed a request.");
 
-        [Function("SqlInputBindingHttpTriggerCSharp")]
-        public IEnumerable<Object> Run(
-            [HttpTrigger(AuthorizationLevel.Function, "get", Route = null)] HttpRequestData req,
-            [SqlInput("SELECT * FROM object",
-            "SqlConnectionString")] IEnumerable<Object> result)
-        {
-            _logger.LogInformation("C# HTTP trigger with SQL Input Binding function processed a request.");
-
-            return result;
-        }
+        return result;
     }
 }

--- a/Functions.Templates/Templates/SqlOutputBinding-CSharp-Isolated/SqlOutputBindingHttpTriggerCSharp.cs
+++ b/Functions.Templates/Templates/SqlOutputBinding-CSharp-Isolated/SqlOutputBindingHttpTriggerCSharp.cs
@@ -5,39 +5,38 @@ using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Azure.Functions.Worker.Extensions.Sql;
 using Microsoft.Extensions.Logging;
 
-namespace Company.Function
+namespace Company.Function;
+
+public class SqlOutputBindingHttpTriggerCSharp
 {
-    public class SqlOutputBindingHttpTriggerCSharp
+    private readonly ILogger _logger;
+
+    public SqlOutputBindingHttpTriggerCSharp(ILoggerFactory loggerFactory)
     {
-        private readonly ILogger _logger;
-
-        public SqlOutputBindingHttpTriggerCSharp(ILoggerFactory loggerFactory)
-        {
-            _logger = loggerFactory.CreateLogger<SqlOutputBindingHttpTriggerCSharp>();
-        }
-
-        // Visit https://aka.ms/sqlbindingsoutput to learn how to use this output binding
-        [Function("SqlOutputBindingHttpTriggerCSharp")]
-        [SqlOutput("table", "SqlConnectionString")]
-        public async Task<ToDoItem> Run(
-            [HttpTrigger(AuthorizationLevel.Function, "post", Route = null)] HttpRequestData req)
-        {
-            _logger.LogInformation("C# HTTP trigger with SQL Output Binding function processed a request.");
-
-            ToDoItem todoitem = await req.ReadFromJsonAsync<ToDoItem>() ?? new ToDoItem
-                {
-                    Id = "1",
-                    Priority = 1,
-                    Description = "Hello World"
-                };
-            return todoitem;
-        }
+        _logger = loggerFactory.CreateLogger<SqlOutputBindingHttpTriggerCSharp>();
     }
 
-    public class ToDoItem
+    // Visit https://aka.ms/sqlbindingsoutput to learn how to use this output binding
+    [Function("SqlOutputBindingHttpTriggerCSharp")]
+    [SqlOutput("table", "SqlConnectionString")]
+    public async Task<ToDoItem> Run(
+        [HttpTrigger(AuthorizationLevel.Function, "post", Route = null)] HttpRequestData req)
     {
-        public string Id { get; set; }
-        public int Priority { get; set; }
-        public string Description { get; set; }
+        _logger.LogInformation("C# HTTP trigger with SQL Output Binding function processed a request.");
+
+        ToDoItem todoitem = await req.ReadFromJsonAsync<ToDoItem>() ?? new ToDoItem
+            {
+                Id = "1",
+                Priority = 1,
+                Description = "Hello World"
+            };
+        return todoitem;
     }
+}
+
+public class ToDoItem
+{
+    public string Id { get; set; }
+    public int Priority { get; set; }
+    public string Description { get; set; }
 }

--- a/Functions.Templates/Templates/SqlTrigger-CSharp-Isolated/SqlTriggerBindingCSharp.cs
+++ b/Functions.Templates/Templates/SqlTrigger-CSharp-Isolated/SqlTriggerBindingCSharp.cs
@@ -5,32 +5,31 @@ using Microsoft.Azure.Functions.Worker.Extensions.Sql;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 
-namespace Company.Function
+namespace Company.Function;
+
+public class SqlTriggerBindingCSharp
 {
-    public class SqlTriggerBindingCSharp
+    private readonly ILogger _logger;
+
+    public SqlTriggerBindingCSharp(ILoggerFactory loggerFactory)
     {
-        private readonly ILogger _logger;
-
-        public SqlTriggerBindingCSharp(ILoggerFactory loggerFactory)
-        {
-            _logger = loggerFactory.CreateLogger<SqlTriggerBindingCSharp>();
-        }
-
-        // Visit https://aka.ms/sqltrigger to learn how to use this trigger binding
-        [Function("SqlTriggerBindingCSharp")]
-        public void Run(
-            [SqlTrigger("table", "SqlConnectionString")] IReadOnlyList<SqlChange<ToDoItem>> changes,
-                FunctionContext context)
-        {
-            _logger.LogInformation("SQL Changes: " + JsonConvert.SerializeObject(changes));
-
-        }
+        _logger = loggerFactory.CreateLogger<SqlTriggerBindingCSharp>();
     }
 
-    public class ToDoItem
+    // Visit https://aka.ms/sqltrigger to learn how to use this trigger binding
+    [Function("SqlTriggerBindingCSharp")]
+    public void Run(
+        [SqlTrigger("table", "SqlConnectionString")] IReadOnlyList<SqlChange<ToDoItem>> changes,
+            FunctionContext context)
     {
-        public string Id { get; set; }
-        public int Priority { get; set; }
-        public string Description { get; set; }
+        _logger.LogInformation("SQL Changes: " + JsonConvert.SerializeObject(changes));
+
     }
+}
+
+public class ToDoItem
+{
+    public string Id { get; set; }
+    public int Priority { get; set; }
+    public string Description { get; set; }
 }

--- a/Functions.Templates/Templates/TimerTrigger-CSharp-Isolated/TimerTriggerCSharp.cs
+++ b/Functions.Templates/Templates/TimerTrigger-CSharp-Isolated/TimerTriggerCSharp.cs
@@ -2,26 +2,25 @@ using System;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 
-namespace Company.Function
+namespace Company.Function;
+
+public class TimerTriggerCSharp
 {
-    public class TimerTriggerCSharp
+    private readonly ILogger _logger;
+
+    public TimerTriggerCSharp(ILoggerFactory loggerFactory)
     {
-        private readonly ILogger _logger;
+        _logger = loggerFactory.CreateLogger<TimerTriggerCSharp>();
+    }
 
-        public TimerTriggerCSharp(ILoggerFactory loggerFactory)
+    [Function("TimerTriggerCSharp")]
+    public void Run([TimerTrigger("ScheduleValue")] TimerInfo myTimer)
+    {
+        _logger.LogInformation($"C# Timer trigger function executed at: {DateTime.Now}");
+        
+        if (myTimer.ScheduleStatus is not null)
         {
-            _logger = loggerFactory.CreateLogger<TimerTriggerCSharp>();
-        }
-
-        [Function("TimerTriggerCSharp")]
-        public void Run([TimerTrigger("ScheduleValue")] TimerInfo myTimer)
-        {
-            _logger.LogInformation($"C# Timer trigger function executed at: {DateTime.Now}");
-            
-            if (myTimer.ScheduleStatus is not null)
-            {
-                _logger.LogInformation($"Next timer schedule at: {myTimer.ScheduleStatus.Next}");
-            }
+            _logger.LogInformation($"Next timer schedule at: {myTimer.ScheduleStatus.Next}");
         }
     }
 }

--- a/Functions.Templates/Templates/TimerTrigger-CSharp-Isolated/TimerTriggerCSharp.cs
+++ b/Functions.Templates/Templates/TimerTrigger-CSharp-Isolated/TimerTriggerCSharp.cs
@@ -16,11 +16,11 @@ public class TimerTriggerCSharp
     [Function("TimerTriggerCSharp")]
     public void Run([TimerTrigger("ScheduleValue")] TimerInfo myTimer)
     {
-        _logger.LogInformation($"C# Timer trigger function executed at: {DateTime.Now}");
+        _logger.LogInformation("C# Timer trigger function executed at: {executionTime}", DateTime.Now);
         
         if (myTimer.ScheduleStatus is not null)
         {
-            _logger.LogInformation($"Next timer schedule at: {myTimer.ScheduleStatus.Next}");
+            _logger.LogInformation("Next timer schedule at: {nextSchedule}", myTimer.ScheduleStatus.Next);
         }
     }
 }


### PR DESCRIPTION
Cleaning up templates by removing some verbosity. Some of the settings in the project template have been unnecessary since the SDK provides many of these behaviors already. Of note, we're also removing the reference to `Microsoft.Azure.Functions.Worker.Extensions.Http` when `Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore` is included, since it's already pulling it in transitively. For the item templates, we're just moving to file-scoped namespaces (which involves removing indentation and is making the diff messy), as that gets rid of a small bit of clutter.