### PR TITLE
Updating project templates to support .NET 10

### DIFF
--- a/Functions.Templates/ProjectTemplate_v4.x/CSharp-Isolated/.template.config/template.json
+++ b/Functions.Templates/ProjectTemplate_v4.x/CSharp-Isolated/.template.config/template.json
@@ -40,6 +40,10 @@
                 "description": "Target .NET 9"
                 },
                 {
+                "choice": "net10.0",
+                "description": "Target .NET 10 (Preview)"
+                },
+                {
                 "choice": "net48",
                 "description": "Target .NET Framework 4.8"
                 }
@@ -51,7 +55,7 @@
         },
         "NetCore": {
             "type": "computed",
-            "value": "(Framework == \"net9.0\" || Framework == \"net8.0\" || Framework == \"net7.0\" || Framework == \"net6.0\")"
+            "value": "(Framework == \"net10.0\" || Framework == \"net9.0\" || Framework == \"net8.0\" || Framework == \"net7.0\" || Framework == \"net6.0\")"
         },
         "FrameworkShouldUseV1Dependencies": {
             "type": "computed",
@@ -104,6 +108,10 @@
                         "value": "1.24.0"
                     },
                     {
+                        "condition": "FrameworkShouldUseV1Dependencies",
+                        "value": "2.50.0-preview1"
+                    },
+                    {
                         "value": "2.0.0"
                     }
                 ]
@@ -121,7 +129,7 @@
                         "value": "1.3.3"
                     },
                     {
-                        "value": "2.0.1"
+                        "value": "2.0.2"
                     }
                 ]
             }
@@ -138,7 +146,7 @@
                         "value": "1.18.1"
                     },
                     {
-                        "value": "2.0.2"
+                        "value": "2.0.5"
                     }
                 ]
             }

--- a/Functions.Templates/ProjectTemplate_v4.x/CSharp-Isolated/.template.config/template.json
+++ b/Functions.Templates/ProjectTemplate_v4.x/CSharp-Isolated/.template.config/template.json
@@ -108,7 +108,7 @@
                         "value": "1.24.0"
                     },
                     {
-                        "condition": "FrameworkShouldUseV1Dependencies",
+                        "condition": "(Framework == \"net10.0\")",
                         "value": "2.50.0-preview1"
                     },
                     {

--- a/Functions.Templates/ProjectTemplate_v4.x/FSharp-Isolated/.template.config/template.json
+++ b/Functions.Templates/ProjectTemplate_v4.x/FSharp-Isolated/.template.config/template.json
@@ -38,12 +38,16 @@
                 {
                 "choice": "net9.0",
                 "description": "Target .NET 9"
+                },
+                {
+                "choice": "net10.0",
+                "description": "Target .NET 10 (Preview)"
                 }
             ]
         },
         "NetCore": {
             "type": "computed",
-            "value": "(Framework == \"net9.0\" || Framework == \"net8.0\" || Framework == \"net7.0\" || Framework == \"net6.0\")"
+            "value": "(Framework == \"net10.0\" || Framework == \"net9.0\" || Framework == \"net8.0\" || Framework == \"net7.0\" || Framework == \"net6.0\")"
         },
         "FrameworkShouldUseV1Dependencies": {
             "type": "computed",
@@ -74,6 +78,10 @@
                         "value": "1.24.0"
                     },
                     {
+                        "condition": "FrameworkShouldUseV1Dependencies",
+                        "value": "2.50.0-preview1"
+                    },
+                    {
                         "value": "2.0.0"
                     }
                 ]
@@ -91,7 +99,7 @@
                         "value": "1.3.3"
                     },
                     {
-                        "value": "2.0.0"
+                        "value": "2.0.2"
                     }
                 ]
             }
@@ -108,7 +116,7 @@
                         "value": "1.18.1"
                     },
                     {
-                        "value": "2.0.1"
+                        "value": "2.0.5"
                     }
                 ]
             }
@@ -172,7 +180,7 @@
             "args": {
                 "referenceType": "package",
                 "reference": "Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore",
-                "version": "2.0.0-preview2",
+                "version": "2.0.2",
                 "projectFileExtensions": ".fsproj"
             }
         },

--- a/Functions.Templates/ProjectTemplate_v4.x/FSharp-Isolated/.template.config/template.json
+++ b/Functions.Templates/ProjectTemplate_v4.x/FSharp-Isolated/.template.config/template.json
@@ -78,7 +78,7 @@
                         "value": "1.24.0"
                     },
                     {
-                        "condition": "FrameworkShouldUseV1Dependencies",
+                        "condition": "(Framework == \"net10.0\")",
                         "value": "2.50.0-preview1"
                     },
                     {

--- a/Functions.Templates/Templates/HttpTrigger-CSharp-Isolated/.template.config/template.json
+++ b/Functions.Templates/Templates/HttpTrigger-CSharp-Isolated/.template.config/template.json
@@ -27,7 +27,7 @@
     },
     "NetCore": {
       "type": "computed",
-      "value": "(Framework == \"net9.0\" || Framework == \"net8.0\" || Framework == \"net7.0\" || Framework == \"net6.0\")"
+      "value": "(Framework == \"net10.0\" || Framework == \"net9.0\" || Framework == \"net8.0\" || Framework == \"net7.0\" || Framework == \"net6.0\")"
     },
     "FrameworkShouldUseV1Dependencies": {
       "type": "computed",
@@ -93,7 +93,7 @@
       "args": {
         "referenceType": "package",
         "reference": "Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore",
-        "version": "2.0.1",
+        "version": "2.0.2",
         "projectFileExtensions": ".csproj"
       }
     },

--- a/Functions.Templates/Templates/HttpTrigger-FSharp-Isolated/.template.config/template.json
+++ b/Functions.Templates/Templates/HttpTrigger-FSharp-Isolated/.template.config/template.json
@@ -56,7 +56,7 @@
         "referenceType": "package",
         "reference": "Microsoft.Azure.Functions.Worker.Extensions.Http",
         "version": "3.3.0",
-        "projectFileExtensions": ".csproj"
+        "projectFileExtensions": ".fsproj"
       }
     },
     {


### PR DESCRIPTION
Fixes #1679

Introducing .NET 10 as a target framework and updating package references to support that (which includes a general bump outside of .NET 10).

While testing, I noticed issues with F# that I can reproduce without these changes as well. I will file a separate issue for those.