### PR TITLE
Add CodeQL.yml to try and suppress the scan

### DIFF
--- a/CodeQL.yml
+++ b/CodeQL.yml
@@ -1,0 +1,5 @@
+path_classifiers:
+  # While not 'generated' in the traditional sense, these files are templates and will be 'generated'
+  # at template creation time for the customer.
+  generated:
+    - Functions.Templates/**


### PR DESCRIPTION
CodeQL is currently expecting a C# report since it sees `.cs` files. Given these are templates, there are never actually built. Adding this suppression file to see if it will prevent CodeQL from expecting the report.