### PR TITLE
Updating Durable version for isolated worker model

### DIFF
--- a/Functions.Templates/Templates/DurableFunctionsOrchestration-CSharp-Isolated/.template.config/template.json
+++ b/Functions.Templates/Templates/DurableFunctionsOrchestration-CSharp-Isolated/.template.config/template.json
@@ -39,7 +39,7 @@
       "args": {
         "referenceType": "package",
         "reference": "Microsoft.Azure.Functions.Worker.Extensions.DurableTask",
-        "version": "1.1.7",
+        "version": "1.2.2",
         "projectFileExtensions": ".csproj"
       }
     },


### PR DESCRIPTION
This is related to https://github.com/dotnet/aspire/issues/6760 but not alone sufficient to fix it.

The Durable Functions item templates currently reference an older version of the Durable Functions extension which is not tolerant of forward proxies. There is a newer version which is, so this PR is just to move to the latest version. With the change, the error reported in the Aspire issue does not manifest.