### PR TITLE
Updating .NET item templates to use primary constructors

### DIFF
--- a/Functions.Templates/Templates/BlobTrigger-CSharp-Isolated/BlobTriggerCSharp.cs
+++ b/Functions.Templates/Templates/BlobTrigger-CSharp-Isolated/BlobTriggerCSharp.cs
@@ -5,20 +5,13 @@ using Microsoft.Extensions.Logging;
 
 namespace Company.Function;
 
-public class BlobTriggerCSharp
+public class BlobTriggerCSharp(ILogger<BlobTriggerCSharp> logger)
 {
-    private readonly ILogger<BlobTriggerCSharp> _logger;
-
-    public BlobTriggerCSharp(ILogger<BlobTriggerCSharp> logger)
-    {
-        _logger = logger;
-    }
-
     [Function(nameof(BlobTriggerCSharp))]
     public async Task Run([BlobTrigger("PathValue/{name}", Connection = "ConnectionValue")] Stream stream, string name)
     {
         using var blobStreamReader = new StreamReader(stream);
         var content = await blobStreamReader.ReadToEndAsync();
-        _logger.LogInformation("C# Blob trigger function Processed blob\n Name: {name} \n Data: {content}", name, content);
+        logger.LogInformation("C# Blob trigger function Processed blob\n Name: {name} \n Data: {content}", name, content);
     }
 }

--- a/Functions.Templates/Templates/CosmosDBTrigger-CSharp-Isolated/CosmosDBTriggerCSharp.cs
+++ b/Functions.Templates/Templates/CosmosDBTrigger-CSharp-Isolated/CosmosDBTriggerCSharp.cs
@@ -5,15 +5,8 @@ using Microsoft.Extensions.Logging;
 
 namespace Company.Function;
 
-public class CosmosDBTriggerCSharp
+public class CosmosDBTriggerCSharp(ILogger<CosmosDBTriggerCSharp> logger)
 {
-    private readonly ILogger<CosmosDBTriggerCSharp> _logger;
-
-    public CosmosDBTriggerCSharp(ILogger<CosmosDBTriggerCSharp> logger)
-    {
-        _logger = logger;
-    }
-
     [Function("CosmosDBTriggerCSharp")]
     public void Run([CosmosDBTrigger(
         databaseName: "DatabaseValue",
@@ -24,8 +17,8 @@ public class CosmosDBTriggerCSharp
     {
         if (input != null && input.Count > 0)
         {
-            _logger.LogInformation("Documents modified: " + input.Count);
-            _logger.LogInformation("First document Id: " + input[0].id);
+            logger.LogInformation("Documents modified: " + input.Count);
+            logger.LogInformation("First document Id: " + input[0].id);
         }
     }
 }

--- a/Functions.Templates/Templates/EventGridTrigger-CSharp-Isolated/EventGridTriggerCSharp.cs
+++ b/Functions.Templates/Templates/EventGridTrigger-CSharp-Isolated/EventGridTriggerCSharp.cs
@@ -8,18 +8,11 @@ using Microsoft.Extensions.Logging;
 
 namespace Company.Function;
 
-public class EventGridTriggerCSharp
+public class EventGridTriggerCSharp(ILogger<EventGridTriggerCSharp> logger)
 {
-    private readonly ILogger<EventGridTriggerCSharp> _logger;
-
-    public EventGridTriggerCSharp(ILogger<EventGridTriggerCSharp> logger)
-    {
-        _logger = logger;
-    }
-
     [Function(nameof(EventGridTriggerCSharp))]
     public void Run([EventGridTrigger] CloudEvent cloudEvent)
     {
-        _logger.LogInformation("Event type: {type}, Event subject: {subject}", cloudEvent.Type, cloudEvent.Subject);
+        logger.LogInformation("Event type: {type}, Event subject: {subject}", cloudEvent.Type, cloudEvent.Subject);
     }
 }

--- a/Functions.Templates/Templates/EventHubTrigger-CSharp-Isolated/EventHubTriggerCSharp.cs
+++ b/Functions.Templates/Templates/EventHubTrigger-CSharp-Isolated/EventHubTriggerCSharp.cs
@@ -4,22 +4,15 @@ using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 
 namespace Company.Function;
-public class EventHubTriggerCSharp
+public class EventHubTriggerCSharp(ILogger<EventHubTriggerCSharp> logger)
 {
-    private readonly ILogger<EventHubTriggerCSharp> _logger;
-
-    public EventHubTriggerCSharp(ILogger<EventHubTriggerCSharp> logger)
-    {
-        _logger = logger;
-    }
-
     [Function(nameof(EventHubTriggerCSharp))]
     public void Run([EventHubTrigger("eventHubNameValue", Connection = "ConnectionValue")] EventData[] events)
     {
         foreach (EventData @event in events)
         {
-            _logger.LogInformation("Event Body: {body}", @event.Body);
-            _logger.LogInformation("Event Content-Type: {contentType}", @event.ContentType);
+            logger.LogInformation("Event Body: {body}", @event.Body);
+            logger.LogInformation("Event Content-Type: {contentType}", @event.ContentType);
         }
     }
 }

--- a/Functions.Templates/Templates/HttpTrigger-CSharp-Isolated-NetCore/HttpTriggerCSharp.cs
+++ b/Functions.Templates/Templates/HttpTrigger-CSharp-Isolated-NetCore/HttpTriggerCSharp.cs
@@ -5,19 +5,12 @@ using Microsoft.Extensions.Logging;
 
 namespace Company.Function;
 
-public class HttpTriggerCSharp
+public class HttpTriggerCSharp(ILogger<HttpTriggerCSharp> logger)
 {
-    private readonly ILogger<HttpTriggerCSharp> _logger;
-
-    public HttpTriggerCSharp(ILogger<HttpTriggerCSharp> logger)
-    {
-        _logger = logger;
-    }
-
     [Function("HttpTriggerCSharp")]
     public IActionResult Run([HttpTrigger(AuthorizationLevel.AuthLevelValue, "get", "post")] HttpRequest req)
     {
-        _logger.LogInformation("C# HTTP trigger function processed a request.");
+        logger.LogInformation("C# HTTP trigger function processed a request.");
         return new OkObjectResult("Welcome to Azure Functions!");
     }
 }

--- a/Functions.Templates/Templates/HttpTrigger-CSharp-Isolated/HttpTriggerCSharp.cs
+++ b/Functions.Templates/Templates/HttpTrigger-CSharp-Isolated/HttpTriggerCSharp.cs
@@ -6,19 +6,12 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace Company.Function;
 
-public class HttpTriggerCSharp
+public class HttpTriggerCSharp(ILogger<HttpTriggerCSharp> logger)
 {
-    private readonly ILogger<HttpTriggerCSharp> _logger;
-
-    public HttpTriggerCSharp(ILogger<HttpTriggerCSharp> logger)
-    {
-        _logger = logger;
-    }
-
     [Function("HttpTriggerCSharp")]
     public IActionResult Run([HttpTrigger(AuthorizationLevel.AuthLevelValue, "get", "post")] HttpRequest req)
     {
-        _logger.LogInformation("C# HTTP trigger function processed a request.");
+        logger.LogInformation("C# HTTP trigger function processed a request.");
         return new OkObjectResult("Welcome to Azure Functions!");
     }
 }

--- a/Functions.Templates/Templates/KustoInputBinding-CSharp-Isolated/KustoInputBindingIsolated.cs
+++ b/Functions.Templates/Templates/KustoInputBinding-CSharp-Isolated/KustoInputBindingIsolated.cs
@@ -11,15 +11,8 @@ namespace Company.Function;
 // KustoInputBinding sample 
 // Execute queries against the ADX cluster.
 // Add `KustoConnectionString` to the local.settings.json
-public class KustoInputBindingIsolated
+public class KustoInputBindingIsolated(ILogger<KustoInputBindingIsolated> logger)
 {
-    private readonly ILogger _logger;
-
-    public KustoInputBindingIsolated(ILoggerFactory loggerFactory)
-    {
-        _logger = loggerFactory.CreateLogger<KustoInputBindingIsolated>();
-    }
-
     [Function("KustoInputBindingIsolated")]
     public IEnumerable<Object> Run(
         [HttpTrigger(AuthorizationLevel.Function, "get", Route = null)] HttpRequestData req,
@@ -28,7 +21,7 @@ public class KustoInputBindingIsolated
             KqlParameters = "", // Parameters to bind : @records={records}
             Connection = "KustoConnectionString")] IEnumerable<Object> result)
     {
-        _logger.LogInformation("C# HTTP trigger with Kusto Input Binding function processed a request.");
+        logger.LogInformation("C# HTTP trigger with Kusto Input Binding function processed a request.");
         return result;
     }
 }

--- a/Functions.Templates/Templates/KustoOutputBinding-CSharp-Isolated/KustoOutputBindingIsolated.cs
+++ b/Functions.Templates/Templates/KustoOutputBinding-CSharp-Isolated/KustoOutputBindingIsolated.cs
@@ -7,15 +7,8 @@ using Microsoft.Extensions.Logging;
 
 namespace Company.Function;
 
-public class KustoOutputBindingIsolated
+public class KustoOutputBindingIsolated(ILogger<KustoOutputBindingIsolated> logger)
 {
-    private readonly ILogger _logger;
-
-    public KustoOutputBindingIsolated(ILoggerFactory loggerFactory)
-    {
-        _logger = loggerFactory.CreateLogger<KustoOutputBindingIsolated>();
-    }
-
     // Visit https://github.com/Azure/Webjobs.Extensions.Kusto/tree/main/samples/samples-outofproc/OutputBindingSamples 
     // KustoOutputBinding sample 
     // Execute queries against the ADX cluster.
@@ -27,7 +20,7 @@ public class KustoOutputBindingIsolated
     public async Task<ToDoItem> Run(
         [HttpTrigger(AuthorizationLevel.Function, "post", Route = null)] HttpRequestData req)
     {
-        _logger.LogInformation("C# HTTP trigger with Kusto Output Binding function processed a request.");
+        logger.LogInformation("C# HTTP trigger with Kusto Output Binding function processed a request.");
         ToDoItem todoitem = await req.ReadFromJsonAsync<ToDoItem>() ?? new ToDoItem
             {
                 Id = "1",

--- a/Functions.Templates/Templates/McpToolTrigger-CSharp-Isolated/HelloTool.cs
+++ b/Functions.Templates/Templates/McpToolTrigger-CSharp-Isolated/HelloTool.cs
@@ -4,22 +4,15 @@ using Microsoft.Extensions.Logging;
 
 namespace Company.Function;
 
-public class HelloTool
+public class HelloTool(ILogger<HelloTool> logger)
 {
-    private ILogger<HelloTool> _logger;
-
-    public HelloTool(ILogger<HelloTool> logger)
-    {
-        _logger = logger;
-    }
-
     [Function(nameof(HelloTool))]
     public string Run(
         [McpToolTrigger(nameof(HelloTool), "Responds to the user with a hello message.")] ToolInvocationContext context,
         [McpToolProperty(nameof(name), "The name of the person to greet.")] string? name
     )
     {
-        _logger.LogInformation("C# MCP tool trigger function processed a request.");
+        logger.LogInformation("C# MCP tool trigger function processed a request.");
         return $"Hello, {name ?? "world"}! This is an MCP Tool!";
     }
 }

--- a/Functions.Templates/Templates/MySqlInputBinding-CSharp-Isolated/MySqlInputBindingHttpTriggerCSharp.cs
+++ b/Functions.Templates/Templates/MySqlInputBinding-CSharp-Isolated/MySqlInputBindingHttpTriggerCSharp.cs
@@ -5,22 +5,15 @@ using Microsoft.Extensions.Logging;
 
 namespace Company.Function;
 
-public class MySqlInputBindingHttpTriggerCSharp
+public class MySqlInputBindingHttpTriggerCSharp(ILogger<MySqlInputBindingHttpTriggerCSharp> logger)
 {
-    private readonly ILogger _logger;
-
-    public MySqlInputBindingHttpTriggerCSharp(ILoggerFactory loggerFactory)
-    {
-        _logger = loggerFactory.CreateLogger<MySqlInputBindingHttpTriggerCSharp>();
-    }
-
     [Function("MySqlInputBindingHttpTriggerCSharp")]
     public IEnumerable<Object> Run(
         [HttpTrigger(AuthorizationLevel.Function, "get", Route = null)] HttpRequestData req,
         [MySqlInput("SELECT * FROM object",
         "MySqlConnectionString")] IEnumerable<Object> result)
     {
-        _logger.LogInformation("C# HTTP trigger with MySQL Input Binding function processed a request.");
+        logger.LogInformation("C# HTTP trigger with MySQL Input Binding function processed a request.");
 
         return result;
     }

--- a/Functions.Templates/Templates/MySqlOutputBinding-CSharp-Isolated/MySqlOutputBindingHttpTriggerCSharp.cs
+++ b/Functions.Templates/Templates/MySqlOutputBinding-CSharp-Isolated/MySqlOutputBindingHttpTriggerCSharp.cs
@@ -5,21 +5,14 @@ using Microsoft.Extensions.Logging;
 
 namespace Company.Function;
 
-public class MySqlOutputBindingHttpTriggerCSharp
+public class MySqlOutputBindingHttpTriggerCSharp(ILogger<MySqlOutputBindingHttpTriggerCSharp> logger)
 {
-    private readonly ILogger _logger;
-
-    public MySqlOutputBindingHttpTriggerCSharp(ILoggerFactory loggerFactory)
-    {
-        _logger = loggerFactory.CreateLogger<MySqlOutputBindingHttpTriggerCSharp>();
-    }
-
     [Function("MySqlOutputBindingHttpTriggerCSharp")]
     [MySqlOutput("table", "MySqlConnectionString")]
     public async Task<ToDoItem> Run(
         [HttpTrigger(AuthorizationLevel.Function, "post", Route = null)] HttpRequestData req)
     {
-        _logger.LogInformation("C# HTTP trigger with MySql Output Binding function processed a request.");
+        logger.LogInformation("C# HTTP trigger with MySql Output Binding function processed a request.");
 
         ToDoItem todoitem = await req.ReadFromJsonAsync<ToDoItem>() ?? new ToDoItem
             {

--- a/Functions.Templates/Templates/MySqlTrigger-CSharp-Isolated/MySqlTriggerBindingCSharp.cs
+++ b/Functions.Templates/Templates/MySqlTrigger-CSharp-Isolated/MySqlTriggerBindingCSharp.cs
@@ -4,27 +4,20 @@ using Microsoft.Extensions.Logging;
 
 namespace Company.Function;
 
-public class MySqlTriggerBindingCSharp
+public class MySqlTriggerBindingCSharp(ILogger<MySqlTriggerBindingCSharp> logger)
 {
-    private readonly ILogger _logger;
-
-    public MySqlTriggerBindingCSharp(ILoggerFactory loggerFactory)
-    {
-        _logger = loggerFactory.CreateLogger<MySqlTriggerBindingCSharp>();
-    }
-
     [Function("MySqlTriggerBindingCSharp")]
     public void Run(
         [MySqlTrigger("table1", "MySqlConnectionString")] IReadOnlyList<MySqlChange<ToDoItem>> changes,
             FunctionContext context)
     {
-        _logger.LogInformation("MySql Changes: ");
+        logger.LogInformation("MySql Changes: ");
         // The output is used to inspect the trigger binding parameter in test methods.
         foreach (MySqlChange<ToDoItem> change in changes)
         {
             ToDoItem toDoItem = change.Item;
-            _logger.LogInformation($"Change operation: {change.Operation}");
-            _logger.LogInformation($"Id: {toDoItem.Id}, Priority: {toDoItem.Priority}, Description: {toDoItem.Description}");
+            logger.LogInformation($"Change operation: {change.Operation}");
+            logger.LogInformation($"Id: {toDoItem.Id}, Priority: {toDoItem.Priority}, Description: {toDoItem.Description}");
         }
     }
 }

--- a/Functions.Templates/Templates/QueueTrigger-CSharp-Isolated/QueueTriggerCSharp.cs
+++ b/Functions.Templates/Templates/QueueTrigger-CSharp-Isolated/QueueTriggerCSharp.cs
@@ -5,18 +5,11 @@ using Microsoft.Extensions.Logging;
 
 namespace Company.Function;
 
-public class QueueTriggerCSharp
+public class QueueTriggerCSharp(ILogger<QueueTriggerCSharp> logger)
 {
-    private readonly ILogger<QueueTriggerCSharp> _logger;
-
-    public QueueTriggerCSharp(ILogger<QueueTriggerCSharp> logger)
-    {
-        _logger = logger;
-    }
-
     [Function(nameof(QueueTriggerCSharp))]
     public void Run([QueueTrigger("PathValue", Connection = "ConnectionValue")] QueueMessage message)
     {
-        _logger.LogInformation("C# Queue trigger function processed: {messageText}", message.MessageText);
+        logger.LogInformation("C# Queue trigger function processed: {messageText}", message.MessageText);
     }
 }

--- a/Functions.Templates/Templates/RabbitMQTrigger-CSharp-Isolated/RabbitMQTriggerCSharp.cs
+++ b/Functions.Templates/Templates/RabbitMQTrigger-CSharp-Isolated/RabbitMQTriggerCSharp.cs
@@ -4,18 +4,11 @@ using Microsoft.Extensions.Logging;
 
 namespace Company.Function;
 
-public class RabbitMQTriggerCSharp
+public class RabbitMQTriggerCSharp(ILogger<RabbitMQTriggerCSharp> logger)
 {
-    private readonly ILogger _logger;
-
-    public RabbitMQTriggerCSharp(ILoggerFactory loggerFactory)
-    {
-        _logger = loggerFactory.CreateLogger<RabbitMQTriggerCSharp>();
-    }
-
     [Function("RabbitMQTriggerCSharp")]
     public void Run([RabbitMQTrigger("NameOfQueue", ConnectionStringSetting = "ConnectionValue")] string myQueueItem)
     {
-        _logger.LogInformation("C# Queue trigger function processed: {item}", myQueueItem);
+        logger.LogInformation("C# Queue trigger function processed: {item}", myQueueItem);
     }
 }

--- a/Functions.Templates/Templates/ServiceBusQueueTrigger-CSharp-Isolated/ServiceBusQueueTriggerCSharp.cs
+++ b/Functions.Templates/Templates/ServiceBusQueueTrigger-CSharp-Isolated/ServiceBusQueueTriggerCSharp.cs
@@ -6,24 +6,17 @@ using Microsoft.Extensions.Logging;
 
 namespace Company.Function;
 
-public class ServiceBusQueueTriggerCSharp
+public class ServiceBusQueueTriggerCSharp(ILogger<ServiceBusQueueTriggerCSharp> logger)
 {
-    private readonly ILogger<ServiceBusQueueTriggerCSharp> _logger;
-
-    public ServiceBusQueueTriggerCSharp(ILogger<ServiceBusQueueTriggerCSharp> logger)
-    {
-        _logger = logger;
-    }
-
     [Function(nameof(ServiceBusQueueTriggerCSharp))]
     public async Task Run(
         [ServiceBusTrigger("QueueNameValue", Connection = "ConnectionValue")]
         ServiceBusReceivedMessage message,
         ServiceBusMessageActions messageActions)
     {
-        _logger.LogInformation("Message ID: {id}", message.MessageId);
-        _logger.LogInformation("Message Body: {body}", message.Body);
-        _logger.LogInformation("Message Content-Type: {contentType}", message.ContentType);
+        logger.LogInformation("Message ID: {id}", message.MessageId);
+        logger.LogInformation("Message Body: {body}", message.Body);
+        logger.LogInformation("Message Content-Type: {contentType}", message.ContentType);
 
         // Complete the message
         await messageActions.CompleteMessageAsync(message);

--- a/Functions.Templates/Templates/ServiceBusTopicTrigger-CSharp-Isolated/ServiceBusTopicTriggerCSharp.cs
+++ b/Functions.Templates/Templates/ServiceBusTopicTrigger-CSharp-Isolated/ServiceBusTopicTriggerCSharp.cs
@@ -6,24 +6,17 @@ using Microsoft.Extensions.Logging;
 
 namespace Company.Function;
 
-public class ServiceBusTopicTriggerCSharp
+public class ServiceBusTopicTriggerCSharp(ILogger<ServiceBusTopicTriggerCSharp> logger)
 {
-    private readonly ILogger<ServiceBusTopicTriggerCSharp> _logger;
-
-    public ServiceBusTopicTriggerCSharp(ILogger<ServiceBusTopicTriggerCSharp> logger)
-    {
-        _logger = logger;
-    }
-
     [Function(nameof(ServiceBusTopicTriggerCSharp))]
     public async Task Run(
         [ServiceBusTrigger("TopicNameValue", "SubscriptionNameValue", Connection = "ConnectionValue")]
         ServiceBusReceivedMessage message,
         ServiceBusMessageActions messageActions)
     {
-        _logger.LogInformation("Message ID: {id}", message.MessageId);
-        _logger.LogInformation("Message Body: {body}", message.Body);
-        _logger.LogInformation("Message Content-Type: {contentType}", message.ContentType);
+        logger.LogInformation("Message ID: {id}", message.MessageId);
+        logger.LogInformation("Message Body: {body}", message.Body);
+        logger.LogInformation("Message Content-Type: {contentType}", message.ContentType);
 
             // Complete the message
         await messageActions.CompleteMessageAsync(message);

--- a/Functions.Templates/Templates/SignalRConnectionInfoHttpTrigger-CSharp-Isolated/SignalRConnectionInfoHttpTriggerCSharp.cs
+++ b/Functions.Templates/Templates/SignalRConnectionInfoHttpTrigger-CSharp-Isolated/SignalRConnectionInfoHttpTriggerCSharp.cs
@@ -6,21 +6,14 @@ using Microsoft.Extensions.Logging;
 
 namespace Company.Function;
 
-public class SignalRConnectionInfoHttpTriggerCSharp
+public class SignalRConnectionInfoHttpTriggerCSharp(ILogger<SignalRConnectionInfoHttpTriggerCSharp> logger)
 {
-    private readonly ILogger _logger;
-
-    public SignalRConnectionInfoHttpTriggerCSharp(ILoggerFactory loggerFactory)
-    {
-        _logger = loggerFactory.CreateLogger("negotiate");
-    }
-
     [Function("negotiate")]
     public HttpResponseData Negotiate(
         [HttpTrigger(AuthorizationLevel.AuthLevelValue, "post")] HttpRequestData req,
         [SignalRConnectionInfoInput(HubName = "HubValue")] MyConnectionInfo connectionInfo)
     {
-        _logger.LogInformation("SignalR Connection URL = '{url}'", connectionInfo.Url);
+        logger.LogInformation("SignalR Connection URL = '{url}'", connectionInfo.Url);
 
         var response = req.CreateResponse(HttpStatusCode.OK);
         response.Headers.Add("Content-Type", "text/plain; charset=utf-8");

--- a/Functions.Templates/Templates/SqlInputBinding-CSharp-Isolated/SqlInputBindingHttpTriggerCSharp.cs
+++ b/Functions.Templates/Templates/SqlInputBinding-CSharp-Isolated/SqlInputBindingHttpTriggerCSharp.cs
@@ -7,22 +7,15 @@ using Microsoft.Extensions.Logging;
 
 namespace Company.Function;
 
-public class SqlInputBindingHttpTriggerCSharp
+public class SqlInputBindingHttpTriggerCSharp(ILogger<SqlInputBindingHttpTriggerCSharp> logger)
 {
-    private readonly ILogger _logger;
-
-    public SqlInputBindingHttpTriggerCSharp(ILoggerFactory loggerFactory)
-    {
-        _logger = loggerFactory.CreateLogger<SqlInputBindingHttpTriggerCSharp>();
-    }
-
     [Function("SqlInputBindingHttpTriggerCSharp")]
     public IEnumerable<Object> Run(
         [HttpTrigger(AuthorizationLevel.Function, "get", Route = null)] HttpRequestData req,
         [SqlInput("SELECT * FROM object",
         "SqlConnectionString")] IEnumerable<Object> result)
     {
-        _logger.LogInformation("C# HTTP trigger with SQL Input Binding function processed a request.");
+        logger.LogInformation("C# HTTP trigger with SQL Input Binding function processed a request.");
 
         return result;
     }

--- a/Functions.Templates/Templates/SqlOutputBinding-CSharp-Isolated/SqlOutputBindingHttpTriggerCSharp.cs
+++ b/Functions.Templates/Templates/SqlOutputBinding-CSharp-Isolated/SqlOutputBindingHttpTriggerCSharp.cs
@@ -7,22 +7,15 @@ using Microsoft.Extensions.Logging;
 
 namespace Company.Function;
 
-public class SqlOutputBindingHttpTriggerCSharp
+public class SqlOutputBindingHttpTriggerCSharp(ILogger<SqlOutputBindingHttpTriggerCSharp> logger)
 {
-    private readonly ILogger _logger;
-
-    public SqlOutputBindingHttpTriggerCSharp(ILoggerFactory loggerFactory)
-    {
-        _logger = loggerFactory.CreateLogger<SqlOutputBindingHttpTriggerCSharp>();
-    }
-
     // Visit https://aka.ms/sqlbindingsoutput to learn how to use this output binding
     [Function("SqlOutputBindingHttpTriggerCSharp")]
     [SqlOutput("table", "SqlConnectionString")]
     public async Task<ToDoItem> Run(
         [HttpTrigger(AuthorizationLevel.Function, "post", Route = null)] HttpRequestData req)
     {
-        _logger.LogInformation("C# HTTP trigger with SQL Output Binding function processed a request.");
+        logger.LogInformation("C# HTTP trigger with SQL Output Binding function processed a request.");
 
         ToDoItem todoitem = await req.ReadFromJsonAsync<ToDoItem>() ?? new ToDoItem
             {

--- a/Functions.Templates/Templates/SqlTrigger-CSharp-Isolated/SqlTriggerBindingCSharp.cs
+++ b/Functions.Templates/Templates/SqlTrigger-CSharp-Isolated/SqlTriggerBindingCSharp.cs
@@ -7,22 +7,15 @@ using Newtonsoft.Json;
 
 namespace Company.Function;
 
-public class SqlTriggerBindingCSharp
+public class SqlTriggerBindingCSharp(ILogger<SqlTriggerBindingCSharp> logger)
 {
-    private readonly ILogger _logger;
-
-    public SqlTriggerBindingCSharp(ILoggerFactory loggerFactory)
-    {
-        _logger = loggerFactory.CreateLogger<SqlTriggerBindingCSharp>();
-    }
-
     // Visit https://aka.ms/sqltrigger to learn how to use this trigger binding
     [Function("SqlTriggerBindingCSharp")]
     public void Run(
         [SqlTrigger("table", "SqlConnectionString")] IReadOnlyList<SqlChange<ToDoItem>> changes,
             FunctionContext context)
     {
-        _logger.LogInformation("SQL Changes: " + JsonConvert.SerializeObject(changes));
+        logger.LogInformation("SQL Changes: " + JsonConvert.SerializeObject(changes));
 
     }
 }

--- a/Functions.Templates/Templates/TimerTrigger-CSharp-Isolated/TimerTriggerCSharp.cs
+++ b/Functions.Templates/Templates/TimerTrigger-CSharp-Isolated/TimerTriggerCSharp.cs
@@ -4,23 +4,16 @@ using Microsoft.Extensions.Logging;
 
 namespace Company.Function;
 
-public class TimerTriggerCSharp
+public class TimerTriggerCSharp(ILogger<TimerTriggerCSharp> logger)
 {
-    private readonly ILogger _logger;
-
-    public TimerTriggerCSharp(ILoggerFactory loggerFactory)
-    {
-        _logger = loggerFactory.CreateLogger<TimerTriggerCSharp>();
-    }
-
     [Function("TimerTriggerCSharp")]
     public void Run([TimerTrigger("ScheduleValue")] TimerInfo myTimer)
     {
-        _logger.LogInformation("C# Timer trigger function executed at: {executionTime}", DateTime.Now);
+        logger.LogInformation("C# Timer trigger function executed at: {executionTime}", DateTime.Now);
         
         if (myTimer.ScheduleStatus is not null)
         {
-            _logger.LogInformation("Next timer schedule at: {nextSchedule}", myTimer.ScheduleStatus.Next);
+            logger.LogInformation("Next timer schedule at: {nextSchedule}", myTimer.ScheduleStatus.Next);
         }
     }
 }


### PR DESCRIPTION
Updating the .NET templates to use primary constructors to reduce verbosity a little. The changes here require C#12, which means the .NET 8 SDK or later. If we accept these changes, we must ensure that they don't get added to older versions in the tooling feed, for example. We also need to look at some separation in the Core Tools.

This PR is being open as a draft until those enforcement mechanisms can be properly in place. At time of opening, the tooling feed generator has been updated to skip out-of-support versions. However, there are enough manual changes in that repo that we might need to add extra enforcement - I'm currently thinking of auto-review from Copilot, with an appropriate `copilot-instructions.md` to frame this new requirement and help avoid mistakes. I do not yet have a plan for the Core Tools.