### PR TITLE
Disable codeql compiled

### DIFF
--- a/eng/official-build.yml
+++ b/eng/official-build.yml
@@ -40,6 +40,12 @@ extends:
       image: 1es-windows-2022
       os: windows
 
+    sdl:
+      codeql:
+        compiled:
+          enabled: false
+          justificationForDisabling: Repo contains only templates. These are not compiled.
+
     stages:  
     - stage: Build
       jobs:

--- a/eng/public-build.yml
+++ b/eng/public-build.yml
@@ -34,6 +34,12 @@ extends:
       image: 1es-windows-2022
       os: windows
 
+    sdl:
+      codeql:
+        compiled:
+          enabled: false
+          justificationForDisabling: Repo contains only templates. These are not compiled.
+
     settings:
       # PR's from forks do not have sufficient permissions to set tags.
       skipBuildTagsForGitHubPullRequests: ${{ variables['System.PullRequest.IsFork'] }}


### PR DESCRIPTION
Attempt 2 on disabling codeql scans for this repository. CodeQL "sees" the .cs files and expects a compilation step for it to hook into and scan the results. But since these are template files, they are never built.