### PR TITLE
Add codeowners file to dev

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,8 @@
+# See https://help.github.com/articles/about-codeowners/
+# for more info about CODEOWNERS file
+#
+# It uses the same pattern rule for gitignore file
+# https://git-scm.com/docs/gitignore#_pattern_format
+#
+
+* @azure/azure-functions-extensions-bundle-admins


### PR DESCRIPTION
This pull request adds a `CODEOWNERS` file to the repository to define ownership for all files, assigning them to the `@azure/azure-functions-extensions-bundle-admins` team.

* [`CODEOWNERS`](diffhunk://#diff-fcf14c4b7b34fe7a11916195871ae66a59be87a395f28db73e345ebdc828085bR1-R8): Added a new file to specify ownership rules, assigning all files in the repository to the `@azure/azure-functions-extensions-bundle-admins` team.