### PR TITLE
feat: migrate dotnet-isolated project template to OpenTelemetry

### DIFF
--- a/Functions.Templates/ProjectTemplate_v4.x/CSharp-Isolated/.template.config/template.json
+++ b/Functions.Templates/ProjectTemplate_v4.x/CSharp-Isolated/.template.config/template.json
@@ -146,23 +146,6 @@
                     }
                 ]
             }
-        },
-        "FunctionsAppInsightsPackageVersion": {
-            "type": "generated",
-            "generator": "switch",
-            "replaces": "FunctionsAppInsightsPackageVersionValue",
-            "parameters": {
-                "datatype": "string",
-                "cases": [
-                    {
-                        "condition": "FrameworkShouldUseV1Dependencies",
-                        "value": "1.4.0"
-                    },
-                    {
-                        "value": "2.50.0"
-                    }
-                ]
-            }
         }
     },
     "sources": [

--- a/Functions.Templates/ProjectTemplate_v4.x/CSharp-Isolated/Company.FunctionApp.csproj
+++ b/Functions.Templates/ProjectTemplate_v4.x/CSharp-Isolated/Company.FunctionApp.csproj
@@ -15,9 +15,10 @@
   <!--#if (NetCore)-->
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   <!--#endif -->
-    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.23.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="FunctionsWorkerPackageVersionValue" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="FunctionsAppInsightsPackageVersionValue" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.OpenTelemetry" Version="1.2.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+    <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.7.0" />
   <!--#if (NetCore)-->
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="FunctionsAspNetCorePackageVersionValue" />
   <!--#endif -->

--- a/Functions.Templates/ProjectTemplate_v4.x/CSharp-Isolated/Program.cs
+++ b/Functions.Templates/ProjectTemplate_v4.x/CSharp-Isolated/Program.cs
@@ -1,9 +1,12 @@
+using Azure.Monitor.OpenTelemetry.Exporter;
 using Microsoft.Azure.Functions.Worker;
 #if (NetCore && !FrameworkShouldUseV1Dependencies)
 using Microsoft.Azure.Functions.Worker.Builder;
 #endif
+using Microsoft.Azure.Functions.Worker.OpenTelemetry;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using OpenTelemetry;
 
 #if NetFramework
 namespace Company.FunctionApp
@@ -17,8 +20,9 @@ namespace Company.FunctionApp
             var host = new HostBuilder()
                 .ConfigureFunctionsWorkerDefaults()
                 .ConfigureServices(services => {
-                    services.AddApplicationInsightsTelemetryWorkerService();
-                    services.ConfigureFunctionsApplicationInsights();
+                    services.AddOpenTelemetry()
+                        .UseFunctionsWorkerDefaults()
+                        .UseAzureMonitorExporter();
                 })
                 .Build();
 
@@ -30,8 +34,9 @@ namespace Company.FunctionApp
 var host = new HostBuilder()
     .ConfigureFunctionsWebApplication()
     .ConfigureServices(services => {
-        services.AddApplicationInsightsTelemetryWorkerService();
-        services.ConfigureFunctionsApplicationInsights();
+        services.AddOpenTelemetry()
+            .UseFunctionsWorkerDefaults()
+            .UseAzureMonitorExporter();
     })
     .Build();
 
@@ -41,9 +46,9 @@ var builder = FunctionsApplication.CreateBuilder(args);
 
 builder.ConfigureFunctionsWebApplication();
 
-builder.Services
-    .AddApplicationInsightsTelemetryWorkerService()
-    .ConfigureFunctionsApplicationInsights();
+builder.Services.AddOpenTelemetry()
+    .UseFunctionsWorkerDefaults()
+    .UseAzureMonitorExporter();
 
 builder.Build().Run();
 #endif

--- a/Functions.Templates/ProjectTemplate_v4.x/CSharp-Isolated/host.json
+++ b/Functions.Templates/ProjectTemplate_v4.x/CSharp-Isolated/host.json
@@ -1,5 +1,6 @@
 {
     "version": "2.0",
+    "telemetryMode": "OpenTelemetry",
     "logging": {
         "applicationInsights": {
             "samplingSettings": {

--- a/Functions.Templates/ProjectTemplate_v4.x/FSharp-Isolated/.template.config/template.json
+++ b/Functions.Templates/ProjectTemplate_v4.x/FSharp-Isolated/.template.config/template.json
@@ -116,23 +116,6 @@
                     }
                 ]
             }
-        },
-        "FunctionsAppInsightsPackageVersion": {
-            "type": "generated",
-            "generator": "switch",
-            "replaces": "FunctionsAppInsightsPackageVersionValue",
-            "parameters": {
-                "datatype": "string",
-                "cases": [
-                    {
-                        "condition": "FrameworkShouldUseV1Dependencies",
-                        "value": "1.4.0"
-                    },
-                    {
-                        "value": "2.50.0"
-                    }
-                ]
-            }
         }
     },
     "sources": [

--- a/Functions.Templates/ProjectTemplate_v4.x/FSharp-Isolated/Company.FunctionApp.fsproj
+++ b/Functions.Templates/ProjectTemplate_v4.x/FSharp-Isolated/Company.FunctionApp.fsproj
@@ -15,9 +15,10 @@
   <!--#if (NetCore)-->
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   <!--#endif -->
-    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.23.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="FunctionsWorkerPackageVersionValue" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="FunctionsAppInsightsPackageVersionValue" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.OpenTelemetry" Version="1.2.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+    <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.7.0" />
   <!--#if (NetCore)-->
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="FunctionsAspNetCorePackageVersionValue" />
   <!--#endif -->

--- a/Functions.Templates/ProjectTemplate_v4.x/FSharp-Isolated/Program.fs
+++ b/Functions.Templates/ProjectTemplate_v4.x/FSharp-Isolated/Program.fs
@@ -1,9 +1,12 @@
+open Azure.Monitor.OpenTelemetry.Exporter
 open Microsoft.Azure.Functions.Worker
 #if (!FrameworkShouldUseV1Dependencies)
 open Microsoft.Azure.Functions.Worker.Builder
 #endif
+open Microsoft.Azure.Functions.Worker.OpenTelemetry
 open Microsoft.Extensions.DependencyInjection
 open Microsoft.Extensions.Hosting
+open global.OpenTelemetry
 
 #if (FrameworkShouldUseV1Dependencies)
 [<EntryPoint>]
@@ -12,10 +15,10 @@ let main args =
         HostBuilder()
             .ConfigureFunctionsWebApplication()
             .ConfigureServices(fun services ->
-                services.AddApplicationInsightsTelemetryWorkerService()
-                |> ignore
-
-                services.ConfigureFunctionsApplicationInsights() |> ignore)
+                services.AddOpenTelemetry()
+                    .UseFunctionsWorkerDefaults()
+                    .UseAzureMonitorExporter()
+                |> ignore)
             .Build()
 
     // If using the Cosmos DB, Blob or Tables extension, you need to configure the extensions manually using the extension methods below.
@@ -35,9 +38,9 @@ let main args =
 
     builder.ConfigureFunctionsWebApplication() |> ignore
 
-    builder.Services
-        .AddApplicationInsightsTelemetryWorkerService()
-        .ConfigureFunctionsApplicationInsights() 
+    builder.Services.AddOpenTelemetry()
+        .UseFunctionsWorkerDefaults()
+        .UseAzureMonitorExporter()
     |> ignore
             
     // If using the Cosmos DB, Blob or Tables extension, you need to configure the extensions manually using the extension methods below.

--- a/Functions.Templates/ProjectTemplate_v4.x/FSharp-Isolated/host.json
+++ b/Functions.Templates/ProjectTemplate_v4.x/FSharp-Isolated/host.json
@@ -1,5 +1,6 @@
 {
     "version": "2.0",
+    "telemetryMode": "OpenTelemetry",
     "logging": {
         "applicationInsights": {
             "samplingSettings": {


### PR DESCRIPTION
Closes #1778 

Microsoft.ApplicationInsights.WorkerService 3.0+ removed extensibility points (ITelemetryInitializer/ITelemetryProcessor) that the Functions Worker.ApplicationInsights wrapper relies on, and there is no plan to publish a v3 of that wrapper. Switch the modern (NetCore, non-V1Deps) project template to OpenTelemetry as recommended by the Functions docs.

- host.json: enable telemetryMode: OpenTelemetry
- csproj/fsproj: replace AI WorkerService + Functions.Worker.ApplicationInsights with Microsoft.Azure.Functions.Worker.OpenTelemetry, OpenTelemetry.Extensions.Hosting, and Azure.Monitor.OpenTelemetry.Exporter (modern path only)
- Program.cs/.fs: register OTel via builder.Services.AddOpenTelemetry() .UseFunctionsWorkerDefaults().UseAzureMonitorExporter()
- Legacy NetFramework / V1Deps paths keep the AI SDK setup since OTel is not supported there.
