### PR TITLE
add ci step for manifest schema validation

### DIFF
--- a/eng/ci/templates/jobs/build.yml
+++ b/eng/ci/templates/jobs/build.yml
@@ -29,7 +29,8 @@ jobs:
   - template: ../steps/validate-schemas.yml
     parameters:
       validations:
-        - schema: '$(Build.Repository.LocalPath)\Functions.Templates\Template-Manifest\schemas\manifest.schema.json'
+        - name: 'manifest.json'
+          schema: '$(Build.Repository.LocalPath)\Functions.Templates\Template-Manifest\schemas\manifest.schema.json'
           files:
             - '$(Build.Repository.LocalPath)\Functions.Templates\Template-Manifest\manifest.json'
     

--- a/eng/ci/templates/jobs/build.yml
+++ b/eng/ci/templates/jobs/build.yml
@@ -25,6 +25,13 @@ jobs:
     inputs:
       command: 'install'
       workingDir: '.\Build'
+
+  - template: ../steps/validate-schemas.yml
+    parameters:
+      validations:
+        - schema: '$(Build.Repository.LocalPath)\Functions.Templates\Template-Manifest\schemas\manifest.schema.json'
+          files:
+            - '$(Build.Repository.LocalPath)\Functions.Templates\Template-Manifest\manifest.json'
     
   - task: Gulp@1
     inputs:

--- a/eng/ci/templates/steps/validate-schemas.yml
+++ b/eng/ci/templates/steps/validate-schemas.yml
@@ -1,0 +1,92 @@
+parameters:
+  # Array of validation sets. Each item contains:
+  #   - schema: path to the JSON schema file
+  #   - files: array of JSON file paths to validate (optional)
+  #   - pattern: glob pattern to find JSON files (optional)
+  - name: validations
+    type: object
+    displayName: 'List of schema/files validation sets'
+
+steps:
+- task: PowerShell@2
+  displayName: 'Validate JSON files against schemas'
+  inputs:
+    targetType: 'inline'
+    script: |
+      Write-Host "Installing ajv-cli for JSON schema validation..."
+      npm install -g ajv-cli ajv-formats
+
+      $failed = $false
+
+      ${{ each validation in parameters.validations }}:
+      Write-Host ""
+      Write-Host "=========================================="
+      $schemaFile = "${{ validation.schema }}"
+      Write-Host "Schema: $schemaFile"
+
+      if (-not (Test-Path $schemaFile)) {
+          Write-Error "Schema file not found: $schemaFile"
+          $failed = $true
+      } else {
+          # Validate the schema file itself is valid JSON
+          Write-Host "Validating schema file is valid JSON..."
+          try {
+              $schemaContent = Get-Content $schemaFile -Raw | ConvertFrom-Json -ErrorAction Stop
+              Write-Host "  Schema file is valid JSON" -ForegroundColor Green
+          } catch {
+              Write-Error "Failed to parse schema file as valid JSON: $_"
+              $failed = $true
+          }
+
+          # Collect JSON files to validate
+          $filesToValidate = @()
+
+          # From files array
+          ${{ if validation.files }}:
+          ${{ each file in validation.files }}:
+          $filesToValidate += "${{ file }}"
+          ${{ end }}
+          ${{ end }}
+
+          # From glob pattern
+          ${{ if validation.pattern }}:
+          $pattern = "${{ validation.pattern }}"
+          Write-Host "Finding files matching pattern: $pattern"
+          $matchedFiles = Get-ChildItem -Path "$(Build.Repository.LocalPath)" -Filter $pattern -Recurse -File | Select-Object -ExpandProperty FullName
+          $filesToValidate += $matchedFiles
+          ${{ end }}
+
+          if ($filesToValidate.Count -eq 0) {
+              Write-Warning "No JSON files found for schema: $schemaFile"
+          } else {
+              Write-Host "Validating $($filesToValidate.Count) file(s)..."
+
+              foreach ($jsonFile in $filesToValidate) {
+                  if (-not (Test-Path $jsonFile)) {
+                      Write-Error "File not found: $jsonFile"
+                      $failed = $true
+                      continue
+                  }
+
+                  Write-Host ""
+                  Write-Host "  Validating: $jsonFile"
+                  ajv validate -s $schemaFile -d $jsonFile --spec=draft2020 -c ajv-formats --strict=false
+                  if ($LASTEXITCODE -ne 0) {
+                      Write-Error "    Validation FAILED"
+                      $failed = $true
+                  } else {
+                      Write-Host "    Valid" -ForegroundColor Green
+                  }
+              }
+          }
+      }
+      ${{ end }}
+
+      Write-Host ""
+      Write-Host "=========================================="
+      if ($failed) {
+          Write-Error "One or more validations failed!"
+          exit 1
+      }
+
+      Write-Host "All schema validations passed!" -ForegroundColor Green

--- a/eng/ci/templates/steps/validate-schemas.yml
+++ b/eng/ci/templates/steps/validate-schemas.yml
@@ -8,85 +8,88 @@ parameters:
     displayName: 'List of schema/files validation sets'
 
 steps:
-- task: PowerShell@2
-  displayName: 'Validate JSON files against schemas'
-  inputs:
-    targetType: 'inline'
-    script: |
-      Write-Host "Installing ajv-cli for JSON schema validation..."
-      npm install -g ajv-cli ajv-formats
+- ${{ each validation in parameters.validations }}:
+  - task: PowerShell@2
+    displayName: 'Validate against ${{ validation.schema }}'
+    inputs:
+      targetType: 'inline'
+      script: |
+        Write-Host "Installing ajv-cli for JSON schema validation..."
+        npm install -g ajv-cli ajv-formats
 
-      $failed = $false
+        $failed = $false
+        $schemaFile = "${{ validation.schema }}"
 
-      ${{ each validation in parameters.validations }}:
-      Write-Host ""
-      Write-Host "=========================================="
-      $schemaFile = "${{ validation.schema }}"
-      Write-Host "Schema: $schemaFile"
+        Write-Host ""
+        Write-Host "=========================================="
+        Write-Host "Schema: $schemaFile"
 
-      if (-not (Test-Path $schemaFile)) {
-          Write-Error "Schema file not found: $schemaFile"
-          $failed = $true
-      } else {
-          # Validate the schema file itself is valid JSON
-          Write-Host "Validating schema file is valid JSON..."
-          try {
-              $schemaContent = Get-Content $schemaFile -Raw | ConvertFrom-Json -ErrorAction Stop
-              Write-Host "  Schema file is valid JSON" -ForegroundColor Green
-          } catch {
-              Write-Error "Failed to parse schema file as valid JSON: $_"
-              $failed = $true
-          }
+        if (-not (Test-Path $schemaFile)) {
+            Write-Error "Schema file not found: $schemaFile"
+            exit 1
+        }
 
-          # Collect JSON files to validate
-          $filesToValidate = @()
+        # Validate the schema file itself is valid JSON
+        Write-Host "Validating schema file is valid JSON..."
+        try {
+            $schemaContent = Get-Content $schemaFile -Raw | ConvertFrom-Json -ErrorAction Stop
+            Write-Host "  Schema file is valid JSON" -ForegroundColor Green
+        } catch {
+            Write-Error "Failed to parse schema file as valid JSON: $_"
+            exit 1
+        }
 
-          # From files array
-          ${{ if validation.files }}:
-          ${{ each file in validation.files }}:
-          $filesToValidate += "${{ file }}"
-          ${{ end }}
-          ${{ end }}
+        # Collect JSON files to validate
+        $filesToValidate = @()
 
-          # From glob pattern
-          ${{ if validation.pattern }}:
-          $pattern = "${{ validation.pattern }}"
-          Write-Host "Finding files matching pattern: $pattern"
-          $matchedFiles = Get-ChildItem -Path "$(Build.Repository.LocalPath)" -Filter $pattern -Recurse -File | Select-Object -ExpandProperty FullName
-          $filesToValidate += $matchedFiles
-          ${{ end }}
+        # From files array
+        $filesParam = @"
+        ${{ join(';', validation.files) }}
+        "@.Trim()
+        if ($filesParam -ne '') {
+            $filesToValidate += $filesParam.Split(';') | Where-Object { $_.Trim() -ne '' }
+        }
 
-          if ($filesToValidate.Count -eq 0) {
-              Write-Warning "No JSON files found for schema: $schemaFile"
-          } else {
-              Write-Host "Validating $($filesToValidate.Count) file(s)..."
+        # From glob pattern
+        $pattern = "${{ validation.pattern }}"
+        if ($pattern -ne '' -and $pattern -ne '${{ validation.pattern }}') {
+            Write-Host "Finding files matching pattern: $pattern"
+            $matchedFiles = Get-ChildItem -Path "$(Build.Repository.LocalPath)" -Filter $pattern -Recurse -File | Select-Object -ExpandProperty FullName
+            $filesToValidate += $matchedFiles
+        }
 
-              foreach ($jsonFile in $filesToValidate) {
-                  if (-not (Test-Path $jsonFile)) {
-                      Write-Error "File not found: $jsonFile"
-                      $failed = $true
-                      continue
-                  }
+        if ($filesToValidate.Count -eq 0) {
+            Write-Warning "No JSON files found for schema: $schemaFile"
+        } else {
+            Write-Host "Validating $($filesToValidate.Count) file(s)..."
 
-                  Write-Host ""
-                  Write-Host "  Validating: $jsonFile"
-                  ajv validate -s $schemaFile -d $jsonFile --spec=draft2020 -c ajv-formats --strict=false
-                  if ($LASTEXITCODE -ne 0) {
-                      Write-Error "    Validation FAILED"
-                      $failed = $true
-                  } else {
-                      Write-Host "    Valid" -ForegroundColor Green
-                  }
-              }
-          }
-      }
-      ${{ end }}
+            foreach ($jsonFile in $filesToValidate) {
+                $jsonFile = $jsonFile.Trim()
+                if ($jsonFile -eq '') { continue }
 
-      Write-Host ""
-      Write-Host "=========================================="
-      if ($failed) {
-          Write-Error "One or more validations failed!"
-          exit 1
-      }
+                if (-not (Test-Path $jsonFile)) {
+                    Write-Error "File not found: $jsonFile"
+                    $failed = $true
+                    continue
+                }
 
-      Write-Host "All schema validations passed!" -ForegroundColor Green
+                Write-Host ""
+                Write-Host "  Validating: $jsonFile"
+                ajv validate -s $schemaFile -d $jsonFile --spec=draft2020 -c ajv-formats --strict=false
+                if ($LASTEXITCODE -ne 0) {
+                    Write-Error "    Validation FAILED"
+                    $failed = $true
+                } else {
+                    Write-Host "    Valid" -ForegroundColor Green
+                }
+            }
+        }
+
+        Write-Host ""
+        Write-Host "=========================================="
+        if ($failed) {
+            Write-Error "One or more validations failed!"
+            exit 1
+        }
+
+        Write-Host "Schema validation passed!" -ForegroundColor Green

--- a/eng/ci/templates/steps/validate-schemas.yml
+++ b/eng/ci/templates/steps/validate-schemas.yml
@@ -1,5 +1,6 @@
 parameters:
   # Array of validation sets. Each item contains:
+  #   - name: short display name for the validation step
   #   - schema: path to the JSON schema file
   #   - files: array of JSON file paths to validate (optional)
   #   - pattern: glob pattern to find JSON files (optional)
@@ -10,7 +11,7 @@ parameters:
 steps:
 - ${{ each validation in parameters.validations }}:
   - task: PowerShell@2
-    displayName: 'Validate against ${{ validation.schema }}'
+    displayName: 'Validate ${{ validation.name }}'
     inputs:
       targetType: 'inline'
       script: |


### PR DESCRIPTION
This pull request introduces a new schema validation step to the CI pipeline, ensuring that JSON files such as `manifest.json` conform to their respective schemas before proceeding with builds. The validation is implemented as a reusable template and integrated into the build job.

**Schema validation enhancements:**

* Added a new `validate-schemas.yml` template that validates JSON files against specified schemas using `ajv-cli` and PowerShell, with support for both explicit file lists and glob patterns.
* Integrated the schema validation step into the `build.yml` CI job, specifically validating `manifest.json` against `manifest.schema.json` before running build tasks.