### PR TITLE
Update manifest.json with new version and date

### DIFF
--- a/Functions.Templates/Template-Manifest/manifest.json
+++ b/Functions.Templates/Template-Manifest/manifest.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./schemas/manifest.schema.json",
-  "generatedAt": "2026-03-24T06:33:19.007Z",
-  "version": "1.2.0",
+  "generatedAt": "2026-04-09T17:33:22.000Z",
+  "version": "1.3.0",
   "totalTemplates": 70,
   "runtimeVersions": {
     "Python": {


### PR DESCRIPTION
This pull request updates the template manifest to reflect the latest generation date and increments the version number. No other changes were made.

- Updated the `generatedAt` timestamp and bumped the manifest `version` from `1.2.0` to `1.3.0` in `manifest.json` to indicate a new release.