### PR TITLE
Update readme to reflect Python usage instead of C#

### DIFF
--- a/Functions.Templates/Templates/RabbitMQTrigger-Python/readme.md
+++ b/Functions.Templates/Templates/RabbitMQTrigger-Python/readme.md
@@ -1,6 +1,6 @@
-# RabbitMQTrigger - C<span>#</span>
+# RabbitMQTrigger - Python
 
-The `RabbitMQTrigger` makes it incredibly easy to react to new events from a RabbitMQ queue. This sample demonstrates a simple use case of processing data from a given RabbitMQ Queue using C#.
+The `RabbitMQTrigger` makes it incredibly easy to react to new events from a RabbitMQ queue. This sample demonstrates a simple use case of processing data from a given RabbitMQ Queue using Python.
 
 ## How it works
 


### PR DESCRIPTION
This pull request updates the documentation for the RabbitMQ trigger template to correctly describe its usage with Python instead of C#. The change ensures that users are not misled about the language of the sample.

Documentation update:

* Updated the title and description in `Functions.Templates/Templates/RabbitMQTrigger-Python/readme.md` to reference Python instead of C#, clarifying the sample's language and purpose.