### PR TITLE
Granular priority tiers (P00–P99) for template manifest

### DIFF
--- a/Functions.Templates/Template-Manifest/docs/priority-tiers.md
+++ b/Functions.Templates/Template-Manifest/docs/priority-tiers.md
@@ -1,0 +1,238 @@
+# Template Manifest — Priority Tiers (P00–P99)
+
+**Total templates:** 69  
+**Manifest version:** 1.2.0
+
+## Design principles
+
+1. **Priority is the primary sort key.** Lower number = show first.
+2. **5-slot blocks per Azure resource:** `+0` trigger, `+1` input, `+2` output, `+3` variant, `+4` stub.
+3. **10-slot block for MCP:** `+0` Remote Server, `+1` SDK Hosting, `+2` Tool, `+3` Resource, `+4` Prompt, `+5` APIM Gateway.
+4. **Language sort order (secondary):** .NET (C#) → Python → TypeScript → JavaScript → Java → PowerShell.
+   Templates sharing a priority are sorted by this language order by the consumer.
+5. **IaC sort order (tertiary):** ❌ no-IaC → ✅ AZD → 📦 IaC-only.
+   no-IaC = what VS Code Azure Functions extension generates = the familiar baseline.
+6. **Default rule:** New templates without AZD/IaC default to P95–P99.
+
+## Priority block map
+
+| Range | Category | Supported bindings | Slot assignments |
+|---|---|---|---|
+| P00–04 | ⚡ HTTP | Trigger · Output | `P00` Trigger<br>`P01` Input *(N/A)*<br>`P02` Output *(future)*<br>`P03` Variant (Terraform)<br>`P04` Stub |
+| P05–09 | ⏰ Timer | Trigger only | `P05` Trigger |
+| P10–14 | 📦 Blob Storage | Trigger · Input · Output | `P10` Trigger<br>`P11` Input *(future)*<br>`P12` Output *(future)* |
+| P15–19 | 📡 Event Hub | Trigger · Output | `P15` Trigger<br>`P16` Output *(future)* |
+| P20–24 | 📣 Event Grid *(reserved)* | Trigger · Output | `P20` Trigger<br>`P21` Output |
+| P25–29 | 📬 Queue Storage *(reserved)* | Trigger · Output | `P25` Trigger<br>`P26` Output |
+| P30–34 | 🚌 Service Bus *(reserved)* | Trigger · Output | `P30` Trigger<br>`P31` Output |
+| P35–39 | 🌐 Cosmos DB | Trigger · Input · Output | `P35` Trigger<br>`P36` Input *(future)*<br>`P37` Output *(future)* |
+| P40–44 | 🗄️ SQL | Trigger · Input · Output | `P40` Trigger<br>`P41` Input *(future)*<br>`P42` Output *(future)* |
+| P45–49 | 🔴 Redis *(reserved)* | Trigger · Input · Output | `P45` Trigger<br>`P46` Input<br>`P47` Output |
+| P50–59 | 🔌 MCP *(10-slot block)* | Trigger (Tool / Resource / Prompt) | `P50` Remote Server<br>`P51` SDK Hosting<br>`P52` Tool *(future)*<br>`P53` Resource *(future)*<br>`P54` Prompt *(future)*<br>`P55` APIM Gateway<br>`P56` *(reserved)*<br>`P57` *(reserved)*<br>`P58` *(reserved)*<br>`P59` *(reserved)* |
+| P60–64 | 🤖 AI | — | `P60` Agent<br>`P61` ChatGPT<br>`P62` Text Summarize<br>`P63` LangChain |
+| P65–69 | 🔄 Durable Standard | Orchestration | `P65` Orchestration<br>`P66` Order Processor |
+| P70–74 | 🔄 Durable Advanced | Orchestration | `P70` Patterns (saga / tracing / payload)<br>`P71` Scenarios (travel / aspire)<br>`P72` PDF Summarizer |
+| P75–79 | 🤝 Agent Framework | Orchestration | `P75` Multi-Agent |
+| P80–89 | — *(reserved for future categories)* | — | — |
+| P90–94 | 🏗️ IaC | — | `P90` Flex Consumption (ARM / Bicep / TF) |
+| P95–99 | ⚠️ Non-AZD Stubs | — | `P95` Gap-fillers (AZD upgrade planned) |
+
+## Full template listing
+
+Sorted by priority → language order (.NET → Py → TS → JS → Java → PS).
+
+| P | Template ID | Lang | Binding | IaC | Was |
+|--:|---|---|---|---|---|
+| | **⚡ HTTP** | | | | |
+| 0 | `http-trigger-csharp-azd` | .NET | trigger | ✅ bicep | P0 |
+| 0 | `http-trigger-python-azd` | Py | trigger | ✅ bicep | P0 |
+| 0 | `http-trigger-typescript-azd` | TS | trigger | ✅ bicep | P0 |
+| 0 | `http-trigger-javascript-azd` | JS | trigger | ✅ bicep | P0 |
+| 0 | `http-trigger-java-azd` | Java | trigger | ✅ bicep | P0 |
+| 0 | `http-trigger-powershell-azd` | PS | trigger | ✅ bicep | P0 |
+| 3 | `http-trigger-csharp-terraform` | .NET | trigger | 📦 terraform | P0→3 |
+| | **⏰ Timer** | | | | |
+| 5 | `timer-trigger-csharp-azd` | .NET | trigger | ✅ bicep | P0→5 |
+| 5 | `timer-trigger-python-azd` | Py | trigger | ✅ bicep | P0→5 |
+| 5 | `timer-trigger-typescript-azd` | TS | trigger | ✅ bicep | P0→5 |
+| 5 | `timer-trigger-javascript-azd` | JS | trigger | ✅ bicep | P0→5 |
+| 5 | `timer-trigger-java-azd` | Java | trigger | ✅ bicep | P0→5 |
+| 5 | `timer-trigger-powershell-azd` | PS | trigger | ✅ bicep | P0→5 |
+| | **📦 Blob Storage** | | | | |
+| 10 | `blob-eventgrid-trigger-csharp-azd` | .NET | trigger | ✅ bicep | P0→10 |
+| 10 | `blob-eventgrid-trigger-python-azd` | Py | trigger | ✅ bicep | P0→10 |
+| 10 | `blob-eventgrid-trigger-typescript-azd` | TS | trigger | ✅ bicep | P0→10 |
+| 10 | `blob-eventgrid-trigger-javascript-azd` | JS | trigger | ✅ bicep | P0→10 |
+| 10 | `blob-eventgrid-trigger-java-azd` | Java | trigger | ✅ bicep | P0→10 |
+| 10 | `blob-eventgrid-trigger-powershell-azd` | PS | trigger | ✅ bicep | P0→10 |
+| | **📡 Event Hub** | | | | |
+| 15 | `eventhub-trigger-csharp-azd` | .NET | trigger | ✅ bicep | P0→15 |
+| 15 | `eventhub-trigger-python-azd` | Py | trigger | ✅ bicep | P0→15 |
+| 15 | `eventhub-trigger-typescript-azd` | TS | trigger | ✅ bicep | P0→15 |
+| | **🌐 Cosmos DB** | | | | |
+| 35 | `cosmos-trigger-csharp-azd` | .NET | trigger | ✅ bicep | P1→35 |
+| 35 | `cosmos-trigger-python-azd` | Py | trigger | ✅ bicep | P1→35 |
+| 35 | `cosmos-trigger-typescript-azd` | TS | trigger | ✅ bicep | P1→35 |
+| | **🗄️ SQL** | | | | |
+| 40 | `sql-trigger-csharp-azd` | .NET | trigger | ✅ bicep | P1→40 |
+| 40 | `sql-trigger-python-azd` | Py | trigger | ✅ bicep | P1→40 |
+| 40 | `sql-trigger-typescript-azd` | TS | trigger | ✅ bicep | P1→40 |
+| | **🔌 MCP *(10-slot block)*** | | | | |
+| 50 | `mcp-server-remote-csharp` | .NET | trigger | 📦 bicep | P0→50 |
+| 50 | `mcp-server-remote-python` | Py | trigger | 📦 bicep | P0→50 |
+| 50 | `mcp-server-remote-typescript` | TS | trigger | 📦 bicep | P0→50 |
+| 50 | `mcp-server-remote-java` | Java | trigger | 📦 bicep | P0→50 |
+| 51 | `mcp-sdk-hosting-csharp` | .NET | trigger | 📦 bicep | P1→51 |
+| 51 | `mcp-sdk-hosting-python` | Py | trigger | 📦 bicep | P1→51 |
+| 51 | `mcp-sdk-hosting-typescript` | TS | trigger | 📦 bicep | P1→51 |
+| 51 | `mcp-sdk-hosting-java` | Java | trigger | 📦 bicep | P1→51 |
+| 55 | `mcp-server-apim-python` | Py | trigger | 📦 bicep | P2→55 |
+| | **🤖 AI** | | | | |
+| 60 | `ai-agent-csharp` | .NET | trigger | 📦 bicep | P0→60 |
+| 60 | `ai-agent-python` | Py | trigger | 📦 bicep | P0→60 |
+| 60 | `ai-agent-typescript` | TS | trigger | 📦 bicep | P0→60 |
+| 60 | `ai-agent-java` | Java | trigger | 📦 bicep | P0→60 |
+| 61 | `ai-chatgpt-python` | Py | trigger | 📦 bicep | P1→61 |
+| 61 | `ai-chatgpt-javascript` | JS | trigger | 📦 bicep | P1→61 |
+| 62 | `ai-textsummarize-csharp` | .NET | trigger | 📦 bicep | P2→62 |
+| 62 | `ai-textsummarize-python` | Py | trigger | 📦 bicep | P2→62 |
+| 63 | `ai-langchain-python` | Py | trigger | 📦 bicep | P2→63 |
+| | **🔄 Durable Standard** | | | | |
+| 65 | `durable-orchestration-csharp` | .NET | orchestration | ❌ none | P1→65 |
+| 65 | `durable-orchestration-python` | Py | orchestration | ❌ none | P1→65 |
+| 65 | `durable-orchestration-typescript` | TS | orchestration | ❌ none | P1→65 |
+| 65 | `durable-orchestration-javascript` | JS | orchestration | ❌ none | P1→65 |
+| 65 | `durable-orchestration-java` | Java | orchestration | ❌ none | P1→65 |
+| 66 | `durable-order-processor-csharp` | .NET | orchestration | 📦 bicep | P1→66 |
+| 66 | `durable-order-processor-python` | Py | orchestration | 📦 bicep | P1→66 |
+| | **🔄 Durable Advanced** | | | | |
+| 70 | `durable-distributed-tracing-csharp` | .NET | orchestration | ❌ none | P1→70 |
+| 70 | `durable-large-payload-csharp` | .NET | orchestration | ❌ none | P1→70 |
+| 70 | `durable-saga-csharp` | .NET | orchestration | ❌ none | P1→70 |
+| 71 | `durable-ai-travel-planner-csharp` | .NET | orchestration | ❌ none | P2→71 |
+| 71 | `durable-aspire-csharp` | .NET | orchestration | ❌ none | P2→71 |
+| 72 | `durable-pdf-summarizer-csharp` | .NET | orchestration | ❌ none | P2→72 |
+| 72 | `durable-pdf-summarizer-python` | Py | orchestration | ❌ none | P2→72 |
+| | **🤝 Agent Framework** | | | | |
+| 75 | `agentframework-durable-multi-agent-python` | Py | orchestration | ❌ none | P1→75 |
+| | **🏗️ IaC** | | | | |
+| 90 | `iac-flex-consumption-arm` | ARM | none | 📦 arm | P2→90 |
+| 90 | `iac-flex-consumption-bicep` | Bicep | none | 📦 bicep | P2→90 |
+| 90 | `iac-flex-consumption-terraform-azapi` | TF | none | 📦 terraform | P2→90 |
+| 90 | `iac-flex-consumption-terraform-azurerm` | TF | none | 📦 terraform | P2→90 |
+| | **⚠️ Non-AZD Stubs** | | | | |
+| 95 | `cosmos-input-java` | Java | input | ❌ none | P1→95 |
+| 95 | `cosmos-output-java` | Java | output | ❌ none | P1→95 |
+| 95 | `cosmos-trigger-java` | Java | trigger | ❌ none | P1→95 |
+| 95 | `eventhub-trigger-java` | Java | trigger | ❌ none | P0→95 |
+
+## Coverage matrix
+
+### Azure resource templates (P00–P44)
+
+| Resource | Binding | .NET | Py | TS | JS | Java | PS | Gaps |
+|---|---|---|---|---|---|---|---|---|
+| HTTP | Trigger | 📦 | ✅ | ✅ | ✅ | ✅ | ✅ | — |
+| Timer | Trigger | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | — |
+| Blob | Trigger | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | — |
+| | Input | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | *no templates yet* |
+| | Output | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | *no templates yet* |
+|  | Input | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | *no templates yet* |
+|  | Output | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | *no templates yet* |
+| Event Hub | Trigger | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | JS, Java, PS |
+| | Output | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | *no templates yet* |
+|  | Output | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | *no templates yet* |
+| Event Grid | *(reserved)* | — | — | — | — | — | — | no templates yet |
+| Queue | *(reserved)* | — | — | — | — | — | — | no templates yet |
+| Service Bus | *(reserved)* | — | — | — | — | — | — | no templates yet |
+| Cosmos DB | Trigger | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | JS, Java, PS |
+| | Input | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | *no templates yet* |
+| | Output | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | *no templates yet* |
+|  | Input | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | *no templates yet* |
+|  | Output | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | *no templates yet* |
+| SQL | Trigger | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | JS, Java, PS |
+| | Input | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | *no templates yet* |
+| | Output | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | *no templates yet* |
+|  | Input | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | *no templates yet* |
+|  | Output | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | *no templates yet* |
+| Redis | *(reserved)* | — | — | — | — | — | — | no templates yet |
+
+### MCP templates (P50–P59)
+
+| Sub-type | P | .NET | Py | TS | JS | Java | PS | Gaps |
+|---|---|---|---|---|---|---|---|---|
+| Remote Server | P50 | 📦 | 📦 | 📦 | ❌ | 📦 | ❌ | JS, PS |
+| SDK Hosting | P51 | 📦 | 📦 | 📦 | ❌ | 📦 | ❌ | JS, PS |
+| Tool *(future)* | P52 | — | — | — | — | — | — | *not yet created* |
+| Resource *(future)* | P53 | — | — | — | — | — | — | *not yet created* |
+| Prompt *(future)* | P54 | — | — | — | — | — | — | *not yet created* |
+| APIM Gateway | P55 | ❌ | 📦 | ❌ | ❌ | ❌ | ❌ | .NET, TS, JS, Java, PS |
+
+### AI · Durable · Agent Framework (P60–P79)
+
+| Category | Sub-type | P | .NET | Py | TS | JS | Java | PS | Gaps |
+|---|---|---|---|---|---|---|---|---|---|
+| AI | Agent | P60 | 📦 | 📦 | 📦 | ❌ | 📦 | ❌ | JS, PS |
+|  | ChatGPT | P61 | ❌ | 📦 | ❌ | 📦 | ❌ | ❌ | .NET, TS, Java, PS |
+|  | Text Summarize | P62 | 📦 | 📦 | ❌ | ❌ | ❌ | ❌ | TS, JS, Java, PS |
+|  | LangChain | P63 | ❌ | 📦 | ❌ | ❌ | ❌ | ❌ | .NET, TS, JS, Java, PS |
+| Durable | Orchestration | P65 | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ⚠️ | ❌ | PS |
+|  | Order Processor | P66 | 📦 | 📦 | ❌ | ❌ | ❌ | ❌ | TS, JS, Java, PS |
+|  | Patterns | P70 | ⚠️ | ❌ | ❌ | ❌ | ❌ | ❌ | Py, TS, JS, Java, PS |
+|  | Advanced | P71 | ⚠️ | ❌ | ❌ | ❌ | ❌ | ❌ | Py, TS, JS, Java, PS |
+|  | PDF Summarizer | P72 | ⚠️ | ⚠️ | ❌ | ❌ | ❌ | ❌ | TS, JS, Java, PS |
+| Agent Fw | Multi-Agent | P75 | ❌ | ⚠️ | ❌ | ❌ | ❌ | ❌ | .NET, TS, JS, Java, PS |
+
+## Summary
+
+| P | Slot label | Templates |
+|--:|---|--:|
+| 00 | ⚡ HTTP — Trigger | 6 |
+| 03 | ⚡ HTTP — Variant (Terraform) | 1 |
+| 05 | ⏰ Timer — Trigger | 6 |
+| 10 | 📦 Blob Storage — Trigger | 6 |
+| 15 | 📡 Event Hub — Trigger | 3 |
+| 35 | 🌐 Cosmos DB — Trigger | 3 |
+| 40 | 🗄️ SQL — Trigger | 3 |
+| 50 | 🔌 MCP — Remote Server | 4 |
+| 51 | 🔌 MCP — SDK Hosting | 4 |
+| 55 | 🔌 MCP — APIM Gateway | 1 |
+| 60 | 🤖 AI — Agent | 4 |
+| 61 | 🤖 AI — ChatGPT | 2 |
+| 62 | 🤖 AI — Text Summarize | 2 |
+| 63 | 🤖 AI — LangChain | 1 |
+| 65 | 🔄 Durable Standard — Orchestration | 5 |
+| 66 | 🔄 Durable Standard — Order Processor | 2 |
+| 70 | 🔄 Durable Advanced — Patterns (saga / tracing / payload) | 3 |
+| 71 | 🔄 Durable Advanced — Scenarios (travel / aspire) | 2 |
+| 72 | 🔄 Durable Advanced — PDF Summarizer | 2 |
+| 75 | 🤝 Agent Framework — Multi-Agent | 1 |
+| 90 | 🏗️ IaC — Flex Consumption (ARM / Bicep / TF) | 4 |
+| 95 | ⚠️ Non-AZD Stubs — Gap-fillers (AZD upgrade planned) | 4 |
+| | **Total** | **69** |
+
+## Language sort order
+
+When templates share the same priority, sort by:
+
+| Rank | Language | Rationale |
+|---|---|---|
+| 1 | .NET (C#) | Primary SDK, largest Azure Functions user base |
+| 2 | Python | Fastest-growing, AI/ML use cases |
+| 3 | TypeScript | Modern JS with types |
+| 4 | JavaScript | Broad web developer reach |
+| 5 | Java | Enterprise |
+| 6 | PowerShell | IT automation / scripting |
+
+## Schema change required
+
+```json
+// manifest.schema.json — update priority field:
+"priority": {
+  "type": "integer",
+  "minimum": 0,
+  "maximum": 99,
+  "description": "Priority for sorting. 5-slot blocks per Azure resource (+0 trigger, +1 input, +2 output, +3 variant). 10-slot block for MCP (+0 remote, +1 sdk, +2 tool, +3 resource, +4 prompt, +5 apim). See docs/priority-tiers.md."
+}
+```
+___BEGIN___COMMAND_DONE_MARKER___0

--- a/Functions.Templates/Template-Manifest/manifest.json
+++ b/Functions.Templates/Template-Manifest/manifest.json
@@ -986,7 +986,7 @@
         "VS Code mcp.json configuration",
         "MCP Inspector support"
       ],
-      "isPopular": true
+      "isHighlighted": true
     },
     {
       "id": "mcp-server-remote-python",
@@ -1020,7 +1020,7 @@
         "VS Code mcp.json configuration",
         "MCP Inspector support"
       ],
-      "isPopular": true
+      "isHighlighted": true
     },
     {
       "id": "mcp-server-remote-typescript",
@@ -1055,7 +1055,7 @@
         "VS Code mcp.json configuration",
         "MCP Inspector support"
       ],
-      "isPopular": true
+      "isHighlighted": true
     },
     {
       "id": "mcp-server-remote-java",
@@ -1090,7 +1090,7 @@
         "VS Code mcp.json configuration",
         "MCP Inspector support"
       ],
-      "isPopular": true
+      "isHighlighted": true
     },
     {
       "id": "mcp-sdk-hosting-csharp",
@@ -1120,7 +1120,7 @@
         "Azure Functions hosting",
         "Bicep infrastructure"
       ],
-      "isPopular": true
+      "isHighlighted": true
     },
     {
       "id": "mcp-sdk-hosting-python",
@@ -1150,7 +1150,7 @@
         "Azure Functions hosting",
         "Bicep infrastructure"
       ],
-      "isPopular": true
+      "isHighlighted": true
     },
     {
       "id": "mcp-sdk-hosting-typescript",
@@ -1180,7 +1180,7 @@
         "Azure Functions hosting",
         "Bicep infrastructure"
       ],
-      "isPopular": true
+      "isHighlighted": true
     },
     {
       "id": "mcp-sdk-hosting-java",
@@ -1210,7 +1210,7 @@
         "Azure Functions hosting",
         "Bicep infrastructure"
       ],
-      "isPopular": true
+      "isHighlighted": true
     },
     {
       "id": "mcp-server-apim-python",
@@ -1244,7 +1244,7 @@
         "OAuth support",
         "Bicep infrastructure"
       ],
-      "isPopular": true
+      "isHighlighted": true
     },
     {
       "id": "ai-agent-csharp",

--- a/Functions.Templates/Template-Manifest/manifest.json
+++ b/Functions.Templates/Template-Manifest/manifest.json
@@ -112,133 +112,6 @@
       ]
     },
     {
-      "id": "http-trigger-csharp-terraform",
-      "displayName": "HTTP Trigger (C# + AZD + Terraform)",
-      "shortDescription": "HttpTrigger (GET/POST) C# function on Flex Consumption with managed identity, VNet, deployed via azd+Terraform",
-      "longDescription": "C# Azure Function with an HttpTrigger accepting GET and POST requests. Runs on Flex Consumption plan with managed identity authentication and VNet integration. Infrastructure provisioned with Terraform and deployed with azd.",
-      "language": "CSharp",
-      "bindingType": "trigger",
-      "resource": "http",
-      "iac": "terraform",
-      "priority": 0,
-      "categories": [
-        "web-apis"
-      ],
-      "tags": [
-        "HTTP",
-        "Flex Consumption",
-        "VNET",
-        "Managed Identity",
-        "Terraform",
-        "Azd"
-      ],
-      "author": "Azure Functions Team",
-      "repositoryUrl": "https://github.com/Azure-Samples/functions-quickstart-dotnet-azd-tf",
-      "folderPath": ".",
-      "whatsIncluded": [
-        "HTTP trigger functions (GET and POST)",
-        "Terraform infrastructure files (AzureRM 4.x)",
-        "Azure Developer CLI (azd) configuration",
-        "VS Code debug configuration",
-        "Test files for local development"
-      ]
-    },
-    {
-      "id": "http-trigger-java-azd",
-      "displayName": "HTTP Trigger (Java + AZD + Bicep)",
-      "shortDescription": "HttpTrigger Java function on Flex Consumption with managed identity, VNet, deployed via azd+Bicep",
-      "longDescription": "Java Azure Function with an HttpTrigger. Runs on Flex Consumption plan with managed identity authentication and VNet integration for secure networking. Infrastructure provisioned with Bicep and deployed with azd.",
-      "language": "Java",
-      "bindingType": "trigger",
-      "resource": "http",
-      "iac": "bicep",
-      "priority": 0,
-      "categories": [
-        "web-apis"
-      ],
-      "tags": [
-        "HTTP",
-        "Flex Consumption",
-        "VNET",
-        "Managed Identity",
-        "Azd"
-      ],
-      "author": "Azure Functions Team",
-      "repositoryUrl": "https://github.com/Azure-Samples/azure-functions-java-flex-consumption-azd",
-      "folderPath": ".",
-      "whatsIncluded": [
-        "HTTP trigger functions",
-        "Bicep infrastructure files",
-        "Azure Developer CLI (azd) configuration",
-        "Maven build configuration",
-        "VS Code debug configuration",
-        "Test files for local development"
-      ]
-    },
-    {
-      "id": "http-trigger-javascript-azd",
-      "displayName": "HTTP Trigger (JavaScript + AZD + Bicep)",
-      "shortDescription": "HttpTrigger JavaScript function on Flex Consumption with managed identity, VNet, deployed via azd+Bicep",
-      "longDescription": "JavaScript Azure Function with an HttpTrigger. Runs on Flex Consumption plan with managed identity authentication and VNet integration for secure networking. Infrastructure provisioned with Bicep and deployed with azd.",
-      "language": "JavaScript",
-      "bindingType": "trigger",
-      "resource": "http",
-      "iac": "bicep",
-      "priority": 0,
-      "categories": [
-        "web-apis"
-      ],
-      "tags": [
-        "HTTP",
-        "Flex Consumption",
-        "VNET",
-        "Managed Identity",
-        "Azd"
-      ],
-      "author": "Azure Functions Team",
-      "repositoryUrl": "https://github.com/Azure-Samples/functions-quickstart-javascript-azd",
-      "folderPath": ".",
-      "whatsIncluded": [
-        "HTTP trigger functions (GET and POST)",
-        "Bicep infrastructure files",
-        "Azure Developer CLI (azd) configuration",
-        "VS Code debug configuration",
-        "Dev Container setup",
-        "Test files for local development"
-      ]
-    },
-    {
-      "id": "http-trigger-powershell-azd",
-      "displayName": "HTTP Trigger (PowerShell + AZD + Bicep)",
-      "shortDescription": "HttpTrigger PowerShell function on Flex Consumption with managed identity, VNet, deployed via azd+Bicep",
-      "longDescription": "PowerShell Azure Function with an HttpTrigger. Runs on Flex Consumption plan with managed identity authentication and VNet integration for secure networking. Infrastructure provisioned with Bicep and deployed with azd.",
-      "language": "PowerShell",
-      "bindingType": "trigger",
-      "resource": "http",
-      "iac": "bicep",
-      "priority": 0,
-      "categories": [
-        "web-apis"
-      ],
-      "tags": [
-        "HTTP",
-        "Flex Consumption",
-        "VNET",
-        "Managed Identity",
-        "Azd"
-      ],
-      "author": "Azure Functions Team",
-      "repositoryUrl": "https://github.com/Azure-Samples/functions-quickstart-powershell-azd",
-      "folderPath": ".",
-      "whatsIncluded": [
-        "HTTP trigger functions",
-        "Bicep infrastructure files",
-        "Azure Developer CLI (azd) configuration",
-        "VS Code debug configuration",
-        "Test files for local development"
-      ]
-    },
-    {
       "id": "http-trigger-python-azd",
       "displayName": "HTTP Trigger (Python + AZD + Bicep)",
       "shortDescription": "HttpTrigger Python function on Flex Consumption with managed identity, VNet, deployed via azd+Bicep",
@@ -303,6 +176,133 @@
       ]
     },
     {
+      "id": "http-trigger-javascript-azd",
+      "displayName": "HTTP Trigger (JavaScript + AZD + Bicep)",
+      "shortDescription": "HttpTrigger JavaScript function on Flex Consumption with managed identity, VNet, deployed via azd+Bicep",
+      "longDescription": "JavaScript Azure Function with an HttpTrigger. Runs on Flex Consumption plan with managed identity authentication and VNet integration for secure networking. Infrastructure provisioned with Bicep and deployed with azd.",
+      "language": "JavaScript",
+      "bindingType": "trigger",
+      "resource": "http",
+      "iac": "bicep",
+      "priority": 0,
+      "categories": [
+        "web-apis"
+      ],
+      "tags": [
+        "HTTP",
+        "Flex Consumption",
+        "VNET",
+        "Managed Identity",
+        "Azd"
+      ],
+      "author": "Azure Functions Team",
+      "repositoryUrl": "https://github.com/Azure-Samples/functions-quickstart-javascript-azd",
+      "folderPath": ".",
+      "whatsIncluded": [
+        "HTTP trigger functions (GET and POST)",
+        "Bicep infrastructure files",
+        "Azure Developer CLI (azd) configuration",
+        "VS Code debug configuration",
+        "Dev Container setup",
+        "Test files for local development"
+      ]
+    },
+    {
+      "id": "http-trigger-java-azd",
+      "displayName": "HTTP Trigger (Java + AZD + Bicep)",
+      "shortDescription": "HttpTrigger Java function on Flex Consumption with managed identity, VNet, deployed via azd+Bicep",
+      "longDescription": "Java Azure Function with an HttpTrigger. Runs on Flex Consumption plan with managed identity authentication and VNet integration for secure networking. Infrastructure provisioned with Bicep and deployed with azd.",
+      "language": "Java",
+      "bindingType": "trigger",
+      "resource": "http",
+      "iac": "bicep",
+      "priority": 0,
+      "categories": [
+        "web-apis"
+      ],
+      "tags": [
+        "HTTP",
+        "Flex Consumption",
+        "VNET",
+        "Managed Identity",
+        "Azd"
+      ],
+      "author": "Azure Functions Team",
+      "repositoryUrl": "https://github.com/Azure-Samples/azure-functions-java-flex-consumption-azd",
+      "folderPath": ".",
+      "whatsIncluded": [
+        "HTTP trigger functions",
+        "Bicep infrastructure files",
+        "Azure Developer CLI (azd) configuration",
+        "Maven build configuration",
+        "VS Code debug configuration",
+        "Test files for local development"
+      ]
+    },
+    {
+      "id": "http-trigger-powershell-azd",
+      "displayName": "HTTP Trigger (PowerShell + AZD + Bicep)",
+      "shortDescription": "HttpTrigger PowerShell function on Flex Consumption with managed identity, VNet, deployed via azd+Bicep",
+      "longDescription": "PowerShell Azure Function with an HttpTrigger. Runs on Flex Consumption plan with managed identity authentication and VNet integration for secure networking. Infrastructure provisioned with Bicep and deployed with azd.",
+      "language": "PowerShell",
+      "bindingType": "trigger",
+      "resource": "http",
+      "iac": "bicep",
+      "priority": 0,
+      "categories": [
+        "web-apis"
+      ],
+      "tags": [
+        "HTTP",
+        "Flex Consumption",
+        "VNET",
+        "Managed Identity",
+        "Azd"
+      ],
+      "author": "Azure Functions Team",
+      "repositoryUrl": "https://github.com/Azure-Samples/functions-quickstart-powershell-azd",
+      "folderPath": ".",
+      "whatsIncluded": [
+        "HTTP trigger functions",
+        "Bicep infrastructure files",
+        "Azure Developer CLI (azd) configuration",
+        "VS Code debug configuration",
+        "Test files for local development"
+      ]
+    },
+    {
+      "id": "http-trigger-csharp-terraform",
+      "displayName": "HTTP Trigger (C# + AZD + Terraform)",
+      "shortDescription": "HttpTrigger (GET/POST) C# function on Flex Consumption with managed identity, VNet, deployed via azd+Terraform",
+      "longDescription": "C# Azure Function with an HttpTrigger accepting GET and POST requests. Runs on Flex Consumption plan with managed identity authentication and VNet integration. Infrastructure provisioned with Terraform and deployed with azd.",
+      "language": "CSharp",
+      "bindingType": "trigger",
+      "resource": "http",
+      "iac": "terraform",
+      "priority": 3,
+      "categories": [
+        "web-apis"
+      ],
+      "tags": [
+        "HTTP",
+        "Flex Consumption",
+        "VNET",
+        "Managed Identity",
+        "Terraform",
+        "Azd"
+      ],
+      "author": "Azure Functions Team",
+      "repositoryUrl": "https://github.com/Azure-Samples/functions-quickstart-dotnet-azd-tf",
+      "folderPath": ".",
+      "whatsIncluded": [
+        "HTTP trigger functions (GET and POST)",
+        "Terraform infrastructure files (AzureRM 4.x)",
+        "Azure Developer CLI (azd) configuration",
+        "VS Code debug configuration",
+        "Test files for local development"
+      ]
+    },
+    {
       "id": "timer-trigger-csharp-azd",
       "displayName": "Timer Trigger (C# + AZD + Bicep)",
       "shortDescription": "TimerTrigger C# function with configurable cron schedule on Flex Consumption, deployed via azd",
@@ -311,7 +311,7 @@
       "bindingType": "trigger",
       "resource": "timer",
       "iac": "bicep",
-      "priority": 0,
+      "priority": 5,
       "categories": [
         "starter",
         "scheduling"
@@ -335,102 +335,6 @@
       ]
     },
     {
-      "id": "timer-trigger-java-azd",
-      "displayName": "Timer Trigger (Java + AZD + Bicep)",
-      "shortDescription": "TimerTrigger Java function with configurable cron schedule on Flex Consumption, deployed via azd",
-      "longDescription": "Java Azure Function with a TimerTrigger that executes on a configurable cron schedule. Runs on Flex Consumption plan. Deployed with azd.",
-      "language": "Java",
-      "bindingType": "trigger",
-      "resource": "timer",
-      "iac": "bicep",
-      "priority": 0,
-      "categories": [
-        "starter",
-        "scheduling"
-      ],
-      "tags": [
-        "Timer",
-        "Scheduled",
-        "Cron",
-        "Flex Consumption",
-        "AZD"
-      ],
-      "author": "Azure Functions Team",
-      "repositoryUrl": "https://github.com/Azure-Samples/functions-quickstart-java-azd-timer",
-      "folderPath": ".",
-      "whatsIncluded": [
-        "Timer trigger function",
-        "Configurable NCRONTAB schedule",
-        "Bicep infrastructure",
-        "azd configuration",
-        "VNet integration option"
-      ]
-    },
-    {
-      "id": "timer-trigger-javascript-azd",
-      "displayName": "Timer Trigger (JavaScript + AZD + Bicep)",
-      "shortDescription": "TimerTrigger JavaScript function with configurable cron schedule on Flex Consumption, deployed via azd",
-      "longDescription": "JavaScript Azure Function with a TimerTrigger that executes on a configurable cron schedule. Runs on Flex Consumption plan. Deployed with azd.",
-      "language": "JavaScript",
-      "bindingType": "trigger",
-      "resource": "timer",
-      "iac": "bicep",
-      "priority": 0,
-      "categories": [
-        "starter",
-        "scheduling"
-      ],
-      "tags": [
-        "Timer",
-        "Scheduled",
-        "Cron",
-        "Flex Consumption",
-        "AZD"
-      ],
-      "author": "Azure Functions Team",
-      "repositoryUrl": "https://github.com/Azure-Samples/functions-quickstart-javascript-azd-timer",
-      "folderPath": ".",
-      "whatsIncluded": [
-        "Timer trigger function",
-        "Configurable NCRONTAB schedule",
-        "Bicep infrastructure",
-        "azd configuration",
-        "VNet integration option"
-      ]
-    },
-    {
-      "id": "timer-trigger-powershell-azd",
-      "displayName": "Timer Trigger (PowerShell + AZD + Bicep)",
-      "shortDescription": "TimerTrigger PowerShell function with configurable cron schedule on Flex Consumption, deployed via azd",
-      "longDescription": "PowerShell Azure Function with a TimerTrigger that executes on a configurable cron schedule. Runs on Flex Consumption plan. Deployed with azd.",
-      "language": "PowerShell",
-      "bindingType": "trigger",
-      "resource": "timer",
-      "iac": "bicep",
-      "priority": 0,
-      "categories": [
-        "starter",
-        "scheduling"
-      ],
-      "tags": [
-        "Timer",
-        "Scheduled",
-        "Cron",
-        "Flex Consumption",
-        "AZD"
-      ],
-      "author": "Azure Functions Team",
-      "repositoryUrl": "https://github.com/Azure-Samples/functions-quickstart-powershell-azd-timer",
-      "folderPath": ".",
-      "whatsIncluded": [
-        "Timer trigger function",
-        "Configurable NCRONTAB schedule",
-        "Bicep infrastructure",
-        "azd configuration",
-        "VNet integration option"
-      ]
-    },
-    {
       "id": "timer-trigger-python-azd",
       "displayName": "Timer Trigger (Python + AZD + Bicep)",
       "shortDescription": "TimerTrigger Python function with configurable cron schedule on Flex Consumption, deployed via azd",
@@ -439,7 +343,7 @@
       "bindingType": "trigger",
       "resource": "timer",
       "iac": "bicep",
-      "priority": 0,
+      "priority": 5,
       "categories": [
         "starter",
         "scheduling"
@@ -471,7 +375,7 @@
       "bindingType": "trigger",
       "resource": "timer",
       "iac": "bicep",
-      "priority": 0,
+      "priority": 5,
       "categories": [
         "starter",
         "scheduling"
@@ -495,6 +399,102 @@
       ]
     },
     {
+      "id": "timer-trigger-javascript-azd",
+      "displayName": "Timer Trigger (JavaScript + AZD + Bicep)",
+      "shortDescription": "TimerTrigger JavaScript function with configurable cron schedule on Flex Consumption, deployed via azd",
+      "longDescription": "JavaScript Azure Function with a TimerTrigger that executes on a configurable cron schedule. Runs on Flex Consumption plan. Deployed with azd.",
+      "language": "JavaScript",
+      "bindingType": "trigger",
+      "resource": "timer",
+      "iac": "bicep",
+      "priority": 5,
+      "categories": [
+        "starter",
+        "scheduling"
+      ],
+      "tags": [
+        "Timer",
+        "Scheduled",
+        "Cron",
+        "Flex Consumption",
+        "AZD"
+      ],
+      "author": "Azure Functions Team",
+      "repositoryUrl": "https://github.com/Azure-Samples/functions-quickstart-javascript-azd-timer",
+      "folderPath": ".",
+      "whatsIncluded": [
+        "Timer trigger function",
+        "Configurable NCRONTAB schedule",
+        "Bicep infrastructure",
+        "azd configuration",
+        "VNet integration option"
+      ]
+    },
+    {
+      "id": "timer-trigger-java-azd",
+      "displayName": "Timer Trigger (Java + AZD + Bicep)",
+      "shortDescription": "TimerTrigger Java function with configurable cron schedule on Flex Consumption, deployed via azd",
+      "longDescription": "Java Azure Function with a TimerTrigger that executes on a configurable cron schedule. Runs on Flex Consumption plan. Deployed with azd.",
+      "language": "Java",
+      "bindingType": "trigger",
+      "resource": "timer",
+      "iac": "bicep",
+      "priority": 5,
+      "categories": [
+        "starter",
+        "scheduling"
+      ],
+      "tags": [
+        "Timer",
+        "Scheduled",
+        "Cron",
+        "Flex Consumption",
+        "AZD"
+      ],
+      "author": "Azure Functions Team",
+      "repositoryUrl": "https://github.com/Azure-Samples/functions-quickstart-java-azd-timer",
+      "folderPath": ".",
+      "whatsIncluded": [
+        "Timer trigger function",
+        "Configurable NCRONTAB schedule",
+        "Bicep infrastructure",
+        "azd configuration",
+        "VNet integration option"
+      ]
+    },
+    {
+      "id": "timer-trigger-powershell-azd",
+      "displayName": "Timer Trigger (PowerShell + AZD + Bicep)",
+      "shortDescription": "TimerTrigger PowerShell function with configurable cron schedule on Flex Consumption, deployed via azd",
+      "longDescription": "PowerShell Azure Function with a TimerTrigger that executes on a configurable cron schedule. Runs on Flex Consumption plan. Deployed with azd.",
+      "language": "PowerShell",
+      "bindingType": "trigger",
+      "resource": "timer",
+      "iac": "bicep",
+      "priority": 5,
+      "categories": [
+        "starter",
+        "scheduling"
+      ],
+      "tags": [
+        "Timer",
+        "Scheduled",
+        "Cron",
+        "Flex Consumption",
+        "AZD"
+      ],
+      "author": "Azure Functions Team",
+      "repositoryUrl": "https://github.com/Azure-Samples/functions-quickstart-powershell-azd-timer",
+      "folderPath": ".",
+      "whatsIncluded": [
+        "Timer trigger function",
+        "Configurable NCRONTAB schedule",
+        "Bicep infrastructure",
+        "azd configuration",
+        "VNet integration option"
+      ]
+    },
+    {
       "id": "blob-eventgrid-trigger-csharp-azd",
       "displayName": "Blob EventGrid Trigger (C# + AZD + Bicep)",
       "shortDescription": "BlobTrigger (EventGrid source) with BlobInput binding for C#. Processes blob content like PDFs/images, deployed via azd",
@@ -503,7 +503,7 @@
       "bindingType": "trigger",
       "resource": "blob",
       "iac": "bicep",
-      "priority": 0,
+      "priority": 10,
       "categories": [
         "data-processing"
       ],
@@ -525,96 +525,6 @@
       ]
     },
     {
-      "id": "blob-eventgrid-trigger-java-azd",
-      "displayName": "Blob EventGrid Trigger (Java + AZD + Bicep)",
-      "shortDescription": "BlobTrigger (EventGrid source) with BlobOutput binding for Java. Writes processed results back to blob storage, deployed via azd",
-      "longDescription": "Java Azure Function with a BlobTrigger using EventGrid as the event source and a BlobOutput binding to write results back to Azure Blob Storage. Deployed with azd.",
-      "language": "Java",
-      "bindingType": "trigger",
-      "resource": "blob",
-      "iac": "bicep",
-      "priority": 0,
-      "categories": [
-        "data-processing"
-      ],
-      "tags": [
-        "Blob",
-        "Event Grid",
-        "Storage",
-        "Flex Consumption",
-        "AZD"
-      ],
-      "author": "Azure Functions Team",
-      "repositoryUrl": "https://github.com/Azure-Samples/functions-quickstart-java-azd-eventgrid-blob",
-      "folderPath": ".",
-      "whatsIncluded": [
-        "Blob EventGrid trigger function",
-        "Bicep infrastructure",
-        "azd configuration",
-        "VNet integration option"
-      ]
-    },
-    {
-      "id": "blob-eventgrid-trigger-javascript-azd",
-      "displayName": "Blob EventGrid Trigger (JavaScript + AZD + Bicep)",
-      "shortDescription": "BlobTrigger (EventGrid source) with BlobInput binding for JavaScript. Reads blob content for processing, deployed via azd",
-      "longDescription": "JavaScript Azure Function with a BlobTrigger using EventGrid as the event source and a BlobInput binding to read blob content from Azure Blob Storage. Deployed with azd.",
-      "language": "JavaScript",
-      "bindingType": "trigger",
-      "resource": "blob",
-      "iac": "bicep",
-      "priority": 0,
-      "categories": [
-        "data-processing"
-      ],
-      "tags": [
-        "Blob",
-        "Event Grid",
-        "Storage",
-        "Flex Consumption",
-        "AZD"
-      ],
-      "author": "Azure Functions Team",
-      "repositoryUrl": "https://github.com/Azure-Samples/functions-quickstart-javascript-azd-eventgrid-blob",
-      "folderPath": ".",
-      "whatsIncluded": [
-        "Blob EventGrid trigger function",
-        "Bicep infrastructure",
-        "azd configuration",
-        "VNet integration option"
-      ]
-    },
-    {
-      "id": "blob-eventgrid-trigger-powershell-azd",
-      "displayName": "Blob EventGrid Trigger (PowerShell + AZD + Bicep)",
-      "shortDescription": "BlobTrigger (EventGrid source) PowerShell function for processing blobs from Azure Blob Storage, deployed via azd",
-      "longDescription": "PowerShell Azure Function with a BlobTrigger using EventGrid as the event source. Processes blobs from Azure Blob Storage when new or updated blobs are detected. Deployed with azd.",
-      "language": "PowerShell",
-      "bindingType": "trigger",
-      "resource": "blob",
-      "iac": "bicep",
-      "priority": 0,
-      "categories": [
-        "data-processing"
-      ],
-      "tags": [
-        "Blob",
-        "Event Grid",
-        "Storage",
-        "Flex Consumption",
-        "AZD"
-      ],
-      "author": "Azure Functions Team",
-      "repositoryUrl": "https://github.com/Azure-Samples/functions-quickstart-powershell-azd-eventgrid-blob",
-      "folderPath": ".",
-      "whatsIncluded": [
-        "Blob EventGrid trigger function",
-        "Bicep infrastructure",
-        "azd configuration",
-        "VNet integration option"
-      ]
-    },
-    {
       "id": "blob-eventgrid-trigger-python-azd",
       "displayName": "Blob EventGrid Trigger (Python + AZD + Bicep)",
       "shortDescription": "BlobTrigger (EventGrid source) with BlobInput binding for Python. Reads blob content for processing, deployed via azd",
@@ -623,7 +533,7 @@
       "bindingType": "trigger",
       "resource": "blob",
       "iac": "bicep",
-      "priority": 0,
+      "priority": 10,
       "categories": [
         "data-processing"
       ],
@@ -653,7 +563,7 @@
       "bindingType": "trigger",
       "resource": "blob",
       "iac": "bicep",
-      "priority": 0,
+      "priority": 10,
       "categories": [
         "data-processing"
       ],
@@ -675,6 +585,96 @@
       ]
     },
     {
+      "id": "blob-eventgrid-trigger-javascript-azd",
+      "displayName": "Blob EventGrid Trigger (JavaScript + AZD + Bicep)",
+      "shortDescription": "BlobTrigger (EventGrid source) with BlobInput binding for JavaScript. Reads blob content for processing, deployed via azd",
+      "longDescription": "JavaScript Azure Function with a BlobTrigger using EventGrid as the event source and a BlobInput binding to read blob content from Azure Blob Storage. Deployed with azd.",
+      "language": "JavaScript",
+      "bindingType": "trigger",
+      "resource": "blob",
+      "iac": "bicep",
+      "priority": 10,
+      "categories": [
+        "data-processing"
+      ],
+      "tags": [
+        "Blob",
+        "Event Grid",
+        "Storage",
+        "Flex Consumption",
+        "AZD"
+      ],
+      "author": "Azure Functions Team",
+      "repositoryUrl": "https://github.com/Azure-Samples/functions-quickstart-javascript-azd-eventgrid-blob",
+      "folderPath": ".",
+      "whatsIncluded": [
+        "Blob EventGrid trigger function",
+        "Bicep infrastructure",
+        "azd configuration",
+        "VNet integration option"
+      ]
+    },
+    {
+      "id": "blob-eventgrid-trigger-java-azd",
+      "displayName": "Blob EventGrid Trigger (Java + AZD + Bicep)",
+      "shortDescription": "BlobTrigger (EventGrid source) with BlobOutput binding for Java. Writes processed results back to blob storage, deployed via azd",
+      "longDescription": "Java Azure Function with a BlobTrigger using EventGrid as the event source and a BlobOutput binding to write results back to Azure Blob Storage. Deployed with azd.",
+      "language": "Java",
+      "bindingType": "trigger",
+      "resource": "blob",
+      "iac": "bicep",
+      "priority": 10,
+      "categories": [
+        "data-processing"
+      ],
+      "tags": [
+        "Blob",
+        "Event Grid",
+        "Storage",
+        "Flex Consumption",
+        "AZD"
+      ],
+      "author": "Azure Functions Team",
+      "repositoryUrl": "https://github.com/Azure-Samples/functions-quickstart-java-azd-eventgrid-blob",
+      "folderPath": ".",
+      "whatsIncluded": [
+        "Blob EventGrid trigger function",
+        "Bicep infrastructure",
+        "azd configuration",
+        "VNet integration option"
+      ]
+    },
+    {
+      "id": "blob-eventgrid-trigger-powershell-azd",
+      "displayName": "Blob EventGrid Trigger (PowerShell + AZD + Bicep)",
+      "shortDescription": "BlobTrigger (EventGrid source) PowerShell function for processing blobs from Azure Blob Storage, deployed via azd",
+      "longDescription": "PowerShell Azure Function with a BlobTrigger using EventGrid as the event source. Processes blobs from Azure Blob Storage when new or updated blobs are detected. Deployed with azd.",
+      "language": "PowerShell",
+      "bindingType": "trigger",
+      "resource": "blob",
+      "iac": "bicep",
+      "priority": 10,
+      "categories": [
+        "data-processing"
+      ],
+      "tags": [
+        "Blob",
+        "Event Grid",
+        "Storage",
+        "Flex Consumption",
+        "AZD"
+      ],
+      "author": "Azure Functions Team",
+      "repositoryUrl": "https://github.com/Azure-Samples/functions-quickstart-powershell-azd-eventgrid-blob",
+      "folderPath": ".",
+      "whatsIncluded": [
+        "Blob EventGrid trigger function",
+        "Bicep infrastructure",
+        "azd configuration",
+        "VNet integration option"
+      ]
+    },
+    {
       "id": "eventhub-trigger-csharp-azd",
       "displayName": "Event Hub Trigger (C# + AZD + Bicep)",
       "shortDescription": "EventHubTrigger + TimerTrigger for real-time news streaming with sentiment analysis in C#. Deployed with azd to Flex Consumption",
@@ -683,7 +683,7 @@
       "bindingType": "trigger",
       "resource": "eventhub",
       "iac": "bicep",
-      "priority": 0,
+      "priority": 15,
       "categories": [
         "event-processing",
         "data-processing"
@@ -708,37 +708,6 @@
       ]
     },
     {
-      "id": "eventhub-trigger-java",
-      "displayName": "Event Hub Trigger (Java)",
-      "shortDescription": "EventHubTrigger for processing streaming data from Azure Event Hubs in Java",
-      "longDescription": "Java Azure Function with a single EventHubTrigger function that processes streaming data from Azure Event Hubs. Suitable for IoT telemetry, log ingestion, and real-time analytics.",
-      "language": "Java",
-      "bindingType": "trigger",
-      "resource": "eventhub",
-      "iac": "none",
-      "priority": 0,
-      "categories": [
-        "starter",
-        "event-processing"
-      ],
-      "tags": [
-        "Event Hub",
-        "Streaming",
-        "IoT",
-        "Telemetry"
-      ],
-      "author": "Azure Functions Team",
-      "repositoryUrl": "https://github.com/Azure/azure-functions-templates-mcp-server",
-      "folderPath": "templates/java/EventHubTrigger",
-      "whatsIncluded": [
-        "Function code (.java)",
-        "pom.xml build file",
-        "host.json configuration",
-        "local.settings.json",
-        "README with setup instructions"
-      ]
-    },
-    {
       "id": "eventhub-trigger-python-azd",
       "displayName": "Event Hub Trigger (Python + AZD + Bicep)",
       "shortDescription": "EventHubTrigger + EventHubOutput + TimerTrigger for real-time event streaming in Python with managed identity. Deployed with azd",
@@ -747,7 +716,7 @@
       "bindingType": "trigger",
       "resource": "eventhub",
       "iac": "bicep",
-      "priority": 0,
+      "priority": 15,
       "categories": [
         "event-processing",
         "data-processing"
@@ -780,7 +749,7 @@
       "bindingType": "trigger",
       "resource": "eventhub",
       "iac": "bicep",
-      "priority": 0,
+      "priority": 15,
       "categories": [
         "event-processing",
         "data-processing"
@@ -805,158 +774,184 @@
       ]
     },
     {
-      "id": "mcp-sdk-hosting-csharp",
-      "displayName": "Self-hosted MCP SDK Server (C# + AZD + Bicep)",
-      "shortDescription": "ASP.NET Core app hosting MCP tools via HTTP/SSE transport using ModelContextProtocol.AspNetCore SDK in C#",
-      "longDescription": "C# ASP.NET Core application hosting MCP protocol tools (weather, user info) via HTTP/SSE transport using the ModelContextProtocol.AspNetCore SDK. Runs on Azure Functions but does not use Azure Functions trigger/binding attributes.",
+      "id": "cosmos-trigger-csharp-azd",
+      "displayName": "Cosmos DB Trigger (C# + AZD + Bicep)",
+      "shortDescription": "CosmosDBTrigger (change feed) C# function reacting to document changes in Cosmos DB. Uses managed identity. Deployed with azd",
+      "longDescription": "C# Azure Function with a CosmosDBTrigger that monitors an Azure Cosmos DB container via the change feed and reacts to document inserts and updates. Uses managed identity for authentication. Deployed with azd.",
       "language": "CSharp",
       "bindingType": "trigger",
-      "resource": "mcp",
+      "resource": "cosmos",
       "iac": "bicep",
-      "priority": 1,
+      "priority": 35,
       "categories": [
-        "ai-ml"
+        "data-processing"
       ],
       "tags": [
-        "MCP",
-        "MCP SDK",
-        "Self-hosted",
-        "AZD",
-        "Preview"
-      ],
-      "author": "Azure Functions Team",
-      "repositoryUrl": "https://github.com/Azure-Samples/mcp-sdk-functions-hosting-dotnet",
-      "folderPath": ".",
-      "whatsIncluded": [
-        "MCP SDK server",
-        "Azure Functions hosting",
-        "Bicep infrastructure"
-      ],
-      "isPopular": true
-    },
-    {
-      "id": "mcp-sdk-hosting-java",
-      "displayName": "Self-hosted MCP SDK Server (Java + AZD + Bicep)",
-      "shortDescription": "Quarkus framework app hosting MCP tools using the MCP SDK in Java",
-      "longDescription": "Java application built on the Quarkus framework hosting MCP protocol tools (weather) using the MCP SDK. Runs on Azure Functions but does not use Azure Functions trigger/binding attributes.",
-      "language": "Java",
-      "bindingType": "trigger",
-      "resource": "mcp",
-      "iac": "bicep",
-      "priority": 1,
-      "categories": [
-        "ai-ml"
-      ],
-      "tags": [
-        "MCP",
-        "MCP SDK",
-        "Self-hosted",
-        "AZD",
-        "Preview"
-      ],
-      "author": "Azure Functions Team",
-      "repositoryUrl": "https://github.com/Azure-Samples/mcp-sdk-functions-hosting-java",
-      "folderPath": ".",
-      "whatsIncluded": [
-        "MCP SDK server",
-        "Azure Functions hosting",
-        "Bicep infrastructure"
-      ],
-      "isPopular": true
-    },
-    {
-      "id": "mcp-sdk-hosting-python",
-      "displayName": "Self-hosted MCP SDK Server (Python + AZD + Bicep)",
-      "shortDescription": "FastMCP SDK app hosting MCP tools via Starlette/ASGI transport in Python",
-      "longDescription": "Python application hosting MCP protocol tools (weather) using the FastMCP SDK (mcp.server.fastmcp) with Starlette/ASGI transport. Runs on Azure Functions but does not use Azure Functions trigger/binding attributes.",
-      "language": "Python",
-      "bindingType": "trigger",
-      "resource": "mcp",
-      "iac": "bicep",
-      "priority": 1,
-      "categories": [
-        "ai-ml"
-      ],
-      "tags": [
-        "MCP",
-        "MCP SDK",
-        "Self-hosted",
-        "AZD",
-        "Preview"
-      ],
-      "author": "Azure Functions Team",
-      "repositoryUrl": "https://github.com/Azure-Samples/mcp-sdk-functions-hosting-python",
-      "folderPath": ".",
-      "whatsIncluded": [
-        "MCP SDK server",
-        "Azure Functions hosting",
-        "Bicep infrastructure"
-      ],
-      "isPopular": true
-    },
-    {
-      "id": "mcp-sdk-hosting-typescript",
-      "displayName": "Self-hosted MCP SDK Server (TypeScript + AZD + Bicep)",
-      "shortDescription": "HttpTrigger wrapper hosting MCP SDK tools in TypeScript on Azure Functions",
-      "longDescription": "TypeScript Azure Functions app using HttpTrigger as the transport layer to host MCP SDK protocol tools. The HTTP trigger serves as the entry point for MCP protocol requests.",
-      "language": "TypeScript",
-      "bindingType": "trigger",
-      "resource": "mcp",
-      "iac": "bicep",
-      "priority": 1,
-      "categories": [
-        "ai-ml"
-      ],
-      "tags": [
-        "MCP",
-        "MCP SDK",
-        "Self-hosted",
-        "AZD",
-        "Preview"
-      ],
-      "author": "Azure Functions Team",
-      "repositoryUrl": "https://github.com/Azure-Samples/mcp-sdk-functions-hosting-node",
-      "folderPath": ".",
-      "whatsIncluded": [
-        "MCP SDK server",
-        "Azure Functions hosting",
-        "Bicep infrastructure"
-      ],
-      "isPopular": true
-    },
-    {
-      "id": "mcp-server-apim-python",
-      "displayName": "Remote MCP Server with APIM Gateway (Python + AZD + Bicep)",
-      "shortDescription": "McpToolTrigger + BlobInput + BlobOutput behind Azure API Management gateway with Entra ID and OAuth in Python",
-      "longDescription": "Python Azure Functions app with McpToolTrigger, BlobInput, and BlobOutput bindings implementing an MCP server behind Azure API Management. Tools include hello, get_snippet, and save_snippet using Azure Blob Storage. Secured with Entra ID authentication and OAuth.",
-      "language": "Python",
-      "bindingType": "trigger",
-      "resource": "mcp",
-      "iac": "bicep",
-      "priority": 2,
-      "categories": [
-        "ai-ml"
-      ],
-      "tags": [
-        "MCP",
-        "API Management",
-        "APIM",
-        "Entra ID",
-        "OAuth",
-        "Gateway",
+        "Cosmos DB",
+        "NoSQL",
+        "Flex Consumption",
         "AZD"
       ],
       "author": "Azure Functions Team",
-      "repositoryUrl": "https://github.com/Azure-Samples/remote-mcp-apim-functions-python",
+      "repositoryUrl": "https://github.com/Azure-Samples/functions-quickstart-dotnet-azd-cosmosdb",
       "folderPath": ".",
       "whatsIncluded": [
-        "MCP server function",
-        "APIM gateway",
-        "Entra ID integration",
-        "OAuth support",
-        "Bicep infrastructure"
+        "Cosmos DB trigger function",
+        "Cosmos DB output binding",
+        "Bicep infrastructure",
+        "azd configuration",
+        "Application Insights monitoring"
+      ]
+    },
+    {
+      "id": "cosmos-trigger-python-azd",
+      "displayName": "Cosmos DB Trigger (Python + AZD + Bicep)",
+      "shortDescription": "CosmosDBTrigger (change feed) Python function reacting to document changes in Azure Cosmos DB. Deployed with azd",
+      "longDescription": "Python Azure Function with a CosmosDBTrigger that monitors an Azure Cosmos DB container via the change feed and reacts to document inserts and updates. Deployed with azd.",
+      "language": "Python",
+      "bindingType": "trigger",
+      "resource": "cosmos",
+      "iac": "bicep",
+      "priority": 35,
+      "categories": [
+        "data-processing"
       ],
-      "isPopular": true
+      "tags": [
+        "Cosmos DB",
+        "NoSQL",
+        "Flex Consumption",
+        "AZD"
+      ],
+      "author": "Azure Functions Team",
+      "repositoryUrl": "https://github.com/Azure-Samples/functions-quickstart-python-azd-cosmosdb",
+      "folderPath": ".",
+      "whatsIncluded": [
+        "Cosmos DB trigger function",
+        "Cosmos DB output binding",
+        "Bicep infrastructure",
+        "azd configuration",
+        "Application Insights monitoring"
+      ]
+    },
+    {
+      "id": "cosmos-trigger-typescript-azd",
+      "displayName": "Cosmos DB Trigger (TypeScript + AZD + Bicep)",
+      "shortDescription": "CosmosDBTrigger (change feed) TypeScript function reacting to document changes in Azure Cosmos DB. Deployed with azd",
+      "longDescription": "TypeScript Azure Function with a CosmosDBTrigger that monitors an Azure Cosmos DB container via the change feed and reacts to document inserts and updates. Deployed with azd.",
+      "language": "TypeScript",
+      "bindingType": "trigger",
+      "resource": "cosmos",
+      "iac": "bicep",
+      "priority": 35,
+      "categories": [
+        "data-processing"
+      ],
+      "tags": [
+        "Cosmos DB",
+        "NoSQL",
+        "Flex Consumption",
+        "AZD"
+      ],
+      "author": "Azure Functions Team",
+      "repositoryUrl": "https://github.com/Azure-Samples/functions-quickstart-typescript-azd-cosmosdb",
+      "folderPath": ".",
+      "whatsIncluded": [
+        "Cosmos DB trigger function",
+        "Bicep infrastructure",
+        "azd configuration",
+        "Application Insights monitoring"
+      ]
+    },
+    {
+      "id": "sql-trigger-csharp-azd",
+      "displayName": "SQL Trigger (C# + AZD + Bicep)",
+      "shortDescription": "SqlTrigger + HttpTrigger + SqlOutput. C# dual-function: SQL trigger monitors row changes, HTTP writes to Azure SQL. Deployed with azd",
+      "longDescription": "C# Azure Functions app with two functions: (1) SqlTrigger monitoring row changes in Azure SQL [dbo].[ToDo] table, and (2) HttpTrigger with SqlOutput binding writing new rows. Deployed with azd.",
+      "language": "CSharp",
+      "bindingType": "trigger",
+      "resource": "sql",
+      "iac": "bicep",
+      "priority": 40,
+      "categories": [
+        "data-processing"
+      ],
+      "tags": [
+        "SQL",
+        "Azure SQL",
+        "Flex Consumption",
+        "AZD"
+      ],
+      "author": "Azure Functions Team",
+      "repositoryUrl": "https://github.com/Azure-Samples/functions-quickstart-dotnet-azd-sql",
+      "folderPath": ".",
+      "whatsIncluded": [
+        "SQL trigger function",
+        "SQL bindings",
+        "Bicep infrastructure",
+        "azd configuration",
+        "Application Insights monitoring"
+      ]
+    },
+    {
+      "id": "sql-trigger-python-azd",
+      "displayName": "SQL Trigger (Python + AZD + Bicep)",
+      "shortDescription": "SqlTrigger + HttpTrigger + SqlOutput. Python dual-function: SQL trigger monitors row changes, HTTP writes to Azure SQL. Deployed with azd",
+      "longDescription": "Python Azure Functions app with two functions: (1) SqlTrigger monitoring row changes in Azure SQL [dbo].[ToDo] table, and (2) HttpTrigger with SqlOutput binding writing new rows. Deployed with azd.",
+      "language": "Python",
+      "bindingType": "trigger",
+      "resource": "sql",
+      "iac": "bicep",
+      "priority": 40,
+      "categories": [
+        "data-processing"
+      ],
+      "tags": [
+        "SQL",
+        "Azure SQL",
+        "Flex Consumption",
+        "AZD"
+      ],
+      "author": "Azure Functions Team",
+      "repositoryUrl": "https://github.com/Azure-Samples/functions-quickstart-python-azd-sql",
+      "folderPath": ".",
+      "whatsIncluded": [
+        "SQL trigger function",
+        "SQL bindings",
+        "Bicep infrastructure",
+        "azd configuration",
+        "Key Vault integration",
+        "Log Analytics monitoring"
+      ]
+    },
+    {
+      "id": "sql-trigger-typescript-azd",
+      "displayName": "SQL Trigger (TypeScript + AZD + Bicep)",
+      "shortDescription": "SqlTrigger + HttpTrigger + SqlOutput. TypeScript dual-function: SQL trigger monitors row changes, HTTP writes to Azure SQL. Deployed with azd",
+      "longDescription": "TypeScript Azure Functions app with two functions: (1) SqlTrigger monitoring row changes in Azure SQL [dbo].[ToDo] table, and (2) HttpTrigger with SqlOutput binding writing new rows. Deployed with azd.",
+      "language": "TypeScript",
+      "bindingType": "trigger",
+      "resource": "sql",
+      "iac": "bicep",
+      "priority": 40,
+      "categories": [
+        "data-processing"
+      ],
+      "tags": [
+        "SQL",
+        "Azure SQL",
+        "Flex Consumption",
+        "AZD"
+      ],
+      "author": "Azure Functions Team",
+      "repositoryUrl": "https://github.com/Azure-Samples/functions-quickstart-typescript-azd-sql",
+      "folderPath": ".",
+      "whatsIncluded": [
+        "SQL trigger function",
+        "SQL bindings",
+        "Bicep infrastructure",
+        "azd configuration",
+        "Azure Monitor integration"
+      ]
     },
     {
       "id": "mcp-server-remote-csharp",
@@ -967,7 +962,7 @@
       "bindingType": "trigger",
       "resource": "mcp",
       "iac": "bicep",
-      "priority": 0,
+      "priority": 50,
       "categories": [
         "starter",
         "ai-ml"
@@ -994,41 +989,6 @@
       "isPopular": true
     },
     {
-      "id": "mcp-server-remote-java",
-      "displayName": "Remote MCP Server (Java + AZD + Bicep)",
-      "shortDescription": "McpToolTrigger + McpResourceTrigger + BlobInput + BlobOutput for a remote MCP server with weather and code snippets in Java",
-      "longDescription": "Java Azure Functions app with McpToolTrigger and McpResourceTrigger, BlobInput, and BlobOutput bindings implementing an MCP server. Includes weather tools/resources via Open-Meteo and code snippet storage in Azure Blob Storage.",
-      "language": "Java",
-      "bindingType": "trigger",
-      "resource": "mcp",
-      "iac": "bicep",
-      "priority": 0,
-      "categories": [
-        "starter",
-        "ai-ml"
-      ],
-      "tags": [
-        "MCP",
-        "Model Context Protocol",
-        "Remote",
-        "Copilot",
-        "VS Code"
-      ],
-      "author": "Azure Functions Team",
-      "repositoryUrl": "https://github.com/Azure-Samples/remote-mcp-functions-java",
-      "folderPath": ".",
-      "whatsIncluded": [
-        "MCP Tool trigger functions",
-        "Snippet save/retrieve tools with Blob storage",
-        "Bicep infrastructure files",
-        "Azure Developer CLI (azd) configuration",
-        "Maven build configuration",
-        "VS Code mcp.json configuration",
-        "MCP Inspector support"
-      ],
-      "isPopular": true
-    },
-    {
       "id": "mcp-server-remote-python",
       "displayName": "Remote MCP Server (Python + AZD + Bicep)",
       "shortDescription": "McpToolTrigger + McpResourceTrigger + BlobInput + BlobOutput for a remote MCP server with weather and code snippets in Python",
@@ -1037,7 +997,7 @@
       "bindingType": "trigger",
       "resource": "mcp",
       "iac": "bicep",
-      "priority": 0,
+      "priority": 50,
       "categories": [
         "starter",
         "ai-ml"
@@ -1071,7 +1031,7 @@
       "bindingType": "trigger",
       "resource": "mcp",
       "iac": "bicep",
-      "priority": 0,
+      "priority": 50,
       "categories": [
         "starter",
         "ai-ml"
@@ -1098,6 +1058,195 @@
       "isPopular": true
     },
     {
+      "id": "mcp-server-remote-java",
+      "displayName": "Remote MCP Server (Java + AZD + Bicep)",
+      "shortDescription": "McpToolTrigger + McpResourceTrigger + BlobInput + BlobOutput for a remote MCP server with weather and code snippets in Java",
+      "longDescription": "Java Azure Functions app with McpToolTrigger and McpResourceTrigger, BlobInput, and BlobOutput bindings implementing an MCP server. Includes weather tools/resources via Open-Meteo and code snippet storage in Azure Blob Storage.",
+      "language": "Java",
+      "bindingType": "trigger",
+      "resource": "mcp",
+      "iac": "bicep",
+      "priority": 50,
+      "categories": [
+        "starter",
+        "ai-ml"
+      ],
+      "tags": [
+        "MCP",
+        "Model Context Protocol",
+        "Remote",
+        "Copilot",
+        "VS Code"
+      ],
+      "author": "Azure Functions Team",
+      "repositoryUrl": "https://github.com/Azure-Samples/remote-mcp-functions-java",
+      "folderPath": ".",
+      "whatsIncluded": [
+        "MCP Tool trigger functions",
+        "Snippet save/retrieve tools with Blob storage",
+        "Bicep infrastructure files",
+        "Azure Developer CLI (azd) configuration",
+        "Maven build configuration",
+        "VS Code mcp.json configuration",
+        "MCP Inspector support"
+      ],
+      "isPopular": true
+    },
+    {
+      "id": "mcp-sdk-hosting-csharp",
+      "displayName": "Self-hosted MCP SDK Server (C# + AZD + Bicep)",
+      "shortDescription": "ASP.NET Core app hosting MCP tools via HTTP/SSE transport using ModelContextProtocol.AspNetCore SDK in C#",
+      "longDescription": "C# ASP.NET Core application hosting MCP protocol tools (weather, user info) via HTTP/SSE transport using the ModelContextProtocol.AspNetCore SDK. Runs on Azure Functions but does not use Azure Functions trigger/binding attributes.",
+      "language": "CSharp",
+      "bindingType": "trigger",
+      "resource": "mcp",
+      "iac": "bicep",
+      "priority": 51,
+      "categories": [
+        "ai-ml"
+      ],
+      "tags": [
+        "MCP",
+        "MCP SDK",
+        "Self-hosted",
+        "AZD",
+        "Preview"
+      ],
+      "author": "Azure Functions Team",
+      "repositoryUrl": "https://github.com/Azure-Samples/mcp-sdk-functions-hosting-dotnet",
+      "folderPath": ".",
+      "whatsIncluded": [
+        "MCP SDK server",
+        "Azure Functions hosting",
+        "Bicep infrastructure"
+      ],
+      "isPopular": true
+    },
+    {
+      "id": "mcp-sdk-hosting-python",
+      "displayName": "Self-hosted MCP SDK Server (Python + AZD + Bicep)",
+      "shortDescription": "FastMCP SDK app hosting MCP tools via Starlette/ASGI transport in Python",
+      "longDescription": "Python application hosting MCP protocol tools (weather) using the FastMCP SDK (mcp.server.fastmcp) with Starlette/ASGI transport. Runs on Azure Functions but does not use Azure Functions trigger/binding attributes.",
+      "language": "Python",
+      "bindingType": "trigger",
+      "resource": "mcp",
+      "iac": "bicep",
+      "priority": 51,
+      "categories": [
+        "ai-ml"
+      ],
+      "tags": [
+        "MCP",
+        "MCP SDK",
+        "Self-hosted",
+        "AZD",
+        "Preview"
+      ],
+      "author": "Azure Functions Team",
+      "repositoryUrl": "https://github.com/Azure-Samples/mcp-sdk-functions-hosting-python",
+      "folderPath": ".",
+      "whatsIncluded": [
+        "MCP SDK server",
+        "Azure Functions hosting",
+        "Bicep infrastructure"
+      ],
+      "isPopular": true
+    },
+    {
+      "id": "mcp-sdk-hosting-typescript",
+      "displayName": "Self-hosted MCP SDK Server (TypeScript + AZD + Bicep)",
+      "shortDescription": "HttpTrigger wrapper hosting MCP SDK tools in TypeScript on Azure Functions",
+      "longDescription": "TypeScript Azure Functions app using HttpTrigger as the transport layer to host MCP SDK protocol tools. The HTTP trigger serves as the entry point for MCP protocol requests.",
+      "language": "TypeScript",
+      "bindingType": "trigger",
+      "resource": "mcp",
+      "iac": "bicep",
+      "priority": 51,
+      "categories": [
+        "ai-ml"
+      ],
+      "tags": [
+        "MCP",
+        "MCP SDK",
+        "Self-hosted",
+        "AZD",
+        "Preview"
+      ],
+      "author": "Azure Functions Team",
+      "repositoryUrl": "https://github.com/Azure-Samples/mcp-sdk-functions-hosting-node",
+      "folderPath": ".",
+      "whatsIncluded": [
+        "MCP SDK server",
+        "Azure Functions hosting",
+        "Bicep infrastructure"
+      ],
+      "isPopular": true
+    },
+    {
+      "id": "mcp-sdk-hosting-java",
+      "displayName": "Self-hosted MCP SDK Server (Java + AZD + Bicep)",
+      "shortDescription": "Quarkus framework app hosting MCP tools using the MCP SDK in Java",
+      "longDescription": "Java application built on the Quarkus framework hosting MCP protocol tools (weather) using the MCP SDK. Runs on Azure Functions but does not use Azure Functions trigger/binding attributes.",
+      "language": "Java",
+      "bindingType": "trigger",
+      "resource": "mcp",
+      "iac": "bicep",
+      "priority": 51,
+      "categories": [
+        "ai-ml"
+      ],
+      "tags": [
+        "MCP",
+        "MCP SDK",
+        "Self-hosted",
+        "AZD",
+        "Preview"
+      ],
+      "author": "Azure Functions Team",
+      "repositoryUrl": "https://github.com/Azure-Samples/mcp-sdk-functions-hosting-java",
+      "folderPath": ".",
+      "whatsIncluded": [
+        "MCP SDK server",
+        "Azure Functions hosting",
+        "Bicep infrastructure"
+      ],
+      "isPopular": true
+    },
+    {
+      "id": "mcp-server-apim-python",
+      "displayName": "Remote MCP Server with APIM Gateway (Python + AZD + Bicep)",
+      "shortDescription": "McpToolTrigger + BlobInput + BlobOutput behind Azure API Management gateway with Entra ID and OAuth in Python",
+      "longDescription": "Python Azure Functions app with McpToolTrigger, BlobInput, and BlobOutput bindings implementing an MCP server behind Azure API Management. Tools include hello, get_snippet, and save_snippet using Azure Blob Storage. Secured with Entra ID authentication and OAuth.",
+      "language": "Python",
+      "bindingType": "trigger",
+      "resource": "mcp",
+      "iac": "bicep",
+      "priority": 55,
+      "categories": [
+        "ai-ml"
+      ],
+      "tags": [
+        "MCP",
+        "API Management",
+        "APIM",
+        "Entra ID",
+        "OAuth",
+        "Gateway",
+        "AZD"
+      ],
+      "author": "Azure Functions Team",
+      "repositoryUrl": "https://github.com/Azure-Samples/remote-mcp-apim-functions-python",
+      "folderPath": ".",
+      "whatsIncluded": [
+        "MCP server function",
+        "APIM gateway",
+        "Entra ID integration",
+        "OAuth support",
+        "Bicep infrastructure"
+      ],
+      "isPopular": true
+    },
+    {
       "id": "ai-agent-csharp",
       "displayName": "Simple Agent QuickStart (C# + AZD + Bicep)",
       "shortDescription": "HttpTrigger C# AI agent using GitHub Copilot SDK with bring-your-own-model support via Microsoft Foundry",
@@ -1106,7 +1255,7 @@
       "bindingType": "trigger",
       "resource": "http",
       "iac": "bicep",
-      "priority": 0,
+      "priority": 60,
       "categories": [
         "ai-ml"
       ],
@@ -1130,38 +1279,6 @@
       ]
     },
     {
-      "id": "ai-agent-java",
-      "displayName": "Simple Agent QuickStart (Java + AZD + Bicep)",
-      "shortDescription": "HttpTrigger Java AI agent using GitHub Copilot SDK with bring-your-own-model support via Microsoft Foundry",
-      "longDescription": "Java Azure Function with an HTTP trigger that implements an AI agent using the GitHub Copilot SDK. Supports GitHub Copilot models or bring-your-own-model (BYOM) via Microsoft Foundry. Deployed with azd.",
-      "language": "Java",
-      "bindingType": "trigger",
-      "resource": "http",
-      "iac": "bicep",
-      "priority": 0,
-      "categories": [
-        "ai-ml"
-      ],
-      "tags": [
-        "AI",
-        "Agents",
-        "Copilot SDK",
-        "Microsoft Foundry",
-        "Byok"
-      ],
-      "author": "Azure Functions Team",
-      "repositoryUrl": "https://github.com/Azure-Samples/simple-agent-functions-java",
-      "folderPath": ".",
-      "whatsIncluded": [
-        "AI agent HTTP endpoint (/api/ask)",
-        "GitHub Copilot SDK integration",
-        "Interactive chat client",
-        "Microsoft Foundry resources (optional)",
-        "Azure Developer CLI (azd) configuration",
-        "Flex Consumption hosting"
-      ]
-    },
-    {
       "id": "ai-agent-python",
       "displayName": "Simple Agent QuickStart (Python + AZD + Bicep)",
       "shortDescription": "HttpTrigger Python AI agent using GitHub Copilot SDK with bring-your-own-model support via Microsoft Foundry",
@@ -1170,7 +1287,7 @@
       "bindingType": "trigger",
       "resource": "http",
       "iac": "bicep",
-      "priority": 0,
+      "priority": 60,
       "categories": [
         "ai-ml"
       ],
@@ -1202,7 +1319,7 @@
       "bindingType": "trigger",
       "resource": "http",
       "iac": "bicep",
-      "priority": 0,
+      "priority": 60,
       "categories": [
         "ai-ml"
       ],
@@ -1226,36 +1343,35 @@
       ]
     },
     {
-      "id": "ai-chatgpt-javascript",
-      "displayName": "Chat using ChatGPT (JavaScript + AZD + Bicep)",
-      "shortDescription": "HttpTrigger + OpenAI TextCompletionInput + AssistantCreate/Post/Query bindings. JavaScript ChatGPT chatbot with Blob state",
-      "longDescription": "JavaScript Azure Function with an HTTP trigger, OpenAI TextCompletionInput binding for prompt completion, and AssistantCreate/AssistantPost/AssistantQuery bindings for managing conversation state stored in Azure Blob Storage. Builds a ChatGPT-style chatbot with persistent multi-turn conversations.",
-      "language": "JavaScript",
+      "id": "ai-agent-java",
+      "displayName": "Simple Agent QuickStart (Java + AZD + Bicep)",
+      "shortDescription": "HttpTrigger Java AI agent using GitHub Copilot SDK with bring-your-own-model support via Microsoft Foundry",
+      "longDescription": "Java Azure Function with an HTTP trigger that implements an AI agent using the GitHub Copilot SDK. Supports GitHub Copilot models or bring-your-own-model (BYOM) via Microsoft Foundry. Deployed with azd.",
+      "language": "Java",
       "bindingType": "trigger",
       "resource": "http",
       "iac": "bicep",
-      "priority": 1,
+      "priority": 60,
       "categories": [
         "ai-ml"
       ],
       "tags": [
         "AI",
-        "OpenAI",
-        "ChatGPT",
-        "HTTP"
+        "Agents",
+        "Copilot SDK",
+        "Microsoft Foundry",
+        "Byok"
       ],
-      "author": "Paul Yuknewicz",
-      "repositoryUrl": "https://github.com/Azure-Samples/function-javascript-ai-openai-chatgpt",
+      "author": "Azure Functions Team",
+      "repositoryUrl": "https://github.com/Azure-Samples/simple-agent-functions-java",
       "folderPath": ".",
       "whatsIncluded": [
-        "Ask and Chat HTTP functions",
-        "Azure OpenAI integration",
-        "Blob storage for conversation state",
-        "Bicep infrastructure files",
+        "AI agent HTTP endpoint (/api/ask)",
+        "GitHub Copilot SDK integration",
+        "Interactive chat client",
+        "Microsoft Foundry resources (optional)",
         "Azure Developer CLI (azd) configuration",
-        "Dockerfile for containerization",
-        "Dev Container setup",
-        "Test files with sample prompts"
+        "Flex Consumption hosting"
       ]
     },
     {
@@ -1267,7 +1383,7 @@
       "bindingType": "trigger",
       "resource": "http",
       "iac": "bicep",
-      "priority": 1,
+      "priority": 61,
       "categories": [
         "ai-ml"
       ],
@@ -1292,35 +1408,36 @@
       ]
     },
     {
-      "id": "ai-langchain-python",
-      "displayName": "LangChain with OpenAI (Python + AZD + Bicep)",
-      "shortDescription": "HttpTrigger Python function using LangChain SDK with Azure OpenAI and DefaultAzureCredential for Entra ID auth",
-      "longDescription": "Python Azure Function with an HTTP trigger that uses the LangChain SDK for prompt templates and chain-of-thought processing against Azure OpenAI. Authenticates to Azure OpenAI via DefaultAzureCredential with Entra ID. No additional input/output bindings.",
-      "language": "Python",
+      "id": "ai-chatgpt-javascript",
+      "displayName": "Chat using ChatGPT (JavaScript + AZD + Bicep)",
+      "shortDescription": "HttpTrigger + OpenAI TextCompletionInput + AssistantCreate/Post/Query bindings. JavaScript ChatGPT chatbot with Blob state",
+      "longDescription": "JavaScript Azure Function with an HTTP trigger, OpenAI TextCompletionInput binding for prompt completion, and AssistantCreate/AssistantPost/AssistantQuery bindings for managing conversation state stored in Azure Blob Storage. Builds a ChatGPT-style chatbot with persistent multi-turn conversations.",
+      "language": "JavaScript",
       "bindingType": "trigger",
       "resource": "http",
       "iac": "bicep",
-      "priority": 2,
+      "priority": 61,
       "categories": [
         "ai-ml"
       ],
       "tags": [
         "AI",
         "OpenAI",
-        "Langchain",
+        "ChatGPT",
         "HTTP"
       ],
       "author": "Paul Yuknewicz",
-      "repositoryUrl": "https://github.com/Azure-Samples/function-python-ai-langchain",
+      "repositoryUrl": "https://github.com/Azure-Samples/function-javascript-ai-openai-chatgpt",
       "folderPath": ".",
       "whatsIncluded": [
-        "LangChain integration",
+        "Ask and Chat HTTP functions",
         "Azure OpenAI integration",
-        "HTTP trigger functions",
+        "Blob storage for conversation state",
         "Bicep infrastructure files",
         "Azure Developer CLI (azd) configuration",
+        "Dockerfile for containerization",
         "Dev Container setup",
-        "Test files for local development"
+        "Test files with sample prompts"
       ]
     },
     {
@@ -1332,7 +1449,7 @@
       "bindingType": "trigger",
       "resource": "http",
       "iac": "bicep",
-      "priority": 2,
+      "priority": 62,
       "categories": [
         "ai-ml"
       ],
@@ -1364,7 +1481,7 @@
       "bindingType": "trigger",
       "resource": "http",
       "iac": "bicep",
-      "priority": 2,
+      "priority": 62,
       "categories": [
         "ai-ml"
       ],
@@ -1388,124 +1505,35 @@
       ]
     },
     {
-      "id": "durable-ai-travel-planner-csharp",
-      "displayName": "Durable Functions AI Travel Planner (C#)",
-      "shortDescription": "HttpTrigger + DurableClient + OrchestrationTrigger + ActivityTrigger. C# AI travel planner using Azure OpenAI",
-      "longDescription": "C# Durable Functions app with an HttpTrigger starter that uses DurableClient to launch an OrchestrationTrigger workflow coordinating multiple ActivityTrigger functions. Each activity calls Azure OpenAI for destination research, itinerary creation, and booking recommendations.",
-      "language": "CSharp",
-      "bindingType": "orchestration",
-      "resource": "durable",
-      "iac": "none",
-      "priority": 2,
+      "id": "ai-langchain-python",
+      "displayName": "LangChain with OpenAI (Python + AZD + Bicep)",
+      "shortDescription": "HttpTrigger Python function using LangChain SDK with Azure OpenAI and DefaultAzureCredential for Entra ID auth",
+      "longDescription": "Python Azure Function with an HTTP trigger that uses the LangChain SDK for prompt templates and chain-of-thought processing against Azure OpenAI. Authenticates to Azure OpenAI via DefaultAzureCredential with Entra ID. No additional input/output bindings.",
+      "language": "Python",
+      "bindingType": "trigger",
+      "resource": "http",
+      "iac": "bicep",
+      "priority": 63,
       "categories": [
-        "ai-ml",
-        "workflows"
+        "ai-ml"
       ],
       "tags": [
-        "Durable Functions",
-        "Orchestration",
-        "AI Agent",
-        "Azure OpenAI",
-        "Travel Planning"
+        "AI",
+        "OpenAI",
+        "Langchain",
+        "HTTP"
       ],
-      "author": "Azure Functions Team",
-      "repositoryUrl": "https://github.com/Azure-Samples/Durable-Task-Scheduler",
-      "folderPath": "samples/durable-functions/dotnet/AiAgentTravelPlanOrchestrator",
+      "author": "Paul Yuknewicz",
+      "repositoryUrl": "https://github.com/Azure-Samples/function-python-ai-langchain",
+      "folderPath": ".",
       "whatsIncluded": [
-        "AI agent orchestration",
-        "Multiple AI service integration",
-        "Activity functions",
-        "README.md"
-      ]
-    },
-    {
-      "id": "durable-aspire-csharp",
-      "displayName": "Durable Functions with .NET Aspire (C#)",
-      "shortDescription": "HttpTrigger + DurableClient + OrchestrationTrigger + ActivityTrigger. C# Durable Functions with .NET Aspire integration",
-      "longDescription": "C# Durable Functions app with HttpTrigger starter, DurableClient, OrchestrationTrigger, and ActivityTrigger, integrated with .NET Aspire for enhanced local development with service discovery, dashboard, and observability.",
-      "language": "CSharp",
-      "bindingType": "orchestration",
-      "resource": "durable",
-      "iac": "none",
-      "priority": 2,
-      "categories": [
-        "workflows"
-      ],
-      "tags": [
-        "Durable Functions",
-        "Orchestration",
-        ".NET Aspire",
-        "Cloud Native",
-        "Observability"
-      ],
-      "author": "Azure Functions Team",
-      "repositoryUrl": "https://github.com/Azure-Samples/Durable-Task-Scheduler",
-      "folderPath": "samples/durable-functions/dotnet/AzureFunctionsAndDtsWithAspire",
-      "whatsIncluded": [
-        "Aspire AppHost configuration",
-        "Durable Functions service",
-        "Service discovery setup",
-        "README.md"
-      ]
-    },
-    {
-      "id": "durable-distributed-tracing-csharp",
-      "displayName": "Durable Functions Distributed Tracing (C#)",
-      "shortDescription": "HttpTrigger + DurableClient + OrchestrationTrigger + ActivityTrigger + OpenTelemetry. C# distributed tracing for orchestrations",
-      "longDescription": "C# Durable Functions app with HttpTrigger starter, DurableClient, OrchestrationTrigger, and ActivityTrigger. Adds OpenTelemetry distributed tracing with correlation IDs across orchestrations and activities.",
-      "language": "CSharp",
-      "bindingType": "orchestration",
-      "resource": "durable",
-      "iac": "none",
-      "priority": 1,
-      "categories": [
-        "workflows"
-      ],
-      "tags": [
-        "Durable Functions",
-        "Orchestration",
-        "OpenTelemetry",
-        "Distributed Tracing",
-        "Observability"
-      ],
-      "author": "Azure Functions Team",
-      "repositoryUrl": "https://github.com/Azure-Samples/Durable-Task-Scheduler",
-      "folderPath": "samples/durable-functions/dotnet/DistributedTracing",
-      "whatsIncluded": [
-        "OpenTelemetry configuration",
-        "Traced orchestration",
-        "Activity functions with spans",
-        "README.md"
-      ]
-    },
-    {
-      "id": "durable-large-payload-csharp",
-      "displayName": "Durable Functions Large Payload (C#)",
-      "shortDescription": "HttpTrigger + DurableClient + OrchestrationTrigger + ActivityTrigger + Blob Storage for large payload offloading. C#",
-      "longDescription": "C# Durable Functions app with HttpTrigger starter, DurableClient, OrchestrationTrigger, and ActivityTrigger. Demonstrates handling payloads exceeding message size limits by offloading to Azure Blob Storage.",
-      "language": "CSharp",
-      "bindingType": "orchestration",
-      "resource": "durable",
-      "iac": "none",
-      "priority": 1,
-      "categories": [
-        "workflows"
-      ],
-      "tags": [
-        "Durable Functions",
-        "Orchestration",
-        "Large Payload",
-        "Blob Storage",
-        "Best Practices"
-      ],
-      "author": "Azure Functions Team",
-      "repositoryUrl": "https://github.com/Azure-Samples/Durable-Task-Scheduler",
-      "folderPath": "samples/durable-functions/dotnet/LargePayload",
-      "whatsIncluded": [
-        "Large payload handling",
-        "Blob storage integration",
-        "Orchestration code",
-        "README.md"
+        "LangChain integration",
+        "Azure OpenAI integration",
+        "HTTP trigger functions",
+        "Bicep infrastructure files",
+        "Azure Developer CLI (azd) configuration",
+        "Dev Container setup",
+        "Test files for local development"
       ]
     },
     {
@@ -1517,7 +1545,7 @@
       "bindingType": "orchestration",
       "resource": "durable",
       "iac": "none",
-      "priority": 1,
+      "priority": 65,
       "categories": [
         "starter",
         "workflows"
@@ -1542,71 +1570,6 @@
       ]
     },
     {
-      "id": "durable-orchestration-java",
-      "displayName": "Durable Functions (Java)",
-      "shortDescription": "HttpTrigger + DurableClientInput + DurableOrchestrationTrigger + DurableActivityTrigger. Java fault-tolerant workflow",
-      "longDescription": "Java Durable Functions app with an HttpTrigger starter using DurableClientInput binding to launch a DurableOrchestrationTrigger workflow that coordinates DurableActivityTrigger functions for fault-tolerant orchestration.",
-      "language": "Java",
-      "bindingType": "orchestration",
-      "resource": "durable",
-      "iac": "none",
-      "priority": 1,
-      "categories": [
-        "starter",
-        "workflows"
-      ],
-      "tags": [
-        "Durable Functions",
-        "Orchestration",
-        "Activity",
-        "Workflow",
-        "Stateful"
-      ],
-      "author": "Azure Functions Team",
-      "repositoryUrl": "https://github.com/Azure/azure-functions-templates-mcp-server",
-      "folderPath": "templates/java/DurableFunctions",
-      "whatsIncluded": [
-        "Function code (.java)",
-        "pom.xml build file",
-        "host.json configuration",
-        "local.settings.json",
-        "README with setup instructions"
-      ]
-    },
-    {
-      "id": "durable-orchestration-javascript",
-      "displayName": "Durable Functions Orchestration (JavaScript)",
-      "shortDescription": "HttpTrigger + DurableClient + OrchestrationTrigger + ActivityTrigger. JavaScript function chaining and fan-out/fan-in",
-      "longDescription": "JavaScript Durable Functions app with HttpTrigger starter, DurableClient, OrchestrationTrigger, and ActivityTrigger. Demonstrates function chaining and fan-out/fan-in orchestration patterns with HelloCities sample.",
-      "language": "JavaScript",
-      "bindingType": "orchestration",
-      "resource": "durable",
-      "iac": "none",
-      "priority": 1,
-      "categories": [
-        "starter",
-        "workflows"
-      ],
-      "tags": [
-        "Durable Functions",
-        "Orchestration",
-        "Activity",
-        "Function Chaining",
-        "Fan-out/Fan-in",
-        "Starter"
-      ],
-      "author": "Azure Functions Team",
-      "repositoryUrl": "https://github.com/Azure-Samples/Durable-Task-Scheduler",
-      "folderPath": "samples/durable-functions/javascript/HelloCities",
-      "whatsIncluded": [
-        "Function code (.js)",
-        "package.json",
-        "host.json configuration",
-        "local.settings.json",
-        "README.md"
-      ]
-    },
-    {
       "id": "durable-orchestration-python",
       "displayName": "Durable Functions Orchestration (Python)",
       "shortDescription": "HttpTrigger + DurableClient + OrchestrationTrigger + ActivityTrigger. Python fan-out/fan-in parallel processing pattern",
@@ -1615,7 +1578,7 @@
       "bindingType": "orchestration",
       "resource": "durable",
       "iac": "none",
-      "priority": 1,
+      "priority": 65,
       "categories": [
         "starter",
         "workflows"
@@ -1648,7 +1611,7 @@
       "bindingType": "orchestration",
       "resource": "durable",
       "iac": "none",
-      "priority": 1,
+      "priority": 65,
       "categories": [
         "starter",
         "workflows"
@@ -1674,6 +1637,71 @@
       ]
     },
     {
+      "id": "durable-orchestration-javascript",
+      "displayName": "Durable Functions Orchestration (JavaScript)",
+      "shortDescription": "HttpTrigger + DurableClient + OrchestrationTrigger + ActivityTrigger. JavaScript function chaining and fan-out/fan-in",
+      "longDescription": "JavaScript Durable Functions app with HttpTrigger starter, DurableClient, OrchestrationTrigger, and ActivityTrigger. Demonstrates function chaining and fan-out/fan-in orchestration patterns with HelloCities sample.",
+      "language": "JavaScript",
+      "bindingType": "orchestration",
+      "resource": "durable",
+      "iac": "none",
+      "priority": 65,
+      "categories": [
+        "starter",
+        "workflows"
+      ],
+      "tags": [
+        "Durable Functions",
+        "Orchestration",
+        "Activity",
+        "Function Chaining",
+        "Fan-out/Fan-in",
+        "Starter"
+      ],
+      "author": "Azure Functions Team",
+      "repositoryUrl": "https://github.com/Azure-Samples/Durable-Task-Scheduler",
+      "folderPath": "samples/durable-functions/javascript/HelloCities",
+      "whatsIncluded": [
+        "Function code (.js)",
+        "package.json",
+        "host.json configuration",
+        "local.settings.json",
+        "README.md"
+      ]
+    },
+    {
+      "id": "durable-orchestration-java",
+      "displayName": "Durable Functions (Java)",
+      "shortDescription": "HttpTrigger + DurableClientInput + DurableOrchestrationTrigger + DurableActivityTrigger. Java fault-tolerant workflow",
+      "longDescription": "Java Durable Functions app with an HttpTrigger starter using DurableClientInput binding to launch a DurableOrchestrationTrigger workflow that coordinates DurableActivityTrigger functions for fault-tolerant orchestration.",
+      "language": "Java",
+      "bindingType": "orchestration",
+      "resource": "durable",
+      "iac": "none",
+      "priority": 65,
+      "categories": [
+        "starter",
+        "workflows"
+      ],
+      "tags": [
+        "Durable Functions",
+        "Orchestration",
+        "Activity",
+        "Workflow",
+        "Stateful"
+      ],
+      "author": "Azure Functions Team",
+      "repositoryUrl": "https://github.com/Azure/azure-functions-templates-mcp-server",
+      "folderPath": "templates/java/DurableFunctions",
+      "whatsIncluded": [
+        "Function code (.java)",
+        "pom.xml build file",
+        "host.json configuration",
+        "local.settings.json",
+        "README with setup instructions"
+      ]
+    },
+    {
       "id": "durable-order-processor-csharp",
       "displayName": "Durable Functions Order Processing (C#)",
       "shortDescription": "HttpTrigger + DurableClient + OrchestrationTrigger + ActivityTrigger. C# order processing with retry and compensation. Deployed with azd",
@@ -1682,7 +1710,7 @@
       "bindingType": "orchestration",
       "resource": "durable",
       "iac": "bicep",
-      "priority": 1,
+      "priority": 66,
       "categories": [
         "workflows"
       ],
@@ -1714,7 +1742,7 @@
       "bindingType": "orchestration",
       "resource": "durable",
       "iac": "bicep",
-      "priority": 1,
+      "priority": 66,
       "categories": [
         "workflows"
       ],
@@ -1738,6 +1766,157 @@
       ]
     },
     {
+      "id": "durable-distributed-tracing-csharp",
+      "displayName": "Durable Functions Distributed Tracing (C#)",
+      "shortDescription": "HttpTrigger + DurableClient + OrchestrationTrigger + ActivityTrigger + OpenTelemetry. C# distributed tracing for orchestrations",
+      "longDescription": "C# Durable Functions app with HttpTrigger starter, DurableClient, OrchestrationTrigger, and ActivityTrigger. Adds OpenTelemetry distributed tracing with correlation IDs across orchestrations and activities.",
+      "language": "CSharp",
+      "bindingType": "orchestration",
+      "resource": "durable",
+      "iac": "none",
+      "priority": 70,
+      "categories": [
+        "workflows"
+      ],
+      "tags": [
+        "Durable Functions",
+        "Orchestration",
+        "OpenTelemetry",
+        "Distributed Tracing",
+        "Observability"
+      ],
+      "author": "Azure Functions Team",
+      "repositoryUrl": "https://github.com/Azure-Samples/Durable-Task-Scheduler",
+      "folderPath": "samples/durable-functions/dotnet/DistributedTracing",
+      "whatsIncluded": [
+        "OpenTelemetry configuration",
+        "Traced orchestration",
+        "Activity functions with spans",
+        "README.md"
+      ]
+    },
+    {
+      "id": "durable-large-payload-csharp",
+      "displayName": "Durable Functions Large Payload (C#)",
+      "shortDescription": "HttpTrigger + DurableClient + OrchestrationTrigger + ActivityTrigger + Blob Storage for large payload offloading. C#",
+      "longDescription": "C# Durable Functions app with HttpTrigger starter, DurableClient, OrchestrationTrigger, and ActivityTrigger. Demonstrates handling payloads exceeding message size limits by offloading to Azure Blob Storage.",
+      "language": "CSharp",
+      "bindingType": "orchestration",
+      "resource": "durable",
+      "iac": "none",
+      "priority": 70,
+      "categories": [
+        "workflows"
+      ],
+      "tags": [
+        "Durable Functions",
+        "Orchestration",
+        "Large Payload",
+        "Blob Storage",
+        "Best Practices"
+      ],
+      "author": "Azure Functions Team",
+      "repositoryUrl": "https://github.com/Azure-Samples/Durable-Task-Scheduler",
+      "folderPath": "samples/durable-functions/dotnet/LargePayload",
+      "whatsIncluded": [
+        "Large payload handling",
+        "Blob storage integration",
+        "Orchestration code",
+        "README.md"
+      ]
+    },
+    {
+      "id": "durable-saga-csharp",
+      "displayName": "Durable Functions Saga Pattern (C#)",
+      "shortDescription": "HttpTrigger + DurableClient + OrchestrationTrigger + ActivityTrigger. C# Saga pattern with compensation for distributed transactions",
+      "longDescription": "C# Durable Functions app with HttpTrigger starter, DurableClient, OrchestrationTrigger, and ActivityTrigger. Implements the Saga pattern for distributed transactions with compensation logic to roll back completed steps on failure.",
+      "language": "CSharp",
+      "bindingType": "orchestration",
+      "resource": "durable",
+      "iac": "none",
+      "priority": 70,
+      "categories": [
+        "workflows"
+      ],
+      "tags": [
+        "Durable Functions",
+        "Orchestration",
+        "Saga Pattern",
+        "Compensation",
+        "Distributed Transactions"
+      ],
+      "author": "Azure Functions Team",
+      "repositoryUrl": "https://github.com/Azure-Samples/Durable-Task-Scheduler",
+      "folderPath": "samples/durable-functions/dotnet/Saga",
+      "whatsIncluded": [
+        "Orchestrator with compensation logic",
+        "Activity functions",
+        "Error handling patterns",
+        "README.md"
+      ]
+    },
+    {
+      "id": "durable-ai-travel-planner-csharp",
+      "displayName": "Durable Functions AI Travel Planner (C#)",
+      "shortDescription": "HttpTrigger + DurableClient + OrchestrationTrigger + ActivityTrigger. C# AI travel planner using Azure OpenAI",
+      "longDescription": "C# Durable Functions app with an HttpTrigger starter that uses DurableClient to launch an OrchestrationTrigger workflow coordinating multiple ActivityTrigger functions. Each activity calls Azure OpenAI for destination research, itinerary creation, and booking recommendations.",
+      "language": "CSharp",
+      "bindingType": "orchestration",
+      "resource": "durable",
+      "iac": "none",
+      "priority": 71,
+      "categories": [
+        "ai-ml",
+        "workflows"
+      ],
+      "tags": [
+        "Durable Functions",
+        "Orchestration",
+        "AI Agent",
+        "Azure OpenAI",
+        "Travel Planning"
+      ],
+      "author": "Azure Functions Team",
+      "repositoryUrl": "https://github.com/Azure-Samples/Durable-Task-Scheduler",
+      "folderPath": "samples/durable-functions/dotnet/AiAgentTravelPlanOrchestrator",
+      "whatsIncluded": [
+        "AI agent orchestration",
+        "Multiple AI service integration",
+        "Activity functions",
+        "README.md"
+      ]
+    },
+    {
+      "id": "durable-aspire-csharp",
+      "displayName": "Durable Functions with .NET Aspire (C#)",
+      "shortDescription": "HttpTrigger + DurableClient + OrchestrationTrigger + ActivityTrigger. C# Durable Functions with .NET Aspire integration",
+      "longDescription": "C# Durable Functions app with HttpTrigger starter, DurableClient, OrchestrationTrigger, and ActivityTrigger, integrated with .NET Aspire for enhanced local development with service discovery, dashboard, and observability.",
+      "language": "CSharp",
+      "bindingType": "orchestration",
+      "resource": "durable",
+      "iac": "none",
+      "priority": 71,
+      "categories": [
+        "workflows"
+      ],
+      "tags": [
+        "Durable Functions",
+        "Orchestration",
+        ".NET Aspire",
+        "Cloud Native",
+        "Observability"
+      ],
+      "author": "Azure Functions Team",
+      "repositoryUrl": "https://github.com/Azure-Samples/Durable-Task-Scheduler",
+      "folderPath": "samples/durable-functions/dotnet/AzureFunctionsAndDtsWithAspire",
+      "whatsIncluded": [
+        "Aspire AppHost configuration",
+        "Durable Functions service",
+        "Service discovery setup",
+        "README.md"
+      ]
+    },
+    {
       "id": "durable-pdf-summarizer-csharp",
       "displayName": "Durable Functions PDF Summarizer (C#)",
       "shortDescription": "BlobTrigger + DurableClient + OrchestrationTrigger + ActivityTrigger. C# PDF summarizer with Document Intelligence and Azure OpenAI",
@@ -1746,7 +1925,7 @@
       "bindingType": "orchestration",
       "resource": "durable",
       "iac": "none",
-      "priority": 2,
+      "priority": 72,
       "categories": [
         "ai-ml",
         "workflows"
@@ -1777,7 +1956,7 @@
       "bindingType": "orchestration",
       "resource": "durable",
       "iac": "none",
-      "priority": 2,
+      "priority": 72,
       "categories": [
         "ai-ml",
         "workflows"
@@ -1801,33 +1980,147 @@
       ]
     },
     {
-      "id": "durable-saga-csharp",
-      "displayName": "Durable Functions Saga Pattern (C#)",
-      "shortDescription": "HttpTrigger + DurableClient + OrchestrationTrigger + ActivityTrigger. C# Saga pattern with compensation for distributed transactions",
-      "longDescription": "C# Durable Functions app with HttpTrigger starter, DurableClient, OrchestrationTrigger, and ActivityTrigger. Implements the Saga pattern for distributed transactions with compensation logic to roll back completed steps on failure.",
-      "language": "CSharp",
+      "id": "agentframework-durable-multi-agent-python",
+      "displayName": "Agent Framework Multi Agent (Python)",
+      "shortDescription": "HttpTrigger (AgentFunctionApp) + Azure OpenAI. Python multi-agent hosting weather and math AI agents with independent endpoints",
+      "longDescription": "Python Azure Functions app using the Agent Framework SDK with HttpTrigger endpoints via AgentFunctionApp. Hosts multiple AI agents (weather, math) each with unique instructions, independent HTTP endpoints, and isolated conversation management, backed by Azure OpenAI.",
+      "language": "Python",
       "bindingType": "orchestration",
-      "resource": "durable",
+      "resource": "agentframework",
       "iac": "none",
-      "priority": 1,
+      "priority": 75,
       "categories": [
-        "workflows"
+        "starter",
+        "ai-ml"
       ],
       "tags": [
+        "Agent Framework",
         "Durable Functions",
-        "Orchestration",
-        "Saga Pattern",
-        "Compensation",
-        "Distributed Transactions"
+        "Azure OpenAI",
+        "Multi-Agent",
+        "Starter"
+      ],
+      "author": "Microsoft Agent Framework Team",
+      "repositoryUrl": "https://github.com/microsoft/agent-framework",
+      "folderPath": "python/samples/04-hosting/azure_functions/02_multi_agent",
+      "whatsIncluded": [
+        "Function code (.py)",
+        "Multiple agent definitions",
+        "HTTP endpoints",
+        "requirements.txt",
+        "README.md"
+      ]
+    },
+    {
+      "id": "iac-flex-consumption-arm",
+      "displayName": "Flex Consumption (ARM)",
+      "shortDescription": "ARM template for provisioning Azure Functions Flex Consumption plan, function app, storage, and networking. No function code",
+      "longDescription": "ARM (Azure Resource Manager) JSON template that provisions Azure Functions Flex Consumption resources including the function app, hosting plan, storage account, and networking. Infrastructure-as-code only — contains no function code.",
+      "language": "ARM",
+      "bindingType": "none",
+      "resource": "arm",
+      "iac": "arm",
+      "priority": 90,
+      "categories": [
+        "starter"
+      ],
+      "tags": [
+        "ARM",
+        "Flex Consumption",
+        "Infrastructure As Code",
+        "Deployment"
       ],
       "author": "Azure Functions Team",
-      "repositoryUrl": "https://github.com/Azure-Samples/Durable-Task-Scheduler",
-      "folderPath": "samples/durable-functions/dotnet/Saga",
+      "repositoryUrl": "https://github.com/Azure-Samples/azure-functions-flex-consumption-samples",
+      "folderPath": "IaC/armtemplate",
       "whatsIncluded": [
-        "Orchestrator with compensation logic",
-        "Activity functions",
-        "Error handling patterns",
-        "README.md"
+        "ARM template files",
+        "Parameter files",
+        "Deployment scripts"
+      ]
+    },
+    {
+      "id": "iac-flex-consumption-bicep",
+      "displayName": "Flex Consumption (Bicep)",
+      "shortDescription": "Bicep template for provisioning Azure Functions Flex Consumption plan, function app, storage, and networking. No function code",
+      "longDescription": "Bicep template that provisions Azure Functions Flex Consumption resources including the function app, hosting plan, storage account, and networking. Infrastructure-as-code only — contains no function code.",
+      "language": "Bicep",
+      "bindingType": "none",
+      "resource": "bicep",
+      "iac": "bicep",
+      "priority": 90,
+      "categories": [
+        "starter"
+      ],
+      "tags": [
+        "Bicep",
+        "Flex Consumption",
+        "Infrastructure As Code",
+        "Deployment"
+      ],
+      "author": "Azure Functions Team",
+      "repositoryUrl": "https://github.com/Azure-Samples/azure-functions-flex-consumption-samples",
+      "folderPath": "IaC/bicep",
+      "whatsIncluded": [
+        "Bicep modules",
+        "Parameter files",
+        "Deployment configuration"
+      ]
+    },
+    {
+      "id": "iac-flex-consumption-terraform-azapi",
+      "displayName": "Flex Consumption (Terraform AzAPI)",
+      "shortDescription": "Terraform (AzAPI provider) for provisioning Azure Functions Flex Consumption plan and resources. No function code",
+      "longDescription": "Terraform template using the AzAPI provider that provisions Azure Functions Flex Consumption resources including the function app, hosting plan, storage account, and networking. Infrastructure-as-code only — contains no function code.",
+      "language": "Terraform",
+      "bindingType": "none",
+      "resource": "terraform",
+      "iac": "terraform",
+      "priority": 90,
+      "categories": [
+        "starter"
+      ],
+      "tags": [
+        "Terraform",
+        "Azapi",
+        "Flex Consumption",
+        "Infrastructure As Code"
+      ],
+      "author": "Azure Functions Team",
+      "repositoryUrl": "https://github.com/Azure-Samples/azure-functions-flex-consumption-samples",
+      "folderPath": "IaC/terraformazapi",
+      "whatsIncluded": [
+        "Terraform configuration files",
+        "AzAPI provider setup",
+        "Variable definitions"
+      ]
+    },
+    {
+      "id": "iac-flex-consumption-terraform-azurerm",
+      "displayName": "Flex Consumption (Terraform AzureRM)",
+      "shortDescription": "Terraform (AzureRM provider) for provisioning Azure Functions Flex Consumption plan and resources. No function code",
+      "longDescription": "Terraform template using the AzureRM provider that provisions Azure Functions Flex Consumption resources including the function app, hosting plan, storage account, and networking. Infrastructure-as-code only — contains no function code.",
+      "language": "Terraform",
+      "bindingType": "none",
+      "resource": "terraform",
+      "iac": "terraform",
+      "priority": 90,
+      "categories": [
+        "starter"
+      ],
+      "tags": [
+        "Terraform",
+        "Azurerm",
+        "Flex Consumption",
+        "Infrastructure As Code"
+      ],
+      "author": "Azure Functions Team",
+      "repositoryUrl": "https://github.com/Azure-Samples/azure-functions-flex-consumption-samples",
+      "folderPath": "IaC/terraformazurerm",
+      "whatsIncluded": [
+        "Terraform configuration files",
+        "AzureRM provider setup",
+        "Variable definitions"
       ]
     },
     {
@@ -1839,7 +2132,7 @@
       "bindingType": "input",
       "resource": "cosmos",
       "iac": "none",
-      "priority": 1,
+      "priority": 95,
       "categories": [
         "starter",
         "data-processing"
@@ -1870,7 +2163,7 @@
       "bindingType": "output",
       "resource": "cosmos",
       "iac": "none",
-      "priority": 1,
+      "priority": 95,
       "categories": [
         "starter",
         "data-processing"
@@ -1893,36 +2186,6 @@
       ]
     },
     {
-      "id": "cosmos-trigger-csharp-azd",
-      "displayName": "Cosmos DB Trigger (C# + AZD + Bicep)",
-      "shortDescription": "CosmosDBTrigger (change feed) C# function reacting to document changes in Cosmos DB. Uses managed identity. Deployed with azd",
-      "longDescription": "C# Azure Function with a CosmosDBTrigger that monitors an Azure Cosmos DB container via the change feed and reacts to document inserts and updates. Uses managed identity for authentication. Deployed with azd.",
-      "language": "CSharp",
-      "bindingType": "trigger",
-      "resource": "cosmos",
-      "iac": "bicep",
-      "priority": 1,
-      "categories": [
-        "data-processing"
-      ],
-      "tags": [
-        "Cosmos DB",
-        "NoSQL",
-        "Flex Consumption",
-        "AZD"
-      ],
-      "author": "Azure Functions Team",
-      "repositoryUrl": "https://github.com/Azure-Samples/functions-quickstart-dotnet-azd-cosmosdb",
-      "folderPath": ".",
-      "whatsIncluded": [
-        "Cosmos DB trigger function",
-        "Cosmos DB output binding",
-        "Bicep infrastructure",
-        "azd configuration",
-        "Application Insights monitoring"
-      ]
-    },
-    {
       "id": "cosmos-trigger-java",
       "displayName": "Cosmos DB Trigger (Java)",
       "shortDescription": "CosmosDBTrigger (change feed) Java function monitoring document changes in Azure Cosmos DB",
@@ -1931,7 +2194,7 @@
       "bindingType": "trigger",
       "resource": "cosmos",
       "iac": "none",
-      "priority": 1,
+      "priority": 95,
       "categories": [
         "starter",
         "data-processing"
@@ -1954,297 +2217,34 @@
       ]
     },
     {
-      "id": "cosmos-trigger-python-azd",
-      "displayName": "Cosmos DB Trigger (Python + AZD + Bicep)",
-      "shortDescription": "CosmosDBTrigger (change feed) Python function reacting to document changes in Azure Cosmos DB. Deployed with azd",
-      "longDescription": "Python Azure Function with a CosmosDBTrigger that monitors an Azure Cosmos DB container via the change feed and reacts to document inserts and updates. Deployed with azd.",
-      "language": "Python",
+      "id": "eventhub-trigger-java",
+      "displayName": "Event Hub Trigger (Java)",
+      "shortDescription": "EventHubTrigger for processing streaming data from Azure Event Hubs in Java",
+      "longDescription": "Java Azure Function with a single EventHubTrigger function that processes streaming data from Azure Event Hubs. Suitable for IoT telemetry, log ingestion, and real-time analytics.",
+      "language": "Java",
       "bindingType": "trigger",
-      "resource": "cosmos",
-      "iac": "bicep",
-      "priority": 1,
-      "categories": [
-        "data-processing"
-      ],
-      "tags": [
-        "Cosmos DB",
-        "NoSQL",
-        "Flex Consumption",
-        "AZD"
-      ],
-      "author": "Azure Functions Team",
-      "repositoryUrl": "https://github.com/Azure-Samples/functions-quickstart-python-azd-cosmosdb",
-      "folderPath": ".",
-      "whatsIncluded": [
-        "Cosmos DB trigger function",
-        "Cosmos DB output binding",
-        "Bicep infrastructure",
-        "azd configuration",
-        "Application Insights monitoring"
-      ]
-    },
-    {
-      "id": "cosmos-trigger-typescript-azd",
-      "displayName": "Cosmos DB Trigger (TypeScript + AZD + Bicep)",
-      "shortDescription": "CosmosDBTrigger (change feed) TypeScript function reacting to document changes in Azure Cosmos DB. Deployed with azd",
-      "longDescription": "TypeScript Azure Function with a CosmosDBTrigger that monitors an Azure Cosmos DB container via the change feed and reacts to document inserts and updates. Deployed with azd.",
-      "language": "TypeScript",
-      "bindingType": "trigger",
-      "resource": "cosmos",
-      "iac": "bicep",
-      "priority": 1,
-      "categories": [
-        "data-processing"
-      ],
-      "tags": [
-        "Cosmos DB",
-        "NoSQL",
-        "Flex Consumption",
-        "AZD"
-      ],
-      "author": "Azure Functions Team",
-      "repositoryUrl": "https://github.com/Azure-Samples/functions-quickstart-typescript-azd-cosmosdb",
-      "folderPath": ".",
-      "whatsIncluded": [
-        "Cosmos DB trigger function",
-        "Bicep infrastructure",
-        "azd configuration",
-        "Application Insights monitoring"
-      ]
-    },
-    {
-      "id": "sql-trigger-csharp-azd",
-      "displayName": "SQL Trigger (C# + AZD + Bicep)",
-      "shortDescription": "SqlTrigger + HttpTrigger + SqlOutput. C# dual-function: SQL trigger monitors row changes, HTTP writes to Azure SQL. Deployed with azd",
-      "longDescription": "C# Azure Functions app with two functions: (1) SqlTrigger monitoring row changes in Azure SQL [dbo].[ToDo] table, and (2) HttpTrigger with SqlOutput binding writing new rows. Deployed with azd.",
-      "language": "CSharp",
-      "bindingType": "trigger",
-      "resource": "sql",
-      "iac": "bicep",
-      "priority": 1,
-      "categories": [
-        "data-processing"
-      ],
-      "tags": [
-        "SQL",
-        "Azure SQL",
-        "Flex Consumption",
-        "AZD"
-      ],
-      "author": "Azure Functions Team",
-      "repositoryUrl": "https://github.com/Azure-Samples/functions-quickstart-dotnet-azd-sql",
-      "folderPath": ".",
-      "whatsIncluded": [
-        "SQL trigger function",
-        "SQL bindings",
-        "Bicep infrastructure",
-        "azd configuration",
-        "Application Insights monitoring"
-      ]
-    },
-    {
-      "id": "sql-trigger-python-azd",
-      "displayName": "SQL Trigger (Python + AZD + Bicep)",
-      "shortDescription": "SqlTrigger + HttpTrigger + SqlOutput. Python dual-function: SQL trigger monitors row changes, HTTP writes to Azure SQL. Deployed with azd",
-      "longDescription": "Python Azure Functions app with two functions: (1) SqlTrigger monitoring row changes in Azure SQL [dbo].[ToDo] table, and (2) HttpTrigger with SqlOutput binding writing new rows. Deployed with azd.",
-      "language": "Python",
-      "bindingType": "trigger",
-      "resource": "sql",
-      "iac": "bicep",
-      "priority": 1,
-      "categories": [
-        "data-processing"
-      ],
-      "tags": [
-        "SQL",
-        "Azure SQL",
-        "Flex Consumption",
-        "AZD"
-      ],
-      "author": "Azure Functions Team",
-      "repositoryUrl": "https://github.com/Azure-Samples/functions-quickstart-python-azd-sql",
-      "folderPath": ".",
-      "whatsIncluded": [
-        "SQL trigger function",
-        "SQL bindings",
-        "Bicep infrastructure",
-        "azd configuration",
-        "Key Vault integration",
-        "Log Analytics monitoring"
-      ]
-    },
-    {
-      "id": "sql-trigger-typescript-azd",
-      "displayName": "SQL Trigger (TypeScript + AZD + Bicep)",
-      "shortDescription": "SqlTrigger + HttpTrigger + SqlOutput. TypeScript dual-function: SQL trigger monitors row changes, HTTP writes to Azure SQL. Deployed with azd",
-      "longDescription": "TypeScript Azure Functions app with two functions: (1) SqlTrigger monitoring row changes in Azure SQL [dbo].[ToDo] table, and (2) HttpTrigger with SqlOutput binding writing new rows. Deployed with azd.",
-      "language": "TypeScript",
-      "bindingType": "trigger",
-      "resource": "sql",
-      "iac": "bicep",
-      "priority": 1,
-      "categories": [
-        "data-processing"
-      ],
-      "tags": [
-        "SQL",
-        "Azure SQL",
-        "Flex Consumption",
-        "AZD"
-      ],
-      "author": "Azure Functions Team",
-      "repositoryUrl": "https://github.com/Azure-Samples/functions-quickstart-typescript-azd-sql",
-      "folderPath": ".",
-      "whatsIncluded": [
-        "SQL trigger function",
-        "SQL bindings",
-        "Bicep infrastructure",
-        "azd configuration",
-        "Azure Monitor integration"
-      ]
-    },
-    {
-      "id": "agentframework-durable-multi-agent-python",
-      "displayName": "Agent Framework Multi Agent (Python)",
-      "shortDescription": "HttpTrigger (AgentFunctionApp) + Azure OpenAI. Python multi-agent hosting weather and math AI agents with independent endpoints",
-      "longDescription": "Python Azure Functions app using the Agent Framework SDK with HttpTrigger endpoints via AgentFunctionApp. Hosts multiple AI agents (weather, math) each with unique instructions, independent HTTP endpoints, and isolated conversation management, backed by Azure OpenAI.",
-      "language": "Python",
-      "bindingType": "orchestration",
-      "resource": "agentframework",
+      "resource": "eventhub",
       "iac": "none",
-      "priority": 1,
+      "priority": 95,
       "categories": [
         "starter",
-        "ai-ml"
+        "event-processing"
       ],
       "tags": [
-        "Agent Framework",
-        "Durable Functions",
-        "Azure OpenAI",
-        "Multi-Agent",
-        "Starter"
-      ],
-      "author": "Microsoft Agent Framework Team",
-      "repositoryUrl": "https://github.com/microsoft/agent-framework",
-      "folderPath": "python/samples/04-hosting/azure_functions/02_multi_agent",
-      "whatsIncluded": [
-        "Function code (.py)",
-        "Multiple agent definitions",
-        "HTTP endpoints",
-        "requirements.txt",
-        "README.md"
-      ]
-    },
-    {
-      "id": "iac-flex-consumption-arm",
-      "displayName": "Flex Consumption (ARM)",
-      "shortDescription": "ARM template for provisioning Azure Functions Flex Consumption plan, function app, storage, and networking. No function code",
-      "longDescription": "ARM (Azure Resource Manager) JSON template that provisions Azure Functions Flex Consumption resources including the function app, hosting plan, storage account, and networking. Infrastructure-as-code only \u2014 contains no function code.",
-      "language": "ARM",
-      "bindingType": "none",
-      "resource": "arm",
-      "iac": "arm",
-      "priority": 2,
-      "categories": [
-        "starter"
-      ],
-      "tags": [
-        "ARM",
-        "Flex Consumption",
-        "Infrastructure As Code",
-        "Deployment"
+        "Event Hub",
+        "Streaming",
+        "IoT",
+        "Telemetry"
       ],
       "author": "Azure Functions Team",
-      "repositoryUrl": "https://github.com/Azure-Samples/azure-functions-flex-consumption-samples",
-      "folderPath": "IaC/armtemplate",
+      "repositoryUrl": "https://github.com/Azure/azure-functions-templates-mcp-server",
+      "folderPath": "templates/java/EventHubTrigger",
       "whatsIncluded": [
-        "ARM template files",
-        "Parameter files",
-        "Deployment scripts"
-      ]
-    },
-    {
-      "id": "iac-flex-consumption-bicep",
-      "displayName": "Flex Consumption (Bicep)",
-      "shortDescription": "Bicep template for provisioning Azure Functions Flex Consumption plan, function app, storage, and networking. No function code",
-      "longDescription": "Bicep template that provisions Azure Functions Flex Consumption resources including the function app, hosting plan, storage account, and networking. Infrastructure-as-code only \u2014 contains no function code.",
-      "language": "Bicep",
-      "bindingType": "none",
-      "resource": "bicep",
-      "iac": "bicep",
-      "priority": 2,
-      "categories": [
-        "starter"
-      ],
-      "tags": [
-        "Bicep",
-        "Flex Consumption",
-        "Infrastructure As Code",
-        "Deployment"
-      ],
-      "author": "Azure Functions Team",
-      "repositoryUrl": "https://github.com/Azure-Samples/azure-functions-flex-consumption-samples",
-      "folderPath": "IaC/bicep",
-      "whatsIncluded": [
-        "Bicep modules",
-        "Parameter files",
-        "Deployment configuration"
-      ]
-    },
-    {
-      "id": "iac-flex-consumption-terraform-azapi",
-      "displayName": "Flex Consumption (Terraform AzAPI)",
-      "shortDescription": "Terraform (AzAPI provider) for provisioning Azure Functions Flex Consumption plan and resources. No function code",
-      "longDescription": "Terraform template using the AzAPI provider that provisions Azure Functions Flex Consumption resources including the function app, hosting plan, storage account, and networking. Infrastructure-as-code only \u2014 contains no function code.",
-      "language": "Terraform",
-      "bindingType": "none",
-      "resource": "terraform",
-      "iac": "terraform",
-      "priority": 2,
-      "categories": [
-        "starter"
-      ],
-      "tags": [
-        "Terraform",
-        "Azapi",
-        "Flex Consumption",
-        "Infrastructure As Code"
-      ],
-      "author": "Azure Functions Team",
-      "repositoryUrl": "https://github.com/Azure-Samples/azure-functions-flex-consumption-samples",
-      "folderPath": "IaC/terraformazapi",
-      "whatsIncluded": [
-        "Terraform configuration files",
-        "AzAPI provider setup",
-        "Variable definitions"
-      ]
-    },
-    {
-      "id": "iac-flex-consumption-terraform-azurerm",
-      "displayName": "Flex Consumption (Terraform AzureRM)",
-      "shortDescription": "Terraform (AzureRM provider) for provisioning Azure Functions Flex Consumption plan and resources. No function code",
-      "longDescription": "Terraform template using the AzureRM provider that provisions Azure Functions Flex Consumption resources including the function app, hosting plan, storage account, and networking. Infrastructure-as-code only \u2014 contains no function code.",
-      "language": "Terraform",
-      "bindingType": "none",
-      "resource": "terraform",
-      "iac": "terraform",
-      "priority": 2,
-      "categories": [
-        "starter"
-      ],
-      "tags": [
-        "Terraform",
-        "Azurerm",
-        "Flex Consumption",
-        "Infrastructure As Code"
-      ],
-      "author": "Azure Functions Team",
-      "repositoryUrl": "https://github.com/Azure-Samples/azure-functions-flex-consumption-samples",
-      "folderPath": "IaC/terraformazurerm",
-      "whatsIncluded": [
-        "Terraform configuration files",
-        "AzureRM provider setup",
-        "Variable definitions"
+        "Function code (.java)",
+        "pom.xml build file",
+        "host.json configuration",
+        "local.settings.json",
+        "README with setup instructions"
       ]
     }
   ]

--- a/Functions.Templates/Template-Manifest/manifest.json
+++ b/Functions.Templates/Template-Manifest/manifest.json
@@ -1119,8 +1119,7 @@
         "MCP SDK server",
         "Azure Functions hosting",
         "Bicep infrastructure"
-      ],
-      "isHighlighted": true
+      ]
     },
     {
       "id": "mcp-sdk-hosting-python",
@@ -1149,8 +1148,7 @@
         "MCP SDK server",
         "Azure Functions hosting",
         "Bicep infrastructure"
-      ],
-      "isHighlighted": true
+      ]
     },
     {
       "id": "mcp-sdk-hosting-typescript",
@@ -1179,8 +1177,7 @@
         "MCP SDK server",
         "Azure Functions hosting",
         "Bicep infrastructure"
-      ],
-      "isHighlighted": true
+      ]
     },
     {
       "id": "mcp-sdk-hosting-java",
@@ -1209,8 +1206,7 @@
         "MCP SDK server",
         "Azure Functions hosting",
         "Bicep infrastructure"
-      ],
-      "isHighlighted": true
+      ]
     },
     {
       "id": "mcp-server-apim-python",
@@ -1243,8 +1239,7 @@
         "Entra ID integration",
         "OAuth support",
         "Bicep infrastructure"
-      ],
-      "isHighlighted": true
+      ]
     },
     {
       "id": "ai-agent-csharp",

--- a/Functions.Templates/Template-Manifest/schemas/manifest.schema.json
+++ b/Functions.Templates/Template-Manifest/schemas/manifest.schema.json
@@ -167,8 +167,8 @@
         "priority": {
           "type": "integer",
           "minimum": 0,
-          "maximum": 10,
-          "description": "Priority for sorting (0 = starter/highest, higher = lower priority)"
+          "maximum": 99,
+          "description": "Priority for sorting. 5-slot blocks per Azure resource (+0 trigger, +1 input, +2 output, +3 variant). 10-slot block for MCP (+0 remote, +1 sdk, +2 tool, +3 resource, +4 prompt, +5 apim). See docs/priority-tiers.md."
         },
         "categories": {
           "type": "array",

--- a/Functions.Templates/Template-Manifest/schemas/manifest.schema.json
+++ b/Functions.Templates/Template-Manifest/schemas/manifest.schema.json
@@ -205,6 +205,11 @@
             "type": "string"
           },
           "description": "List of files and components included in the template"
+        },
+        "isHighlighted": {
+          "type": "boolean",
+          "default": false,
+          "description": "Whether the template should be highlighted/featured in the UI"
         }
       }
     }


### PR DESCRIPTION
## Summary

- Expand template priority from P0–P2 (3 tiers) to P00–P99 for fine-grained sorting, better categorization by Azure resource, and room for future templates.
- changed isPopular to isHighlighted, only remote mcp samples are being highlighted for now

Follows up on #1753 which introduced the priority system.

## Design

### 5-slot blocks per Azure resource
`+0` trigger · `+1` input · `+2` output · `+3` variant · `+4` stub

### 10-slot block for MCP
`+0` Remote Server · `+1` SDK Hosting · `+2` Tool *(future)* · `+3` Resource *(future)* · `+4` Prompt *(future)* · `+5` APIM Gateway

### Sort order
1. **Primary:** Priority number (lower = first)
2. **Secondary (within same priority):** Language: .NET → Python → TS → JS → Java → PowerShell
3. **Tertiary:** IaC complexity: no-IaC → AZD → IaC-only
   *(no-IaC = what VS Code Azure Functions extension generates = familiar baseline)*

### Default rule
New templates arriving without AZD/IaC default to P95–P99.

## Priority block map

| Range | Category | Templates |
|---|---|---|
| P00–04 | ⚡ HTTP | 6 triggers + 1 Terraform variant |
| P05–09 | ⏰ Timer | 6 triggers |
| P10–14 | 📦 Blob Storage | 6 triggers (input/output reserved) |
| P15–19 | 📡 Event Hub | 3 triggers (output reserved) |
| P20–34 | 📣📬🚌 Event Grid / Queue / Service Bus | *(reserved)* |
| P35–39 | 🌐 Cosmos DB | 3 triggers (input/output reserved) |
| P40–44 | 🗄️ SQL | 3 triggers (input/output reserved) |
| P45–49 | 🔴 Redis | *(reserved)* |
| P50–59 | 🔌 MCP | 4 remote + 4 sdk + 1 apim + tool/resource/prompt reserved |
| P60–64 | 🤖 AI | 4 agent + 2 chatgpt + 2 textsummarize + 1 langchain |
| P65–69 | 🔄 Durable Standard | 5 orchestration + 2 order processor |
| P70–74 | 🔄 Durable Advanced | 3 patterns + 2 scenarios + 2 pdf summarizer |
| P75–79 | 🤝 Agent Framework | 1 multi-agent |
| P80–89 | — | *(reserved)* |
| P90–94 | 🏗️ IaC | 4 flex consumption |
| P95–99 | ⚠️ Non-AZD Stubs | 4 Java gap-fillers (AZD upgrade planned) |

**Total: 69 templates**

## Changes

- **manifest.json**: All 69 template priorities updated, templates re-sorted by priority → language → IaC
- **manifest.schema.json**: Priority maximum changed from 10 → 99
- **docs/priority-tiers.md**: Full documentation with block map, coverage matrix, and gap analysis

## Coverage gaps (P00–P44 starters)

| Resource | Missing |
|---|---|
| Event Hub Trigger | Java (stub at P95), JavaScript, PowerShell |
| Cosmos Trigger | Java (stub at P95), JavaScript, PowerShell |
| SQL Trigger | Java, JavaScript, PowerShell |
