### PR TITLE
Add commented out templates for Python SDK-type Bindings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.nupkg
 templates.json
 bin
+.idea
 
 obj
 Publish

--- a/Functions.Templates/Templates-v2/BlobTrigger-Python/function_app.py
+++ b/Functions.Templates/Templates-v2/BlobTrigger-Python/function_app.py
@@ -9,3 +9,16 @@ def $(FUNCTION_NAME_INPUT)(myblob: func.InputStream):
     logging.info(f"Python blob trigger function processed blob"
                 f"Name: {myblob.name}"
                 f"Blob Size: {myblob.length} bytes")
+
+
+# This example uses SDK types to directly access the underlying BlobClient object provided by the Blob storage trigger.
+# To use, uncomment the section below and add azurefunctions-extensions-bindings-blob to your requirements.txt file
+# import azurefunctions.extensions.bindings.blob as blob
+# @app.blob_trigger(arg_name="client", path="samples-workitems/{name}",
+#                   connection="BlobStorageConnection")
+# def blob_sdk_trigger(client: blob.BlobClient):
+#     logging.info(
+#         f"Python blob trigger function processed blob \n"
+#         f"Properties: {client.get_blob_properties()}\n"
+#         f"Blob content head: {client.download_blob().read(size=1)}"
+#     )

--- a/Functions.Templates/Templates-v2/BlobTrigger-Python/function_app.py
+++ b/Functions.Templates/Templates-v2/BlobTrigger-Python/function_app.py
@@ -14,9 +14,9 @@ def $(FUNCTION_NAME_INPUT)(myblob: func.InputStream):
 # This example uses SDK types to directly access the underlying BlobClient object provided by the Blob storage trigger.
 # To use, uncomment the section below and add azurefunctions-extensions-bindings-blob to your requirements.txt file
 # import azurefunctions.extensions.bindings.blob as blob
-# @app.blob_trigger(arg_name="client", path="samples-workitems/{name}",
-#                   connection="BlobStorageConnection")
-# def blob_sdk_trigger(client: blob.BlobClient):
+# @app.blob_trigger(arg_name="client", path="$(PATH_TO_BLOB_INPUT)",
+#                   connection="$(CONNECTION_STRING_INPUT)")
+# def $(FUNCTION_NAME_INPUT)(client: blob.BlobClient):
 #     logging.info(
 #         f"Python blob trigger function processed blob \n"
 #         f"Properties: {client.get_blob_properties()}\n"

--- a/Functions.Templates/Templates-v2/BlobTrigger-Python/function_body.py
+++ b/Functions.Templates/Templates-v2/BlobTrigger-Python/function_body.py
@@ -5,3 +5,16 @@ def $(FUNCTION_NAME_INPUT)(myblob: func.InputStream):
     logging.info(f"Python blob trigger function processed blob"
                 f"Name: {myblob.name}"
                 f"Blob Size: {myblob.length} bytes")
+
+
+# This example uses SDK types to directly access the underlying BlobClient object provided by the Blob storage trigger.
+# To use, uncomment the section below and add azurefunctions-extensions-bindings-blob to your requirements.txt file
+# import azurefunctions.extensions.bindings.blob as blob
+# @app.blob_trigger(arg_name="client", path="$(PATH_TO_BLOB_INPUT)",
+#                   connection="$(CONNECTION_STRING_INPUT)")
+# def $(FUNCTION_NAME_INPUT)(client: blob.BlobClient):
+#     logging.info(
+#         f"Python blob trigger function processed blob \n"
+#         f"Properties: {client.get_blob_properties()}\n"
+#         f"Blob content head: {client.download_blob().read(size=1)}"
+#     )

--- a/Functions.Templates/Templates-v2/CosmosDbTrigger-Python/cosmosdb_trigger_template.md
+++ b/Functions.Templates/Templates-v2/CosmosDbTrigger-Python/cosmosdb_trigger_template.md
@@ -6,7 +6,7 @@ The Azure Cosmos DB Trigger uses the Azure Cosmos DB Change Feed to listen for i
 
 ## Using the Template
 
-Following is an example code snippet for Cosmos DB Trigger using the [Python programming model V2](https://aka.ms/pythonprogrammingmodel) (currently in Preview).
+Following is an example code snippet for Cosmos DB Trigger using the [Python programming model V2](https://aka.ms/pythonprogrammingmodel).
 
 ```python
 import logging

--- a/Functions.Templates/Templates-v2/DaprPublishOutputBinding-Python/dapr-publish-output_binding_template.md
+++ b/Functions.Templates/Templates-v2/DaprPublishOutputBinding-Python/dapr-publish-output_binding_template.md
@@ -6,7 +6,7 @@ With Dapr output binding, you can invoke external resources. An optional payload
 
 ## Using the Template
 
-Following is an example code snippet for Dapr Service Invocation Trigger using the [Python programming model V2](https://aka.ms/pythonprogrammingmodel) (currently in Preview).
+Following is an example code snippet for Dapr Service Invocation Trigger using the [Python programming model V2](https://aka.ms/pythonprogrammingmodel).
 
 ```python
 import datetime

--- a/Functions.Templates/Templates-v2/DaprServiceInvocationTrigger-Python/dapr_service_invocation_trigger_template.md
+++ b/Functions.Templates/Templates-v2/DaprServiceInvocationTrigger-Python/dapr_service_invocation_trigger_template.md
@@ -6,7 +6,7 @@ Using service invocation, your application can reliably and securely communicate
 
 ## Using the Template
 
-Following is an example code snippet for Dapr Service Invocation Trigger using the [Python programming model V2](https://aka.ms/pythonprogrammingmodel) (currently in Preview).
+Following is an example code snippet for Dapr Service Invocation Trigger using the [Python programming model V2](https://aka.ms/pythonprogrammingmodel).
 
 ```python
 import json

--- a/Functions.Templates/Templates-v2/DaprTopicTrigger-Python/dapr-topic_trigger_template.md
+++ b/Functions.Templates/Templates-v2/DaprTopicTrigger-Python/dapr-topic_trigger_template.md
@@ -6,7 +6,7 @@ Using `Dapr Topic Trigger`, your azure functions can react to a message publishe
 
 ## Using the Template
 
-Following is an example code snippet for Dapr Topic Trigger using the [Python programming model V2](https://aka.ms/pythonprogrammingmodel) (currently in Preview).
+Following is an example code snippet for Dapr Topic Trigger using the [Python programming model V2](https://aka.ms/pythonprogrammingmodel).
 
 ```python
 import json

--- a/Functions.Templates/Templates-v2/EventGridBlobTrigger-Python/eventgrid_blob_trigger_template.md
+++ b/Functions.Templates/Templates-v2/EventGridBlobTrigger-Python/eventgrid_blob_trigger_template.md
@@ -1,12 +1,13 @@
-# Azure Functions: Blob Trigger in Python
+# Azure Functions: Blob Trigger (using Event Grid) in Python
 
-## Blob Trigger
+## Blob Trigger (using Event Grid)
 
-The Blob storage trigger starts a function when a new or updated blob is detected. The blob contents are provided as input to the function. The Azure Blob storage trigger requires a general-purpose storage account. Storage V2 accounts with hierarchical namespaces are also supported.
+The Blob storage trigger starts a function when a new or updated blob is detected. The blob contents are provided as input to the function. 
+Starting with extension version 5.x+, you can use an Event Grid event subscription on the container, which reduces latency. The Azure Blob storage trigger requires a general-purpose storage account. Storage V2 accounts with hierarchical namespaces are also supported.
 
 ## Using the Template
 
-Following is an example code snippet for Blob Trigger using the [Python programming model V2](https://aka.ms/pythonprogrammingmodel).
+Following is an example code snippet for Blob Trigger (using Event Grid) using the [Python programming model V2](https://aka.ms/pythonprogrammingmodel).
 
 ```python
 import logging
@@ -16,30 +17,11 @@ app = func.FunctionApp()
 
 @app.function_name(name="BlobTrigger1")
 @app.blob_trigger(arg_name="myblob", path="samples-workitems/{name}",
-                  connection="BlobStorageConnection")
+                  source="EventGrid", connection="BlobStorageConnection")
 def test_function(myblob: func.InputStream):
-   logging.info("Python blob trigger function processed blob \n"
+   logging.info("Python blob trigger (using Event Grid) function processed blob \n"
                 f"Name: {myblob.name}\n"
                 f"Blob Size: {myblob.length} bytes")
-```
-
-This example uses SDK types to directly access the underlying BlobClient object provided by the Blob storage trigger:
-
-```python
-import logging
-import azure.functions as func
-import azurefunctions.extensions.bindings.blob as blob
-
-app = func.FunctionApp(http_auth_level=func.AuthLevel.FUNCTION)
-
-@app.blob_trigger(arg_name="client", path="samples-workitems/{name}",
-                  connection="BlobStorageConnection")
-def blob_trigger(client: blob.BlobClient):
-    logging.info(
-        f"Python blob trigger function processed blob \n"
-        f"Properties: {client.get_blob_properties()}\n"
-        f"Blob content head: {client.download_blob().read(size=1)}"
-    )
 ```
 
 To run the code snippet generated through the command palette, note the following:
@@ -47,9 +29,9 @@ To run the code snippet generated through the command palette, note the followin
 - The function application is defined and named `app`.
 - Confirm that the parameters within the trigger reflect values that correspond with your storage account.
 - The name of the file must be `function_app.py`.
-- If you are using SDK-Type Bindings, make sure to include `azurefunctions-extensions-bindings-blob` in your `requirements.txt` file.
   
 Note that Blob input and output bindings are also supported in Azure Functions. To learn more, see [Azure Blob storage bindings overview](https://aka.ms/azure-function-binding-storage-blob).
+To learn more about Blob Triggers using Event Grid, see the [Trigger Azure Functions on blob containers using an event subscription Tutorial](https://learn.microsoft.com/en-us/azure/azure-functions/functions-event-grid-blob-trigger?pivots=programming-language-python)
 
 ## Programming Model V2
 

--- a/Functions.Templates/Templates-v2/EventGridBlobTrigger-Python/template.json
+++ b/Functions.Templates/Templates-v2/EventGridBlobTrigger-Python/template.json
@@ -201,7 +201,7 @@
         {
             "name": "ShowMarkdownPreview",
             "type": "ShowMarkdownPreview",
-            "filePath" : "blob_trigger_template.md"
+            "filePath" : "eventgrid_blob_trigger_template.md"
         },
         {
             "name": "readFileContent_BlueprintFile",

--- a/Functions.Templates/Templates-v2/EventGridTrigger-Python/eventgrid_trigger_template.md
+++ b/Functions.Templates/Templates-v2/EventGridTrigger-Python/eventgrid_trigger_template.md
@@ -5,7 +5,7 @@
 The Event Grid function trigger can be used to respond to an event sent by an Event Grid source. You must have an event subscription to the source to receive events. When the function is triggered, it converts the event data into a JSON string which is then logged using the Python logging module.
 
 ## Using the Template
-Following is an example code snippet for Event Grid Trigger using the Python programming model V2 (currently in Preview).
+Following is an example code snippet for Event Grid Trigger using the [Python programming model V2](https://aka.ms/pythonprogrammingmodel).
 ```python
 import azure.functions as func
 import logging

--- a/Functions.Templates/Templates-v2/EventHubTrigger-Python/eventhub_trigger_template.md
+++ b/Functions.Templates/Templates-v2/EventHubTrigger-Python/eventhub_trigger_template.md
@@ -6,7 +6,7 @@ The Event Hub function trigger can be used to respond to an event sent to an eve
 
 ## Using the Template
 
-Following is an example code snippet for Event Hub Trigger using the [Python programming model V2](https://aka.ms/pythonprogrammingmodel) (currently in Preview).
+Following is an example code snippet for Event Hub Trigger using the [Python programming model V2](https://aka.ms/pythonprogrammingmodel).
 
 ```python
 import logging
@@ -22,11 +22,31 @@ def test_function(myhub: func.EventHubEvent):
                 myhub.get_body().decode('utf-8'))
 ```
 
+This example uses SDK types to directly access the underlying EventData object provided by the Event Hubs trigger (currently in Preview):
+
+```python
+import logging
+import azure.functions as func
+import azurefunctions.extensions.bindings.eventhub as eh
+
+app = func.FunctionApp(http_auth_level=func.AuthLevel.FUNCTION)
+
+@app.event_hub_message_trigger(
+    arg_name="event", event_hub_name="EVENTHUB_NAME", connection="EventHubConnection"
+)
+def eventhub_trigger(event: eh.EventData):
+    logging.info(
+        "Python EventHub trigger processed an event %s",
+        event.body_as_str()
+    )
+```
+
 To run the code snippet generated through the command palette, note the following:
 
 - The function application is defined and named `app`.
 - Confirm that the parameters within the trigger reflect values that correspond with your storage account.
 - The name of the file must be `function_app.py`.
+- If you are using SDK-Type Bindings, make sure to include `azurefunctions-extensions-bindings-eventhub` in your `requirements.txt` file.
   
 Note that Event Hub output bindings are also supported in Azure Functions. To learn more, see [Azure Event Hubs trigger and bindings for Azure Functions](https://aka.ms/azure-function-binding-event-hubs)
 

--- a/Functions.Templates/Templates-v2/EventHubTrigger-Python/function_app.py
+++ b/Functions.Templates/Templates-v2/EventHubTrigger-Python/function_app.py
@@ -14,9 +14,9 @@ def $(FUNCTION_NAME_INPUT)(azeventhub: func.EventHubEvent):
 # To use, uncomment the section below and add azurefunctions-extensions-bindings-eventhub to your requirements.txt file
 # import azurefunctions.extensions.bindings.eventhub as eh
 # @app.event_hub_message_trigger(
-#     arg_name="event", event_hub_name="EVENTHUB_NAME", connection="EventHubConnection"
+#     arg_name="event", event_hub_name="$(EVENTHUB_NAME_INPUT)", connection="$(CONNECTION_STRING_INPUT)"
 # )
-# def eventhub_trigger(event: eh.EventData):
+# def $(FUNCTION_NAME_INPUT)(event: eh.EventData):
 #     logging.info(
 #         "Python EventHub trigger processed an event %s",
 #         event.body_as_str()

--- a/Functions.Templates/Templates-v2/EventHubTrigger-Python/function_app.py
+++ b/Functions.Templates/Templates-v2/EventHubTrigger-Python/function_app.py
@@ -8,3 +8,16 @@ app = func.FunctionApp()
 def $(FUNCTION_NAME_INPUT)(azeventhub: func.EventHubEvent):
     logging.info('Python EventHub trigger processed an event: %s',
                 azeventhub.get_body().decode('utf-8'))
+
+
+# This example uses SDK types to directly access the underlying EventData object provided by the Event Hubs trigger.
+# To use, uncomment the section below and add azurefunctions-extensions-bindings-eventhub to your requirements.txt file
+# import azurefunctions.extensions.bindings.eventhub as eh
+# @app.event_hub_message_trigger(
+#     arg_name="event", event_hub_name="EVENTHUB_NAME", connection="EventHubConnection"
+# )
+# def eventhub_trigger(event: eh.EventData):
+#     logging.info(
+#         "Python EventHub trigger processed an event %s",
+#         event.body_as_str()
+#     )

--- a/Functions.Templates/Templates-v2/EventHubTrigger-Python/function_body.py
+++ b/Functions.Templates/Templates-v2/EventHubTrigger-Python/function_body.py
@@ -4,3 +4,16 @@
 def $(FUNCTION_NAME_INPUT)(azeventhub: func.EventHubEvent):
     logging.info('Python EventHub trigger processed an event: %s',
                 azeventhub.get_body().decode('utf-8'))
+
+
+# This example uses SDK types to directly access the underlying EventData object provided by the Event Hubs trigger.
+# To use, uncomment the section below and add azurefunctions-extensions-bindings-eventhub to your requirements.txt file
+# import azurefunctions.extensions.bindings.eventhub as eh
+# @app.event_hub_message_trigger(
+#     arg_name="event", event_hub_name="$(EVENTHUB_NAME_INPUT)", connection="$(CONNECTION_STRING_INPUT)"
+# )
+# def $(FUNCTION_NAME_INPUT)(event: eh.EventData):
+#     logging.info(
+#         "Python EventHub trigger processed an event %s",
+#         event.body_as_str()
+#     )

--- a/Functions.Templates/Templates-v2/HttpTrigger-Python/http_trigger_template.md
+++ b/Functions.Templates/Templates-v2/HttpTrigger-Python/http_trigger_template.md
@@ -6,7 +6,7 @@ The HTTP trigger lets you invoke a function with an HTTP request. You can use an
 
 ## Using the Template
 
-Following is an example code snippet for HTTP Trigger using the [Python programming model V2](https://aka.ms/pythonprogrammingmodel) (currently in Preview).
+Following is an example code snippet for HTTP Trigger using the [Python programming model V2](https://aka.ms/pythonprogrammingmodel).
 
 ```python
 import azure.functions as func

--- a/Functions.Templates/Templates-v2/QueueTrigger-Python/queue_trigger_template.md
+++ b/Functions.Templates/Templates-v2/QueueTrigger-Python/queue_trigger_template.md
@@ -6,7 +6,7 @@ The queue storage trigger runs a function as messages are added to Azure Queue s
 
 ## Using the Template
 
-Following is an example code snippet for Queue Trigger using the [Python programming model V2](https://aka.ms/pythonprogrammingmodel) (currently in Preview).
+Following is an example code snippet for Queue Trigger using the [Python programming model V2](https://aka.ms/pythonprogrammingmodel)).
 
 ```python
 import logging

--- a/Functions.Templates/Templates-v2/QueueTrigger-Python/queue_trigger_template.md
+++ b/Functions.Templates/Templates-v2/QueueTrigger-Python/queue_trigger_template.md
@@ -6,7 +6,7 @@ The queue storage trigger runs a function as messages are added to Azure Queue s
 
 ## Using the Template
 
-Following is an example code snippet for Queue Trigger using the [Python programming model V2](https://aka.ms/pythonprogrammingmodel)).
+Following is an example code snippet for Queue Trigger using the [Python programming model V2](https://aka.ms/pythonprogrammingmodel).
 
 ```python
 import logging

--- a/Functions.Templates/Templates-v2/ServiceBusQueueTrigger-Python/function_app.py
+++ b/Functions.Templates/Templates-v2/ServiceBusQueueTrigger-Python/function_app.py
@@ -8,3 +8,17 @@ app = func.FunctionApp()
 def $(FUNCTION_NAME_INPUT)(azservicebus: func.ServiceBusMessage):
     logging.info('Python ServiceBus Queue trigger processed a message: %s',
                 azservicebus.get_body().decode('utf-8'))
+
+
+# This example uses SDK types to directly access the underlying ServiceBusReceivedMessage object provided by the Service Bus trigger.
+# To use, uncomment the section below and add azurefunctions-extensions-bindings-servicebus to your requirements.txt file
+# import azurefunctions.extensions.bindings.servicebus as servicebus
+# @app.service_bus_queue_trigger(arg_name="receivedmessage",
+#                                queue_name="QUEUE_NAME",
+#                                connection="SERVICEBUS_CONNECTION")
+# def servicebus_queue_trigger(receivedmessage: servicebus.ServiceBusReceivedMessage):
+#     logging.info("Python ServiceBus queue trigger processed message.")
+#     logging.info("Receiving: %s\n"
+#                  "Body: %s\n",
+#                  receivedmessage,
+#                  receivedmessage.body)

--- a/Functions.Templates/Templates-v2/ServiceBusQueueTrigger-Python/function_app.py
+++ b/Functions.Templates/Templates-v2/ServiceBusQueueTrigger-Python/function_app.py
@@ -14,9 +14,9 @@ def $(FUNCTION_NAME_INPUT)(azservicebus: func.ServiceBusMessage):
 # To use, uncomment the section below and add azurefunctions-extensions-bindings-servicebus to your requirements.txt file
 # import azurefunctions.extensions.bindings.servicebus as servicebus
 # @app.service_bus_queue_trigger(arg_name="receivedmessage",
-#                                queue_name="QUEUE_NAME",
-#                                connection="SERVICEBUS_CONNECTION")
-# def servicebus_queue_trigger(receivedmessage: servicebus.ServiceBusReceivedMessage):
+#                                queue_name="$(SERVICEBUS_NAME_INPUT)",
+#                                connection="$(CONNECTION_STRING_INPUT)")
+# def $(FUNCTION_NAME_INPUT)(receivedmessage: servicebus.ServiceBusReceivedMessage):
 #     logging.info("Python ServiceBus queue trigger processed message.")
 #     logging.info("Receiving: %s\n"
 #                  "Body: %s\n",

--- a/Functions.Templates/Templates-v2/ServiceBusQueueTrigger-Python/function_body.py
+++ b/Functions.Templates/Templates-v2/ServiceBusQueueTrigger-Python/function_body.py
@@ -4,3 +4,17 @@
 def $(FUNCTION_NAME_INPUT)(azservicebus: func.ServiceBusMessage):
     logging.info('Python ServiceBus Queue trigger processed a message: %s',
                 azservicebus.get_body().decode('utf-8'))
+
+
+# This example uses SDK types to directly access the underlying ServiceBusReceivedMessage object provided by the Service Bus trigger.
+# To use, uncomment the section below and add azurefunctions-extensions-bindings-servicebus to your requirements.txt file
+# import azurefunctions.extensions.bindings.servicebus as servicebus
+# @app.service_bus_queue_trigger(arg_name="receivedmessage",
+#                                queue_name="$(SERVICEBUS_NAME_INPUT)",
+#                                connection="$(CONNECTION_STRING_INPUT)")
+# def $(FUNCTION_NAME_INPUT)(receivedmessage: servicebus.ServiceBusReceivedMessage):
+#     logging.info("Python ServiceBus queue trigger processed message.")
+#     logging.info("Receiving: %s\n"
+#                  "Body: %s\n",
+#                  receivedmessage,
+#                  receivedmessage.body)

--- a/Functions.Templates/Templates-v2/ServiceBusQueueTrigger-Python/servicebusqueue_trigger_template.md
+++ b/Functions.Templates/Templates-v2/ServiceBusQueueTrigger-Python/servicebusqueue_trigger_template.md
@@ -6,7 +6,7 @@ Use the Service Bus Queue trigger to respond to messages from a Service Bus queu
 
 ## Using the Template
 
-Following is an example code snippet for Service Bus Queue Trigger using the [Python programming model V2](https://aka.ms/pythonprogrammingmodel) (currently in Preview).
+Following is an example code snippet for Service Bus Queue Trigger using the [Python programming model V2](https://aka.ms/pythonprogrammingmodel).
 
 ```python
 import logging
@@ -21,11 +21,28 @@ def test_function(msg: func.ServiceBusMessage):
                  msg.get_body().decode('utf-8'))
 ```
 
+This example uses SDK types to directly access the underlying ServiceBusReceivedMessage object provided by the Service Bus trigger (currently in Preview):
+
+```python
+import azurefunctions.extensions.bindings.servicebus as servicebus
+
+@app.service_bus_queue_trigger(arg_name="receivedmessage",
+                               queue_name="QUEUE_NAME",
+                               connection="SERVICEBUS_CONNECTION")
+def servicebus_queue_trigger(receivedmessage: servicebus.ServiceBusReceivedMessage):
+    logging.info("Python ServiceBus queue trigger processed message.")
+    logging.info("Receiving: %s\n"
+                 "Body: %s\n",
+                 receivedmessage,
+                 receivedmessage.body)
+```
+
 To run the code snippet generated through the command palette, note the following:
 
 - The function application is defined and named `app`.
 - Confirm that the parameters within the trigger reflect values that correspond with your storage account.
 - The name of the file must be `function_app.py`.
+- If you are using SDK-Type Bindings, make sure to include `azurefunctions-extensions-bindings-servicebus` in your `requirements.txt` file.
   
 Note that Service Bus output bindings are also supported in Azure Functions. To learn more, see [Azure Service Bus bindings for Azure Functions](https://aka.ms/azure-function-binding-service-bus)
 

--- a/Functions.Templates/Templates-v2/ServiceBusTopicTrigger-Python/function_app.py
+++ b/Functions.Templates/Templates-v2/ServiceBusTopicTrigger-Python/function_app.py
@@ -14,10 +14,10 @@ def $(FUNCTION_NAME_INPUT)(azservicebus: func.ServiceBusMessage):
 # To use, uncomment the section below and add azurefunctions-extensions-bindings-servicebus to your requirements.txt file
 # import azurefunctions.extensions.bindings.servicebus as servicebus
 # @app.service_bus_topic_trigger(arg_name="receivedmessage",
-#                                topic_name="TOPIC_NAME",
-#                                connection="SERVICEBUS_CONNECTION",
-#                                subscription_name="SUBSCRIPTION_NAME")
-# def servicebus_topic_trigger(receivedmessage: servicebus.ServiceBusReceivedMessage):
+#                                topic_name="$(SERVICEBUS_NAME_INPUT)",
+#                                connection="$(CONNECTION_STRING_INPUT)",
+#                                subscription_name="$(SERVICEBUS_SUBSCRIPTION_NAME_INPUT)")
+# def $(FUNCTION_NAME_INPUT)(receivedmessage: servicebus.ServiceBusReceivedMessage):
 #     logging.info("Python ServiceBus topic trigger processed message.")
 #     logging.info("Receiving: %s\n"
 #                  "Body: %s\n",

--- a/Functions.Templates/Templates-v2/ServiceBusTopicTrigger-Python/function_app.py
+++ b/Functions.Templates/Templates-v2/ServiceBusTopicTrigger-Python/function_app.py
@@ -8,3 +8,18 @@ app = func.FunctionApp()
 def $(FUNCTION_NAME_INPUT)(azservicebus: func.ServiceBusMessage):
     logging.info('Python ServiceBus Topic trigger processed a message: %s',
                 azservicebus.get_body().decode('utf-8'))
+
+
+# This example uses SDK types to directly access the underlying ServiceBusReceivedMessage object provided by the Service Bus trigger.
+# To use, uncomment the section below and add azurefunctions-extensions-bindings-servicebus to your requirements.txt file
+# import azurefunctions.extensions.bindings.servicebus as servicebus
+# @app.service_bus_topic_trigger(arg_name="receivedmessage",
+#                                topic_name="TOPIC_NAME",
+#                                connection="SERVICEBUS_CONNECTION",
+#                                subscription_name="SUBSCRIPTION_NAME")
+# def servicebus_topic_trigger(receivedmessage: servicebus.ServiceBusReceivedMessage):
+#     logging.info("Python ServiceBus topic trigger processed message.")
+#     logging.info("Receiving: %s\n"
+#                  "Body: %s\n",
+#                  receivedmessage,
+#                  receivedmessage.body)

--- a/Functions.Templates/Templates-v2/ServiceBusTopicTrigger-Python/function_body.py
+++ b/Functions.Templates/Templates-v2/ServiceBusTopicTrigger-Python/function_body.py
@@ -4,3 +4,18 @@
 def $(FUNCTION_NAME_INPUT)(azservicebus: func.ServiceBusMessage):
     logging.info('Python ServiceBus Topic trigger processed a message: %s',
                 azservicebus.get_body().decode('utf-8'))
+
+
+# This example uses SDK types to directly access the underlying ServiceBusReceivedMessage object provided by the Service Bus trigger.
+# To use, uncomment the section below and add azurefunctions-extensions-bindings-servicebus to your requirements.txt file
+# import azurefunctions.extensions.bindings.servicebus as servicebus
+# @app.service_bus_topic_trigger(arg_name="receivedmessage",
+#                                topic_name="$(SERVICEBUS_NAME_INPUT)",
+#                                connection="$(CONNECTION_STRING_INPUT)",
+#                                subscription_name="$(SERVICEBUS_SUBSCRIPTION_NAME_INPUT)")
+# def $(FUNCTION_NAME_INPUT)(receivedmessage: servicebus.ServiceBusReceivedMessage):
+#     logging.info("Python ServiceBus topic trigger processed message.")
+#     logging.info("Receiving: %s\n"
+#                  "Body: %s\n",
+#                  receivedmessage,
+#                  receivedmessage.body)

--- a/Functions.Templates/Templates-v2/ServiceBusTopicTrigger-Python/servicebustopic_trigger_template.md
+++ b/Functions.Templates/Templates-v2/ServiceBusTopicTrigger-Python/servicebustopic_trigger_template.md
@@ -6,7 +6,7 @@ Use the Service Bus Queue trigger to respond to messages from a Service Bus topi
 
 ## Using the Template
 
-Following is an example code snippet for Service Bus Topic Trigger using the [Python programming model V2](https://aka.ms/pythonprogrammingmodel) (currently in Preview).
+Following is an example code snippet for Service Bus Topic Trigger using the [Python programming model V2](https://aka.ms/pythonprogrammingmodel).
 
 ```python
 import logging
@@ -22,11 +22,33 @@ def test_function(message: func.ServiceBusMessage):
     logging.info("Message Body: " + message_body)
 ```
 
+This example uses SDK types to directly access the underlying ServiceBusReceivedMessage object provided by the Service Bus trigger (currently in Preview):
+
+```python
+import logging
+import azure.functions as func
+import azurefunctions.extensions.bindings.servicebus as servicebus
+
+app = func.FunctionApp(http_auth_level=func.AuthLevel.FUNCTION)
+
+@app.service_bus_topic_trigger(arg_name="receivedmessage",
+                               topic_name="TOPIC_NAME",
+                               connection="SERVICEBUS_CONNECTION",
+                               subscription_name="SUBSCRIPTION_NAME")
+def servicebus_topic_trigger(receivedmessage: servicebus.ServiceBusReceivedMessage):
+    logging.info("Python ServiceBus topic trigger processed message.")
+    logging.info("Receiving: %s\n"
+                 "Body: %s\n",
+                 receivedmessage,
+                 receivedmessage.body)
+```
+
 To run the code snippet generated through the command palette, note the following:
 
 - The function application is defined and named `app`.
 - Confirm that the parameters within the trigger reflect values that correspond with your storage account.
 - The name of the file must be `function_app.py`.
+- If you are using SDK-Type Bindings, make sure to include `azurefunctions-extensions-bindings-servicebus` in your `requirements.txt` file.
   
 Note that Service Bus output bindings are also supported in Azure Functions. To learn more, see [Azure Service Bus bindings for Azure Functions](https://aka.ms/azure-function-binding-service-bus)
 

--- a/Functions.Templates/Templates-v2/TimerTrigger-Python/timer_trigger_template.md
+++ b/Functions.Templates/Templates-v2/TimerTrigger-Python/timer_trigger_template.md
@@ -6,7 +6,7 @@ A timer trigger lets you run a function on a schedule.
 
 ## Using the Template
 
-Following is an example code snippet for Timer Trigger using the [Python programming model V2](https://aka.ms/pythonprogrammingmodel) (currently in Preview).
+Following is an example code snippet for Timer Trigger using the [Python programming model V2](https://aka.ms/pythonprogrammingmodel).
 
 ```python
 import datetime


### PR DESCRIPTION
- Adds sample code snippet using SDK Bindings for Blob, Event Hub, and Service Bus in the template readme
- Adds commented out code snippet using SDK Bindings for Blob, Event Hub, and Service Bus in main function_app.py file only
- Adds template readme for blob trigger using Event Grid
- Removes the preview tag for V2 programming model
- Updates .gitignore for .idea

Changes:
Blob Trigger:
![image](https://github.com/user-attachments/assets/fb33c3d6-b211-4130-804e-0f1bb3a959a1)

Event Hub Trigger:
![image](https://github.com/user-attachments/assets/0d264c37-7784-45ca-b57e-07ceb992aac5)

Service Bus Topic Trigger:
![image](https://github.com/user-attachments/assets/f99c9987-1d51-42d0-bda9-0b8ba2a6a96d)

Service Bus Queue Trigger:
![image](https://github.com/user-attachments/assets/5f945ec6-c127-4d64-a610-695b9987750e)

