### PR TITLE
Bump Durable extension versions to 3.3.1/1.6.1

### DIFF
--- a/Functions.Templates/Bindings/bindings-bundle-v4.json
+++ b/Functions.Templates/Bindings/bindings-bundle-v4.json
@@ -1385,7 +1385,7 @@
       "enabledInTryMode": false,
       "documentation": "$content=Documentation\\activityTrigger.md",
       "extension": {
-        "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "3.3.0"
+        "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "3.3.1"
       },
       "settings": [
         {
@@ -1418,7 +1418,7 @@
       "enabledInTryMode": false,
       "documentation": "$content=Documentation\\orchestrationTrigger.md",
       "extension": {
-        "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "3.3.0"
+        "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "3.3.1"
       },
       "settings": [
         {
@@ -1451,7 +1451,7 @@
       "enabledInTryMode": false,
       "documentation": "$content=Documentation\\entityTrigger.md",
       "extension": {
-        "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "3.3.0"
+        "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "3.3.1"
       },
       "settings": [
         {
@@ -1484,7 +1484,7 @@
       "enabledInTryMode": false,
       "documentation": "$content=Documentation\\orchestrationClientIn.md",
       "extension": {
-        "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "3.3.0"
+        "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "3.3.1"
       },
       "settings": [
         {
@@ -1510,7 +1510,7 @@
       "enabledInTryMode": false,
       "documentation": "$content=Documentation\\orchestrationClientIn.md",
       "extension": {
-        "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "3.3.0"
+        "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "3.3.1"
       },
       "settings": [
         {

--- a/Functions.Templates/Bindings/bindings.json
+++ b/Functions.Templates/Bindings/bindings.json
@@ -1385,7 +1385,7 @@
       "enabledInTryMode": false,
       "documentation": "$content=Documentation\\activityTrigger.md",
       "extension": {
-        "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "3.3.0"
+        "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "3.3.1"
       },
       "settings": [
         {
@@ -1418,7 +1418,7 @@
       "enabledInTryMode": false,
       "documentation": "$content=Documentation\\orchestrationTrigger.md",
       "extension": {
-        "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "3.3.0"
+        "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "3.3.1"
       },
       "settings": [
         {
@@ -1451,7 +1451,7 @@
       "enabledInTryMode": false,
       "documentation": "$content=Documentation\\entityTrigger.md",
       "extension": {
-        "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "3.3.0"
+        "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "3.3.1"
       },
       "settings": [
         {
@@ -1484,7 +1484,7 @@
       "enabledInTryMode": false,
       "documentation": "$content=Documentation\\orchestrationClientIn.md",
       "extension": {
-        "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "3.3.0"
+        "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "3.3.1"
       },
       "settings": [
         {
@@ -1510,7 +1510,7 @@
       "enabledInTryMode": false,
       "documentation": "$content=Documentation\\orchestrationClientIn.md",
       "extension": {
-        "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "3.3.0"
+        "id": "Microsoft.Azure.WebJobs.Extensions.DurableTask", "version": "3.3.1"
       },
       "settings": [
         {

--- a/Functions.Templates/Templates/DurableFunctionsEntityClass-CSharp-Isolated/.template.config/template.json
+++ b/Functions.Templates/Templates/DurableFunctionsEntityClass-CSharp-Isolated/.template.config/template.json
@@ -39,7 +39,7 @@
       "args": {
         "referenceType": "package",
         "reference": "Microsoft.Azure.Functions.Worker.Extensions.DurableTask",
-        "version": "1.5.0",
+        "version": "1.6.1",
         "projectFileExtensions": ".csproj"
       }
     },

--- a/Functions.Templates/Templates/DurableFunctionsEntityFunction-CSharp-Isolated/.template.config/template.json
+++ b/Functions.Templates/Templates/DurableFunctionsEntityFunction-CSharp-Isolated/.template.config/template.json
@@ -39,7 +39,7 @@
       "args": {
         "referenceType": "package",
         "reference": "Microsoft.Azure.Functions.Worker.Extensions.DurableTask",
-        "version": "1.5.0",
+        "version": "1.6.1",
         "projectFileExtensions": ".csproj"
       }
     },

--- a/Functions.Templates/Templates/DurableFunctionsEntityHttp-CSharp-2.x/.template.config/template.json
+++ b/Functions.Templates/Templates/DurableFunctionsEntityHttp-CSharp-2.x/.template.config/template.json
@@ -35,7 +35,7 @@
       "args": {
         "referenceType": "package",
         "reference": "Microsoft.Azure.WebJobs.Extensions.DurableTask",
-        "version": "3.3.0",
+        "version": "3.3.1",
         "projectFileExtensions": ".csproj"
       }
     },

--- a/Functions.Templates/Templates/DurableFunctionsOrchestration-CSharp-2.x/.template.config/template.json
+++ b/Functions.Templates/Templates/DurableFunctionsOrchestration-CSharp-2.x/.template.config/template.json
@@ -39,7 +39,7 @@
       "args": {
         "referenceType": "package",
         "reference": "Microsoft.Azure.WebJobs.Extensions.DurableTask",
-        "version": "3.3.0",
+        "version": "3.3.1",
         "projectFileExtensions": ".csproj"
       }
     },

--- a/Functions.Templates/Templates/DurableFunctionsOrchestration-CSharp-Isolated/.template.config/template.json
+++ b/Functions.Templates/Templates/DurableFunctionsOrchestration-CSharp-Isolated/.template.config/template.json
@@ -39,7 +39,7 @@
       "args": {
         "referenceType": "package",
         "reference": "Microsoft.Azure.Functions.Worker.Extensions.DurableTask",
-        "version": "1.5.0",
+        "version": "1.6.1",
         "projectFileExtensions": ".csproj"
       }
     },


### PR DESCRIPTION
This pull request updates the versions of dependencies related to Azure Durable Functions across multiple configuration files to ensure compatibility and leverage the latest improvements. The changes primarily involve updating the `Microsoft.Azure.WebJobs.Extensions.DurableTask` and `Microsoft.Azure.Functions.Worker.Extensions.DurableTask` packages.

### Dependency Updates:

* Updated `Microsoft.Azure.WebJobs.Extensions.DurableTask` from version `3.3.0` to `3.3.1` in the following files:
  - `Functions.Templates/Bindings/bindings-bundle-v4.json` for bindings such as `activityTrigger`, `orchestrationTrigger`, `entityTrigger`, and `orchestrationClientIn`. [[1]](diffhunk://#diff-be680cd7f8607f3d523b37dac4e51dfff9f42f158f1023015f68b1a58ee480daL1388-R1388) [[2]](diffhunk://#diff-be680cd7f8607f3d523b37dac4e51dfff9f42f158f1023015f68b1a58ee480daL1421-R1421) [[3]](diffhunk://#diff-be680cd7f8607f3d523b37dac4e51dfff9f42f158f1023015f68b1a58ee480daL1454-R1454) [[4]](diffhunk://#diff-be680cd7f8607f3d523b37dac4e51dfff9f42f158f1023015f68b1a58ee480daL1487-R1487) [[5]](diffhunk://#diff-be680cd7f8607f3d523b37dac4e51dfff9f42f158f1023015f68b1a58ee480daL1513-R1513)
  - `Functions.Templates/Bindings/bindings.json` for the same bindings as above. [[1]](diffhunk://#diff-9b0350f5d0b9d035a317da436ff378fef2f58b65f5ec57f04744fe0119504d6fL1388-R1388) [[2]](diffhunk://#diff-9b0350f5d0b9d035a317da436ff378fef2f58b65f5ec57f04744fe0119504d6fL1421-R1421) [[3]](diffhunk://#diff-9b0350f5d0b9d035a317da436ff378fef2f58b65f5ec57f04744fe0119504d6fL1454-R1454) [[4]](diffhunk://#diff-9b0350f5d0b9d035a317da436ff378fef2f58b65f5ec57f04744fe0119504d6fL1487-R1487) [[5]](diffhunk://#diff-9b0350f5d0b9d035a317da436ff378fef2f58b65f5ec57f04744fe0119504d6fL1513-R1513)
  - `Functions.Templates/Templates/DurableFunctionsEntityHttp-CSharp-2.x/.template.config/template.json`.
  - `Functions.Templates/Templates/DurableFunctionsOrchestration-CSharp-2.x/.template.config/template.json`.

* Updated `Microsoft.Azure.Functions.Worker.Extensions.DurableTask` from version `1.5.0` to `1.6.1` in the following files:
  - `Functions.Templates/Templates/DurableFunctionsEntityClass-CSharp-Isolated/.template.config/template.json`.
  - `Functions.Templates/Templates/DurableFunctionsEntityFunction-CSharp-Isolated/.template.config/template.json`.
  - `Functions.Templates/Templates/DurableFunctionsOrchestration-CSharp-Isolated/.template.config/template.json`.