### PR TITLE
Guard OTel setup behind DEBUG and Application Insights connection string

### DIFF
--- a/Functions.Templates/ProjectTemplate_v4.x/CSharp-Isolated/Program.cs
+++ b/Functions.Templates/ProjectTemplate_v4.x/CSharp-Isolated/Program.cs
@@ -20,9 +20,18 @@ namespace Company.FunctionApp
             var host = new HostBuilder()
                 .ConfigureFunctionsWorkerDefaults()
                 .ConfigureServices(services => {
+#if DEBUG
+                    if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("APPLICATIONINSIGHTS_CONNECTION_STRING")))
+                    {
+                        services.AddOpenTelemetry()
+                            .UseFunctionsWorkerDefaults()
+                            .UseAzureMonitorExporter();
+                    }
+#else
                     services.AddOpenTelemetry()
                         .UseFunctionsWorkerDefaults()
                         .UseAzureMonitorExporter();
+#endif
                 })
                 .Build();
 
@@ -34,9 +43,18 @@ namespace Company.FunctionApp
 var host = new HostBuilder()
     .ConfigureFunctionsWebApplication()
     .ConfigureServices(services => {
+#if DEBUG
+        if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("APPLICATIONINSIGHTS_CONNECTION_STRING")))
+        {
+            services.AddOpenTelemetry()
+                .UseFunctionsWorkerDefaults()
+                .UseAzureMonitorExporter();
+        }
+#else
         services.AddOpenTelemetry()
             .UseFunctionsWorkerDefaults()
             .UseAzureMonitorExporter();
+#endif
     })
     .Build();
 
@@ -46,9 +64,18 @@ var builder = FunctionsApplication.CreateBuilder(args);
 
 builder.ConfigureFunctionsWebApplication();
 
+#if DEBUG
+if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("APPLICATIONINSIGHTS_CONNECTION_STRING")))
+{
+    builder.Services.AddOpenTelemetry()
+        .UseFunctionsWorkerDefaults()
+        .UseAzureMonitorExporter();
+}
+#else
 builder.Services.AddOpenTelemetry()
     .UseFunctionsWorkerDefaults()
     .UseAzureMonitorExporter();
+#endif
 
 builder.Build().Run();
 #endif

--- a/Functions.Templates/ProjectTemplate_v4.x/CSharp-Isolated/host.json
+++ b/Functions.Templates/ProjectTemplate_v4.x/CSharp-Isolated/host.json
@@ -1,13 +1,4 @@
 {
     "version": "2.0",
-    "telemetryMode": "OpenTelemetry",
-    "logging": {
-        "applicationInsights": {
-            "samplingSettings": {
-                "isEnabled": true,
-                "excludedTypes": "Request"
-            },
-            "enableLiveMetricsFilters": true
-        }
-    }
+    "telemetryMode": "OpenTelemetry"
 }


### PR DESCRIPTION
In Debug builds (typical local dev with `func start`), only wire up OpenTelemetry / Azure Monitor exporter when an `APPLICATIONINSIGHTS_CONNECTION_STRING` is configured. In Release builds (typical Azure deployments) the OTel pipeline is wired up unconditionally, so missing telemetry config surfaces as an error rather than being silently skipped.

Also removes the now-redundant `logging.applicationInsights` block from `host.json` (no longer relevant once `telemetryMode` is `OpenTelemetry`).

Applies to all three template branches (`NetFramework`, `FrameworkShouldUseV1Dependencies`, and the default top-level `FunctionsApplication.CreateBuilder` flow).