### PR TITLE
Add MCP template to .NET isolated nuspec

### DIFF
--- a/Build/PackageFiles/Dotnet_precompiled/ItemTemplates-Isolated_NetCore_v4.x.nuspec
+++ b/Build/PackageFiles/Dotnet_precompiled/ItemTemplates-Isolated_NetCore_v4.x.nuspec
@@ -50,5 +50,6 @@
     <file src="..\..\..\Functions.Templates\Templates\MySqlInputBinding-CSharp-Isolated\**" target="content\MySqlInputBinding-CSharp-Isolated" />
     <file src="..\..\..\Functions.Templates\Templates\MySqlOutputBinding-CSharp-Isolated\**" target="content\MySqlOutputBinding-CSharp-Isolated" />
     <file src="..\..\..\Functions.Templates\Templates\MySqlTrigger-CSharp-Isolated\**" target="content\MySqlTrigger-CSharp-Isolated" />
+    <file src="..\..\..\Functions.Templates\Templates\McpToolTrigger-CSharp-Isolated\**" target="content\McpToolTrigger-CSharp-Isolated" />
   </files>
 </package>

--- a/Build/PackageFiles/Dotnet_precompiled/ItemTemplates-Isolated_NetFx_v4.x.nuspec
+++ b/Build/PackageFiles/Dotnet_precompiled/ItemTemplates-Isolated_NetFx_v4.x.nuspec
@@ -50,5 +50,6 @@
     <file src="..\..\..\Functions.Templates\Templates\MySqlInputBinding-CSharp-Isolated\**" target="content\MySqlInputBinding-CSharp-Isolated" />
     <file src="..\..\..\Functions.Templates\Templates\MySqlOutputBinding-CSharp-Isolated\**" target="content\MySqlOutputBinding-CSharp-Isolated" />
     <file src="..\..\..\Functions.Templates\Templates\MySqlTrigger-CSharp-Isolated\**" target="content\MySqlTrigger-CSharp-Isolated" />
+    <file src="..\..\..\Functions.Templates\Templates\McpToolTrigger-CSharp-Isolated\**" target="content\McpToolTrigger-CSharp-Isolated" />
   </files>
 </package>

--- a/Build/PackageFiles/Dotnet_precompiled/ItemTemplates_v4.x.nuspec
+++ b/Build/PackageFiles/Dotnet_precompiled/ItemTemplates_v4.x.nuspec
@@ -57,5 +57,6 @@
     <file src="..\..\..\Functions.Templates\Templates\MySqlInputBinding-CSharp\**" target="content\MySqlInputBinding-CSharp" exclude="**\*.csx;**\*.md;**\*.dat;**\function.json;**\metadata.json" />
     <file src="..\..\..\Functions.Templates\Templates\MySqlOutputBinding-CSharp\**" target="content\MySqlOutputBinding-CSharp" exclude="**\*.csx;**\*.md;**\*.dat;**\function.json;**\metadata.json" />
     <file src="..\..\..\Functions.Templates\Templates\MySqlTrigger-CSharp\**" target="content\MySqlTrigger-CSharp" exclude="**\*.csx;**\*.md;**\*.dat;**\function.json;**\metadata.json" />
+    <file src="..\..\..\Functions.Templates\Templates\McpToolTrigger-CSharp-Isolated\**" target="content\McpToolTrigger-CSharp-Isolated" exclude="**\*.csx;**\*.md;**\*.dat;**\function.json;**\metadata.json" />
   </files>
 </package>


### PR DESCRIPTION
The MCP template was only added to the Worker package: https://github.com/Azure/azure-functions-templates/blob/0c7ede87bd1e1cdac3d57cce6b6b68660df7817d/Build/PackageFiles/Dotnet_precompiled/ItemTemplates-Isolated_v4.x.nuspec#L52

Updating the remaining nuspec for various other .NET template packages.