### PR TITLE
Bump SQL extension to 3.1.490

### DIFF
--- a/Functions.Templates/Bindings/bindings-bundle-v4.json
+++ b/Functions.Templates/Bindings/bindings-bundle-v4.json
@@ -1851,7 +1851,7 @@
       "enabledInTryMode": false,
       "documentation": "$content=Documentation\\sqlIn.md",
       "extension": {
-        "id": "Microsoft.Azure.WebJobs.Extensions.Sql", "version": "3.1.376"
+        "id": "Microsoft.Azure.WebJobs.Extensions.Sql", "version": "3.1.490"
       },
       "settings": [
         {
@@ -1920,7 +1920,7 @@
       "enabledInTryMode": false,
       "documentation": "$content=Documentation\\sqlOut.md",
       "extension": {
-        "id": "Microsoft.Azure.WebJobs.Extensions.Sql", "version": "3.1.376"
+        "id": "Microsoft.Azure.WebJobs.Extensions.Sql", "version": "3.1.490"
       },
       "settings": [
         {
@@ -1963,7 +1963,7 @@
       "enabledInTryMode": true,
       "documentation": "$content=Documentation\\sqlTrigger.md",
       "extension": {
-        "id": "Microsoft.Azure.WebJobs.Extensions.Sql", "version": "3.1.376"
+        "id": "Microsoft.Azure.WebJobs.Extensions.Sql", "version": "3.1.490"
       },
       "settings": [
         {

--- a/Functions.Templates/Templates/SqlInputBinding-CSharp-Isolated/.template.config/template.json
+++ b/Functions.Templates/Templates/SqlInputBinding-CSharp-Isolated/.template.config/template.json
@@ -48,7 +48,7 @@
       "args": {
         "referenceType": "package",
         "reference": "Microsoft.Azure.Functions.Worker.Extensions.Sql",
-        "version": "3.1.376",
+        "version": "3.1.490",
         "projectFileExtensions": ".csproj"
       }
     },

--- a/Functions.Templates/Templates/SqlInputBinding-CSharp/.template.config/template.json
+++ b/Functions.Templates/Templates/SqlInputBinding-CSharp/.template.config/template.json
@@ -47,7 +47,7 @@
           "ManualInstructions": [],
           "args": {
             "referenceType": "package",
-            "reference": "Microsoft.Azure.WebJobs.Extensions.Sql", "version": "3.1.376",
+            "reference": "Microsoft.Azure.WebJobs.Extensions.Sql", "version": "3.1.490",
             "projectFileExtensions": ".csproj"
           }
         },

--- a/Functions.Templates/Templates/SqlOutputBinding-CSharp-Isolated/.template.config/template.json
+++ b/Functions.Templates/Templates/SqlOutputBinding-CSharp-Isolated/.template.config/template.json
@@ -48,7 +48,7 @@
       "args": {
         "referenceType": "package",
         "reference": "Microsoft.Azure.Functions.Worker.Extensions.Sql",
-        "version": "3.1.376",
+        "version": "3.1.490",
         "projectFileExtensions": ".csproj"
       }
     },

--- a/Functions.Templates/Templates/SqlOutputBinding-CSharp/.template.config/template.json
+++ b/Functions.Templates/Templates/SqlOutputBinding-CSharp/.template.config/template.json
@@ -47,7 +47,7 @@
           "ManualInstructions": [],
           "args": {
             "referenceType": "package",
-            "reference": "Microsoft.Azure.WebJobs.Extensions.Sql", "version": "3.1.376",
+            "reference": "Microsoft.Azure.WebJobs.Extensions.Sql", "version": "3.1.490",
             "projectFileExtensions": ".csproj"
           }
         },

--- a/Functions.Templates/Templates/SqlTrigger-CSharp-Isolated/.template.config/template.json
+++ b/Functions.Templates/Templates/SqlTrigger-CSharp-Isolated/.template.config/template.json
@@ -47,7 +47,7 @@
           "ManualInstructions": [],
           "args": {
             "referenceType": "package",
-            "reference": "Microsoft.Azure.Functions.Worker.Extensions.Sql", "version": "3.1.376",
+            "reference": "Microsoft.Azure.Functions.Worker.Extensions.Sql", "version": "3.1.490",
             "projectFileExtensions": ".csproj"
           }
         },

--- a/Functions.Templates/Templates/SqlTrigger-CSharp/.template.config/template.json
+++ b/Functions.Templates/Templates/SqlTrigger-CSharp/.template.config/template.json
@@ -47,7 +47,7 @@
           "ManualInstructions": [],
           "args": {
             "referenceType": "package",
-            "reference": "Microsoft.Azure.WebJobs.Extensions.Sql", "version": "3.1.376",
+            "reference": "Microsoft.Azure.WebJobs.Extensions.Sql", "version": "3.1.490",
             "projectFileExtensions": ".csproj"
           }
         },


### PR DESCRIPTION
This pull request updates the version of the `Microsoft.Azure.WebJobs.Extensions.Sql` and `Microsoft.Azure.Functions.Worker.Extensions.Sql` packages across various files to `3.1.490`. These updates ensure compatibility with the latest features and fixes provided in the updated package versions.

### Updates to `bindings-bundle-v4.json`:

* Updated the `Microsoft.Azure.WebJobs.Extensions.Sql` package version from `3.1.376` to `3.1.490` for SQL bindings (`sqlIn`, `sqlOut`, and `sqlTrigger`). [[1]](diffhunk://#diff-be680cd7f8607f3d523b37dac4e51dfff9f42f158f1023015f68b1a58ee480daL1854-R1854) [[2]](diffhunk://#diff-be680cd7f8607f3d523b37dac4e51dfff9f42f158f1023015f68b1a58ee480daL1923-R1923) [[3]](diffhunk://#diff-be680cd7f8607f3d523b37dac4e51dfff9f42f158f1023015f68b1a58ee480daL1966-R1966)

### Updates to template configuration files:

* Updated the `Microsoft.Azure.Functions.Worker.Extensions.Sql` package version from `3.1.376` to `3.1.490` for C# Isolated templates (`SqlInputBinding-CSharp-Isolated`, `SqlOutputBinding-CSharp-Isolated`, and `SqlTrigger-CSharp-Isolated`). [[1]](diffhunk://#diff-4874b2de152853a0f28409a9fb79fc7958735013cb80ebaaf5090615604e12e9L51-R51) [[2]](diffhunk://#diff-59af687e2052ead20d9b40d1ad24b380a4e258dc608570ff7b96d09697e08a24L51-R51) [[3]](diffhunk://#diff-131f1f91e154e01b03feeceef99ddd27ec96e89c265862975b60e76688905b35L50-R50)
* Updated the `Microsoft.Azure.WebJobs.Extensions.Sql` package version from `3.1.376` to `3.1.490` for C# templates (`SqlInputBinding-CSharp`, `SqlOutputBinding-CSharp`, and `SqlTrigger-CSharp`). [[1]](diffhunk://#diff-e2a0b02551911b8790b6c2c2ed6c39bf4fb4afe885f6fabffda0e0b652b16b73L50-R50) [[2]](diffhunk://#diff-736f4c733b1f7292de6c8608e61f6a583a8e30b315b33d33e7b096cc88912565L50-R50) [[3]](diffhunk://#diff-b69b6c691db7f67382ac71cc1d70f0917e30c924d286e97de27ed41ced6b6bebL50-R50)