### PR TITLE
Refactor starter category in manifest

### DIFF
--- a/Functions.Templates/Template-Manifest/manifest.json
+++ b/Functions.Templates/Template-Manifest/manifest.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./schemas/manifest.schema.json",
-  "generatedAt": "2026-04-15T19:31:33.000Z",
+  "generatedAt": "2026-04-15T19:41:34.000Z",
   "version": "1.4.0",
   "totalTemplates": 70,
   "runtimeVersions": {
@@ -1235,7 +1235,6 @@
       "iac": "bicep",
       "priority": 55,
       "categories": [
-        "advanced",
         "ai-ml"
       ],
       "tags": [
@@ -1467,7 +1466,6 @@
       "iac": "bicep",
       "priority": 62,
       "categories": [
-        "advanced",
         "ai-ml"
       ],
       "tags": [
@@ -1500,7 +1498,6 @@
       "iac": "bicep",
       "priority": 62,
       "categories": [
-        "advanced",
         "ai-ml"
       ],
       "tags": [
@@ -1533,7 +1530,6 @@
       "iac": "bicep",
       "priority": 63,
       "categories": [
-        "advanced",
         "ai-ml"
       ],
       "tags": [
@@ -1790,7 +1786,6 @@
       "iac": "none",
       "priority": 70,
       "categories": [
-        "advanced",
         "workflows"
       ],
       "tags": [
@@ -1851,7 +1846,6 @@
       "iac": "none",
       "priority": 70,
       "categories": [
-        "advanced",
         "workflows"
       ],
       "tags": [
@@ -1882,7 +1876,6 @@
       "iac": "none",
       "priority": 71,
       "categories": [
-        "advanced",
         "ai-ml",
         "workflows"
       ],
@@ -1944,7 +1937,6 @@
       "iac": "none",
       "priority": 72,
       "categories": [
-        "advanced",
         "ai-ml",
         "workflows"
       ],
@@ -1976,7 +1968,6 @@
       "iac": "none",
       "priority": 72,
       "categories": [
-        "advanced",
         "ai-ml",
         "workflows"
       ],
@@ -2009,7 +2000,6 @@
       "iac": "none",
       "priority": 75,
       "categories": [
-        "advanced",
         "ai-ml"
       ],
       "tags": [

--- a/Functions.Templates/Template-Manifest/manifest.json
+++ b/Functions.Templates/Template-Manifest/manifest.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./schemas/manifest.schema.json",
-  "generatedAt": "2026-04-09T17:33:22.000Z",
-  "version": "1.3.0",
+  "generatedAt": "2026-04-15T19:31:33.000Z",
+  "version": "1.4.0",
   "totalTemplates": 70,
   "runtimeVersions": {
     "Python": {
@@ -89,6 +89,7 @@
       "iac": "bicep",
       "priority": 0,
       "categories": [
+        "starter",
         "web-apis"
       ],
       "tags": [
@@ -122,6 +123,7 @@
       "iac": "bicep",
       "priority": 0,
       "categories": [
+        "starter",
         "web-apis"
       ],
       "tags": [
@@ -154,6 +156,7 @@
       "iac": "bicep",
       "priority": 0,
       "categories": [
+        "starter",
         "web-apis"
       ],
       "tags": [
@@ -186,6 +189,7 @@
       "iac": "bicep",
       "priority": 0,
       "categories": [
+        "starter",
         "web-apis"
       ],
       "tags": [
@@ -218,6 +222,7 @@
       "iac": "bicep",
       "priority": 0,
       "categories": [
+        "starter",
         "web-apis"
       ],
       "tags": [
@@ -250,6 +255,7 @@
       "iac": "bicep",
       "priority": 0,
       "categories": [
+        "starter",
         "web-apis"
       ],
       "tags": [
@@ -281,6 +287,7 @@
       "iac": "terraform",
       "priority": 3,
       "categories": [
+        "starter",
         "web-apis"
       ],
       "tags": [
@@ -505,6 +512,7 @@
       "iac": "bicep",
       "priority": 10,
       "categories": [
+        "starter",
         "data-processing"
       ],
       "tags": [
@@ -535,6 +543,7 @@
       "iac": "bicep",
       "priority": 10,
       "categories": [
+        "starter",
         "data-processing"
       ],
       "tags": [
@@ -565,6 +574,7 @@
       "iac": "bicep",
       "priority": 10,
       "categories": [
+        "starter",
         "data-processing"
       ],
       "tags": [
@@ -595,6 +605,7 @@
       "iac": "bicep",
       "priority": 10,
       "categories": [
+        "starter",
         "data-processing"
       ],
       "tags": [
@@ -625,6 +636,7 @@
       "iac": "bicep",
       "priority": 10,
       "categories": [
+        "starter",
         "data-processing"
       ],
       "tags": [
@@ -655,6 +667,7 @@
       "iac": "bicep",
       "priority": 10,
       "categories": [
+        "starter",
         "data-processing"
       ],
       "tags": [
@@ -685,6 +698,7 @@
       "iac": "bicep",
       "priority": 15,
       "categories": [
+        "starter",
         "event-processing",
         "data-processing"
       ],
@@ -718,6 +732,7 @@
       "iac": "bicep",
       "priority": 15,
       "categories": [
+        "starter",
         "event-processing",
         "data-processing"
       ],
@@ -751,6 +766,7 @@
       "iac": "bicep",
       "priority": 15,
       "categories": [
+        "starter",
         "event-processing",
         "data-processing"
       ],
@@ -1219,6 +1235,7 @@
       "iac": "bicep",
       "priority": 55,
       "categories": [
+        "advanced",
         "ai-ml"
       ],
       "tags": [
@@ -1252,6 +1269,7 @@
       "iac": "bicep",
       "priority": 60,
       "categories": [
+        "starter",
         "ai-ml"
       ],
       "tags": [
@@ -1284,6 +1302,7 @@
       "iac": "bicep",
       "priority": 60,
       "categories": [
+        "starter",
         "ai-ml"
       ],
       "tags": [
@@ -1316,6 +1335,7 @@
       "iac": "bicep",
       "priority": 60,
       "categories": [
+        "starter",
         "ai-ml"
       ],
       "tags": [
@@ -1348,6 +1368,7 @@
       "iac": "bicep",
       "priority": 60,
       "categories": [
+        "starter",
         "ai-ml"
       ],
       "tags": [
@@ -1446,6 +1467,7 @@
       "iac": "bicep",
       "priority": 62,
       "categories": [
+        "advanced",
         "ai-ml"
       ],
       "tags": [
@@ -1478,6 +1500,7 @@
       "iac": "bicep",
       "priority": 62,
       "categories": [
+        "advanced",
         "ai-ml"
       ],
       "tags": [
@@ -1510,6 +1533,7 @@
       "iac": "bicep",
       "priority": 63,
       "categories": [
+        "advanced",
         "ai-ml"
       ],
       "tags": [
@@ -1542,7 +1566,6 @@
       "iac": "none",
       "priority": 65,
       "categories": [
-        "starter",
         "workflows"
       ],
       "tags": [
@@ -1575,7 +1598,6 @@
       "iac": "none",
       "priority": 65,
       "categories": [
-        "starter",
         "workflows"
       ],
       "tags": [
@@ -1608,7 +1630,6 @@
       "iac": "none",
       "priority": 65,
       "categories": [
-        "starter",
         "workflows"
       ],
       "tags": [
@@ -1642,7 +1663,6 @@
       "iac": "none",
       "priority": 65,
       "categories": [
-        "starter",
         "workflows"
       ],
       "tags": [
@@ -1675,7 +1695,6 @@
       "iac": "none",
       "priority": 65,
       "categories": [
-        "starter",
         "workflows"
       ],
       "tags": [
@@ -1771,6 +1790,7 @@
       "iac": "none",
       "priority": 70,
       "categories": [
+        "advanced",
         "workflows"
       ],
       "tags": [
@@ -1831,6 +1851,7 @@
       "iac": "none",
       "priority": 70,
       "categories": [
+        "advanced",
         "workflows"
       ],
       "tags": [
@@ -1861,6 +1882,7 @@
       "iac": "none",
       "priority": 71,
       "categories": [
+        "advanced",
         "ai-ml",
         "workflows"
       ],
@@ -1922,6 +1944,7 @@
       "iac": "none",
       "priority": 72,
       "categories": [
+        "advanced",
         "ai-ml",
         "workflows"
       ],
@@ -1953,6 +1976,7 @@
       "iac": "none",
       "priority": 72,
       "categories": [
+        "advanced",
         "ai-ml",
         "workflows"
       ],
@@ -1985,7 +2009,7 @@
       "iac": "none",
       "priority": 75,
       "categories": [
-        "starter",
+        "advanced",
         "ai-ml"
       ],
       "tags": [
@@ -2016,9 +2040,7 @@
       "resource": "arm",
       "iac": "arm",
       "priority": 90,
-      "categories": [
-        "starter"
-      ],
+      "categories": [],
       "tags": [
         "ARM",
         "Flex Consumption",
@@ -2044,9 +2066,7 @@
       "resource": "bicep",
       "iac": "bicep",
       "priority": 90,
-      "categories": [
-        "starter"
-      ],
+      "categories": [],
       "tags": [
         "Bicep",
         "Flex Consumption",
@@ -2072,9 +2092,7 @@
       "resource": "terraform",
       "iac": "terraform",
       "priority": 90,
-      "categories": [
-        "starter"
-      ],
+      "categories": [],
       "tags": [
         "Terraform",
         "Azapi",
@@ -2100,9 +2118,7 @@
       "resource": "terraform",
       "iac": "terraform",
       "priority": 90,
-      "categories": [
-        "starter"
-      ],
+      "categories": [],
       "tags": [
         "Terraform",
         "Azurerm",
@@ -2129,7 +2145,6 @@
       "iac": "none",
       "priority": 95,
       "categories": [
-        "starter",
         "data-processing"
       ],
       "tags": [
@@ -2160,7 +2175,6 @@
       "iac": "none",
       "priority": 95,
       "categories": [
-        "starter",
         "data-processing"
       ],
       "tags": [
@@ -2191,7 +2205,6 @@
       "iac": "none",
       "priority": 95,
       "categories": [
-        "starter",
         "data-processing"
       ],
       "tags": [


### PR DESCRIPTION
## Summary
Refactors the template categories in manifest.json to better organize starter samples.
Resolves - https://github.com/Azure/azure-functions-bucees-planning/issues/998

## Changes
Selection of templates based on https://github.com/Azure/azure-functions-templates/pull/1753

### Added 'starter' category to (31 total):
- 7 HTTP triggers (C#, Python, TypeScript, JavaScript, Java, PowerShell + C# Terraform)
- 6 Timer triggers (C#, Python, TypeScript, JavaScript, Java, PowerShell)
- 6 Blob EventGrid triggers (C#, Python, TypeScript, JavaScript, Java, PowerShell)
- 4 EventHub triggers (C#, Python, TypeScript, Java)
- 4 MCP Remote triggers (C#, Python, TypeScript, Java)
- 4 AI Agent templates (C#, Python, TypeScript, Java)

### Removed 'starter' from:
- 4 IaC templates (ARM, Bicep, Terraform AzAPI, Terraform AzureRM) → now have empty categories
- 3 Cosmos Java templates
- 5 Durable orchestration templates

### Other:
- Updated generatedAt timestamp