### PR TITLE
bump manifest version to 1.2.0

### DIFF
--- a/Functions.Templates/Template-Manifest/manifest.json
+++ b/Functions.Templates/Template-Manifest/manifest.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./schemas/manifest.schema.json",
-  "generatedAt": "2026-03-16T19:14:27.007Z",
-  "version": "1.1.0",
+  "generatedAt": "2026-03-24T06:33:19.007Z",
+  "version": "1.2.0",
   "totalTemplates": 70,
   "runtimeVersions": {
     "Python": {


### PR DESCRIPTION
This pull request makes a minor update to the `manifest.json` file, incrementing the version number and updating the generated timestamp.

- Bumped the `version` field from `1.1.0` to `1.2.0` and updated the `generatedAt` timestamp in `manifest.json` to reflect the latest build.