### PR TITLE
Update gitRef to use fully qualified refs - refs/heads and refs/tags

### DIFF
--- a/Functions.Templates/Template-Manifest/manifest.json
+++ b/Functions.Templates/Template-Manifest/manifest.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./schemas/manifest.schema.json",
-  "generatedAt": "2026-05-26T06:00:00.000Z",
-  "version": "1.6.0",
+  "generatedAt": "2026-05-28T06:01:00Z",
+  "version": "1.7.0",
   "totalTemplates": 77,
   "runtimeVersions": {
     "Python": {

--- a/Functions.Templates/Template-Manifest/manifest.json
+++ b/Functions.Templates/Template-Manifest/manifest.json
@@ -103,7 +103,7 @@
       "author": "Azure Functions Team",
       "repositoryUrl": "https://github.com/Azure-Samples/functions-quickstart-dotnet-azd",
       "folderPath": ".",
-      "gitRef": "main",
+      "gitRef": "refs/heads/main",
       "whatsIncluded": [
         "HTTP trigger functions (GET and POST)",
         "Bicep infrastructure files",
@@ -138,7 +138,7 @@
       "author": "Azure Functions Team",
       "repositoryUrl": "https://github.com/Azure-Samples/functions-quickstart-python-http-azd",
       "folderPath": ".",
-      "gitRef": "main",
+      "gitRef": "refs/heads/main",
       "whatsIncluded": [
         "HTTP trigger function",
         "Bicep infrastructure files",
@@ -172,7 +172,7 @@
       "author": "Azure Functions Team",
       "repositoryUrl": "https://github.com/Azure-Samples/functions-quickstart-typescript-azd",
       "folderPath": ".",
-      "gitRef": "main",
+      "gitRef": "refs/heads/main",
       "whatsIncluded": [
         "HTTP trigger functions (GET and POST)",
         "Bicep infrastructure files",
@@ -206,7 +206,7 @@
       "author": "Azure Functions Team",
       "repositoryUrl": "https://github.com/Azure-Samples/functions-quickstart-javascript-azd",
       "folderPath": ".",
-      "gitRef": "v1.0.0",
+      "gitRef": "refs/tags/v1.0.0",
       "whatsIncluded": [
         "HTTP trigger functions (GET and POST)",
         "Bicep infrastructure files",
@@ -240,7 +240,7 @@
       "author": "Azure Functions Team",
       "repositoryUrl": "https://github.com/Azure-Samples/azure-functions-java-flex-consumption-azd",
       "folderPath": ".",
-      "gitRef": "v1.0.0",
+      "gitRef": "refs/tags/v1.0.0",
       "whatsIncluded": [
         "HTTP trigger functions",
         "Bicep infrastructure files",
@@ -274,7 +274,7 @@
       "author": "Azure Functions Team",
       "repositoryUrl": "https://github.com/Azure-Samples/functions-quickstart-powershell-azd",
       "folderPath": ".",
-      "gitRef": "main",
+      "gitRef": "refs/heads/main",
       "whatsIncluded": [
         "HTTP trigger functions",
         "Bicep infrastructure files",
@@ -308,7 +308,7 @@
       "author": "Azure Functions Team",
       "repositoryUrl": "https://github.com/Azure-Samples/functions-quickstart-dotnet-azd-tf",
       "folderPath": ".",
-      "gitRef": "main",
+      "gitRef": "refs/heads/main",
       "whatsIncluded": [
         "HTTP trigger functions (GET and POST)",
         "Terraform infrastructure files (AzureRM 4.x)",
@@ -341,7 +341,7 @@
       "author": "Azure Functions Team",
       "repositoryUrl": "https://github.com/Azure-Samples/functions-quickstart-dotnet-azd-timer",
       "folderPath": ".",
-      "gitRef": "main",
+      "gitRef": "refs/heads/main",
       "whatsIncluded": [
         "Timer trigger function",
         "Configurable NCRONTAB schedule",
@@ -374,7 +374,7 @@
       "author": "Azure Functions Team",
       "repositoryUrl": "https://github.com/Azure-Samples/functions-quickstart-python-azd-timer",
       "folderPath": ".",
-      "gitRef": "v1.0.0",
+      "gitRef": "refs/tags/v1.0.0",
       "whatsIncluded": [
         "Timer trigger function",
         "Configurable NCRONTAB schedule",
@@ -407,7 +407,7 @@
       "author": "Azure Functions Team",
       "repositoryUrl": "https://github.com/Azure-Samples/functions-quickstart-typescript-azd-timer",
       "folderPath": ".",
-      "gitRef": "v1.0.0",
+      "gitRef": "refs/tags/v1.0.0",
       "whatsIncluded": [
         "Timer trigger function",
         "Configurable NCRONTAB schedule",
@@ -440,7 +440,7 @@
       "author": "Azure Functions Team",
       "repositoryUrl": "https://github.com/Azure-Samples/functions-quickstart-javascript-azd-timer",
       "folderPath": ".",
-      "gitRef": "main",
+      "gitRef": "refs/heads/main",
       "whatsIncluded": [
         "Timer trigger function",
         "Configurable NCRONTAB schedule",
@@ -473,7 +473,7 @@
       "author": "Azure Functions Team",
       "repositoryUrl": "https://github.com/Azure-Samples/functions-quickstart-java-azd-timer",
       "folderPath": ".",
-      "gitRef": "main",
+      "gitRef": "refs/heads/main",
       "whatsIncluded": [
         "Timer trigger function",
         "Configurable NCRONTAB schedule",
@@ -506,7 +506,7 @@
       "author": "Azure Functions Team",
       "repositoryUrl": "https://github.com/Azure-Samples/functions-quickstart-powershell-azd-timer",
       "folderPath": ".",
-      "gitRef": "main",
+      "gitRef": "refs/heads/main",
       "whatsIncluded": [
         "Timer trigger function",
         "Configurable NCRONTAB schedule",
@@ -539,7 +539,7 @@
       "author": "Azure Functions Team",
       "repositoryUrl": "https://github.com/Azure-Samples/functions-quickstart-dotnet-azd-eventgrid-blob",
       "folderPath": ".",
-      "gitRef": "main",
+      "gitRef": "refs/heads/main",
       "whatsIncluded": [
         "Blob EventGrid trigger function",
         "Bicep infrastructure",
@@ -571,7 +571,7 @@
       "author": "Azure Functions Team",
       "repositoryUrl": "https://github.com/Azure-Samples/functions-quickstart-python-azd-eventgrid-blob",
       "folderPath": ".",
-      "gitRef": "main",
+      "gitRef": "refs/heads/main",
       "whatsIncluded": [
         "Blob EventGrid trigger function",
         "Bicep infrastructure",
@@ -603,7 +603,7 @@
       "author": "Azure Functions Team",
       "repositoryUrl": "https://github.com/Azure-Samples/functions-quickstart-typescript-azd-eventgrid-blob",
       "folderPath": ".",
-      "gitRef": "main",
+      "gitRef": "refs/heads/main",
       "whatsIncluded": [
         "Blob EventGrid trigger function",
         "Bicep infrastructure",
@@ -635,7 +635,7 @@
       "author": "Azure Functions Team",
       "repositoryUrl": "https://github.com/Azure-Samples/functions-quickstart-javascript-azd-eventgrid-blob",
       "folderPath": ".",
-      "gitRef": "main",
+      "gitRef": "refs/heads/main",
       "whatsIncluded": [
         "Blob EventGrid trigger function",
         "Bicep infrastructure",
@@ -667,7 +667,7 @@
       "author": "Azure Functions Team",
       "repositoryUrl": "https://github.com/Azure-Samples/functions-quickstart-java-azd-eventgrid-blob",
       "folderPath": ".",
-      "gitRef": "main",
+      "gitRef": "refs/heads/main",
       "whatsIncluded": [
         "Blob EventGrid trigger function",
         "Bicep infrastructure",
@@ -699,7 +699,7 @@
       "author": "Azure Functions Team",
       "repositoryUrl": "https://github.com/Azure-Samples/functions-quickstart-powershell-azd-eventgrid-blob",
       "folderPath": ".",
-      "gitRef": "main",
+      "gitRef": "refs/heads/main",
       "whatsIncluded": [
         "Blob EventGrid trigger function",
         "Bicep infrastructure",
@@ -732,7 +732,7 @@
       "author": "Azure Functions Team",
       "repositoryUrl": "https://github.com/Azure-Samples/functions-quickstart-dotnet-azd-eventhub",
       "folderPath": ".",
-      "gitRef": "main",
+      "gitRef": "refs/heads/main",
       "whatsIncluded": [
         "Event Hub trigger function",
         "Event Hub output binding",
@@ -769,7 +769,7 @@
       "author": "Azure Functions Team",
       "repositoryUrl": "https://github.com/Azure-Samples/functions-quickstart-python-azd-eventhub",
       "folderPath": ".",
-      "gitRef": "main",
+      "gitRef": "refs/heads/main",
       "whatsIncluded": [
         "Event Hub trigger function",
         "Event Hub output binding",
@@ -806,7 +806,7 @@
       "author": "Azure Functions Team",
       "repositoryUrl": "https://github.com/Azure-Samples/functions-quickstart-typescript-azd-eventhub",
       "folderPath": ".",
-      "gitRef": "main",
+      "gitRef": "refs/heads/main",
       "whatsIncluded": [
         "Event Hub trigger function",
         "Event Hub output binding",
@@ -842,7 +842,7 @@
       "author": "Azure Functions Team",
       "repositoryUrl": "https://github.com/Azure-Samples/functions-quickstart-javascript-azd-eventhub",
       "folderPath": ".",
-      "gitRef": "main",
+      "gitRef": "refs/heads/main",
       "whatsIncluded": [
         "Event Hub trigger function",
         "Event Hub output binding",
@@ -878,7 +878,7 @@
       "author": "Azure Functions Team",
       "repositoryUrl": "https://github.com/Azure-Samples/functions-quickstart-java-azd-eventhub",
       "folderPath": ".",
-      "gitRef": "main",
+      "gitRef": "refs/heads/main",
       "whatsIncluded": [
         "Event Hub trigger function",
         "Event Hub output binding",
@@ -914,7 +914,7 @@
       "author": "Azure Functions Team",
       "repositoryUrl": "https://github.com/Azure-Samples/functions-quickstart-powershell-azd-eventhub",
       "folderPath": ".",
-      "gitRef": "main",
+      "gitRef": "refs/heads/main",
       "whatsIncluded": [
         "Event Hub trigger function",
         "Event Hub output binding",
@@ -950,7 +950,7 @@
       "author": "Azure Functions Team",
       "repositoryUrl": "https://github.com/Azure-Samples/functions-quickstart-dotnet-azd-service-bus",
       "folderPath": ".",
-      "gitRef": "main",
+      "gitRef": "refs/heads/main",
       "whatsIncluded": [
         "Service Bus trigger function",
         "Bicep infrastructure files",
@@ -984,7 +984,7 @@
       "author": "Azure Functions Team",
       "repositoryUrl": "https://github.com/Azure-Samples/functions-quickstart-python-azd-service-bus",
       "folderPath": ".",
-      "gitRef": "main",
+      "gitRef": "refs/heads/main",
       "whatsIncluded": [
         "Service Bus trigger function",
         "Bicep infrastructure files",
@@ -1018,7 +1018,7 @@
       "author": "Azure Functions Team",
       "repositoryUrl": "https://github.com/Azure-Samples/functions-quickstart-typescript-azd-service-bus",
       "folderPath": ".",
-      "gitRef": "main",
+      "gitRef": "refs/heads/main",
       "whatsIncluded": [
         "Service Bus trigger function",
         "Bicep infrastructure files",
@@ -1052,7 +1052,7 @@
       "author": "Azure Functions Team",
       "repositoryUrl": "https://github.com/Azure-Samples/functions-quickstart-javascript-azd-service-bus",
       "folderPath": ".",
-      "gitRef": "main",
+      "gitRef": "refs/heads/main",
       "whatsIncluded": [
         "Service Bus trigger function",
         "Bicep infrastructure files",
@@ -1086,7 +1086,7 @@
       "author": "Azure Functions Team",
       "repositoryUrl": "https://github.com/Azure-Samples/functions-quickstart-java-azd-service-bus",
       "folderPath": ".",
-      "gitRef": "main",
+      "gitRef": "refs/heads/main",
       "whatsIncluded": [
         "Service Bus trigger function",
         "Bicep infrastructure files",
@@ -1120,7 +1120,7 @@
       "author": "Azure Functions Team",
       "repositoryUrl": "https://github.com/Azure-Samples/functions-quickstart-powershell-azd-service-bus",
       "folderPath": ".",
-      "gitRef": "main",
+      "gitRef": "refs/heads/main",
       "whatsIncluded": [
         "Service Bus trigger function",
         "Bicep infrastructure files",
@@ -1152,7 +1152,7 @@
       "author": "Azure Functions Team",
       "repositoryUrl": "https://github.com/Azure-Samples/functions-quickstart-dotnet-azd-cosmosdb",
       "folderPath": ".",
-      "gitRef": "v1.0.0",
+      "gitRef": "refs/tags/v1.0.0",
       "whatsIncluded": [
         "Cosmos DB trigger function",
         "Bicep infrastructure",
@@ -1184,7 +1184,7 @@
       "author": "Azure Functions Team",
       "repositoryUrl": "https://github.com/Azure-Samples/functions-quickstart-python-azd-cosmosdb",
       "folderPath": ".",
-      "gitRef": "v1.0.0",
+      "gitRef": "refs/tags/v1.0.0",
       "whatsIncluded": [
         "Cosmos DB trigger function",
         "Bicep infrastructure",
@@ -1216,7 +1216,7 @@
       "author": "Azure Functions Team",
       "repositoryUrl": "https://github.com/Azure-Samples/functions-quickstart-typescript-azd-cosmosdb",
       "folderPath": ".",
-      "gitRef": "v1.0.0",
+      "gitRef": "refs/tags/v1.0.0",
       "whatsIncluded": [
         "Cosmos DB trigger function",
         "Bicep infrastructure",
@@ -1248,7 +1248,7 @@
       "author": "Azure Functions Team",
       "repositoryUrl": "https://github.com/Azure-Samples/functions-quickstart-javascript-azd-cosmosdb",
       "folderPath": ".",
-      "gitRef": "v1.0.0",
+      "gitRef": "refs/tags/v1.0.0",
       "whatsIncluded": [
         "Function code (.js)",
         "Cosmos DB trigger function",
@@ -1281,7 +1281,7 @@
       "author": "Azure Functions Team",
       "repositoryUrl": "https://github.com/Azure-Samples/functions-quickstart-java-azd-cosmosdb",
       "folderPath": ".",
-      "gitRef": "v1.0.0",
+      "gitRef": "refs/tags/v1.0.0",
       "whatsIncluded": [
         "Function code (.java)",
         "Cosmos DB trigger function",
@@ -1314,7 +1314,7 @@
       "author": "Azure Functions Team",
       "repositoryUrl": "https://github.com/Azure-Samples/functions-quickstart-powershell-azd-cosmosdb",
       "folderPath": ".",
-      "gitRef": "v1.0.0",
+      "gitRef": "refs/tags/v1.0.0",
       "whatsIncluded": [
         "Function code (.ps1)",
         "Cosmos DB trigger function",
@@ -1347,7 +1347,7 @@
       "author": "Azure Functions Team",
       "repositoryUrl": "https://github.com/Azure-Samples/functions-quickstart-dotnet-azd-sql",
       "folderPath": ".",
-      "gitRef": "v1.0.0",
+      "gitRef": "refs/tags/v1.0.0",
       "whatsIncluded": [
         "SQL trigger function",
         "SQL bindings",
@@ -1378,7 +1378,7 @@
       "author": "Azure Functions Team",
       "repositoryUrl": "https://github.com/Azure-Samples/functions-quickstart-python-azd-sql",
       "folderPath": ".",
-      "gitRef": "v1.0.0",
+      "gitRef": "refs/tags/v1.0.0",
       "whatsIncluded": [
         "SQL trigger function",
         "SQL bindings",
@@ -1410,7 +1410,7 @@
       "author": "Azure Functions Team",
       "repositoryUrl": "https://github.com/Azure-Samples/functions-quickstart-typescript-azd-sql",
       "folderPath": ".",
-      "gitRef": "v1.0.0",
+      "gitRef": "refs/tags/v1.0.0",
       "whatsIncluded": [
         "SQL trigger function",
         "SQL bindings",
@@ -1443,7 +1443,7 @@
       "author": "Azure Functions Team",
       "repositoryUrl": "https://github.com/Azure-Samples/remote-mcp-functions-dotnet",
       "folderPath": ".",
-      "gitRef": "main",
+      "gitRef": "refs/heads/main",
       "whatsIncluded": [
         "MCP Tool Trigger functions",
         "MCP Resource Trigger functions",
@@ -1483,7 +1483,7 @@
       "author": "Azure Functions Team",
       "repositoryUrl": "https://github.com/Azure-Samples/remote-mcp-functions-python",
       "folderPath": ".",
-      "gitRef": "v1.0.0",
+      "gitRef": "refs/tags/v1.0.0",
       "whatsIncluded": [
         "MCP Tool trigger functions",
         "Snippet save/retrieve tools with Blob storage",
@@ -1519,7 +1519,7 @@
       "author": "Azure Functions Team",
       "repositoryUrl": "https://github.com/Azure-Samples/remote-mcp-functions-typescript",
       "folderPath": ".",
-      "gitRef": "v1.0.0",
+      "gitRef": "refs/tags/v1.0.0",
       "whatsIncluded": [
         "MCP Tool trigger functions",
         "Snippet save/retrieve tools with Blob storage",
@@ -1556,7 +1556,7 @@
       "author": "Azure Functions Team",
       "repositoryUrl": "https://github.com/Azure-Samples/remote-mcp-functions-java",
       "folderPath": ".",
-      "gitRef": "v1.0.0",
+      "gitRef": "refs/tags/v1.0.0",
       "whatsIncluded": [
         "MCP Tool trigger functions",
         "Snippet save/retrieve tools with Blob storage",
@@ -1592,7 +1592,7 @@
       "author": "Azure Functions Team",
       "repositoryUrl": "https://github.com/Azure-Samples/mcp-sdk-functions-hosting-dotnet",
       "folderPath": ".",
-      "gitRef": "main",
+      "gitRef": "refs/heads/main",
       "whatsIncluded": [
         "MCP SDK server",
         "Azure Functions hosting",
@@ -1622,7 +1622,7 @@
       "author": "Azure Functions Team",
       "repositoryUrl": "https://github.com/Azure-Samples/mcp-sdk-functions-hosting-python",
       "folderPath": ".",
-      "gitRef": "main",
+      "gitRef": "refs/heads/main",
       "whatsIncluded": [
         "MCP SDK server",
         "Azure Functions hosting",
@@ -1652,7 +1652,7 @@
       "author": "Azure Functions Team",
       "repositoryUrl": "https://github.com/Azure-Samples/mcp-sdk-functions-hosting-node",
       "folderPath": ".",
-      "gitRef": "main",
+      "gitRef": "refs/heads/main",
       "whatsIncluded": [
         "MCP SDK server",
         "Azure Functions hosting",
@@ -1682,7 +1682,7 @@
       "author": "Azure Functions Team",
       "repositoryUrl": "https://github.com/Azure-Samples/mcp-sdk-functions-hosting-java",
       "folderPath": ".",
-      "gitRef": "main",
+      "gitRef": "refs/heads/main",
       "whatsIncluded": [
         "MCP SDK server",
         "Azure Functions hosting",
@@ -1714,7 +1714,7 @@
       "author": "Azure Functions Team",
       "repositoryUrl": "https://github.com/Azure-Samples/remote-mcp-apim-functions-python",
       "folderPath": ".",
-      "gitRef": "main",
+      "gitRef": "refs/heads/main",
       "whatsIncluded": [
         "MCP server function",
         "APIM gateway",
@@ -1747,7 +1747,7 @@
       "author": "Azure Functions Team",
       "repositoryUrl": "https://github.com/Azure-Samples/simple-agent-functions-dotnet",
       "folderPath": ".",
-      "gitRef": "main",
+      "gitRef": "refs/heads/main",
       "whatsIncluded": [
         "AI agent HTTP endpoint (/api/ask)",
         "GitHub Copilot SDK integration",
@@ -1781,7 +1781,7 @@
       "author": "Azure Functions Team",
       "repositoryUrl": "https://github.com/Azure-Samples/simple-agent-functions-python",
       "folderPath": ".",
-      "gitRef": "main",
+      "gitRef": "refs/heads/main",
       "whatsIncluded": [
         "AI agent HTTP endpoint (/api/ask)",
         "GitHub Copilot SDK integration",
@@ -1815,7 +1815,7 @@
       "author": "Azure Functions Team",
       "repositoryUrl": "https://github.com/Azure-Samples/simple-agent-functions-typescript",
       "folderPath": ".",
-      "gitRef": "main",
+      "gitRef": "refs/heads/main",
       "whatsIncluded": [
         "AI agent HTTP endpoint (/api/ask)",
         "GitHub Copilot SDK integration",
@@ -1849,7 +1849,7 @@
       "author": "Azure Functions Team",
       "repositoryUrl": "https://github.com/Azure-Samples/simple-agent-functions-java",
       "folderPath": ".",
-      "gitRef": "main",
+      "gitRef": "refs/heads/main",
       "whatsIncluded": [
         "AI agent HTTP endpoint (/api/ask)",
         "GitHub Copilot SDK integration",
@@ -1881,7 +1881,7 @@
       "author": "Paul Yuknewicz",
       "repositoryUrl": "https://github.com/Azure-Samples/function-python-ai-openai-chatgpt",
       "folderPath": ".",
-      "gitRef": "main",
+      "gitRef": "refs/heads/main",
       "whatsIncluded": [
         "Ask and Chat HTTP functions",
         "Azure OpenAI integration",
@@ -1915,7 +1915,7 @@
       "author": "Paul Yuknewicz",
       "repositoryUrl": "https://github.com/Azure-Samples/function-javascript-ai-openai-chatgpt",
       "folderPath": ".",
-      "gitRef": "main",
+      "gitRef": "refs/heads/main",
       "whatsIncluded": [
         "Ask and Chat HTTP functions",
         "Azure OpenAI integration",
@@ -1949,7 +1949,7 @@
       "author": "Paul Yuknewicz",
       "repositoryUrl": "https://github.com/Azure-Samples/function-csharp-ai-textsummarize",
       "folderPath": ".",
-      "gitRef": "main",
+      "gitRef": "refs/heads/main",
       "whatsIncluded": [
         "Blob trigger function",
         "Azure Cognitive Services integration",
@@ -1982,7 +1982,7 @@
       "author": "Paul Yuknewicz",
       "repositoryUrl": "https://github.com/Azure-Samples/function-python-ai-textsummarize",
       "folderPath": ".",
-      "gitRef": "main",
+      "gitRef": "refs/heads/main",
       "whatsIncluded": [
         "Blob trigger function",
         "Azure Cognitive Services integration",
@@ -2015,7 +2015,7 @@
       "author": "Paul Yuknewicz",
       "repositoryUrl": "https://github.com/Azure-Samples/function-python-ai-langchain",
       "folderPath": ".",
-      "gitRef": "main",
+      "gitRef": "refs/heads/main",
       "whatsIncluded": [
         "LangChain integration",
         "Azure OpenAI integration",
@@ -2053,7 +2053,7 @@
       "author": "Azure Functions Team",
       "repositoryUrl": "https://github.com/Azure-Samples/durable-functions-quickstart-dotnet-azd",
       "folderPath": ".",
-      "gitRef": "main",
+      "gitRef": "refs/heads/main",
       "whatsIncluded": [
         "Function code (.cs)",
         "Solution file",
@@ -2089,7 +2089,7 @@
       "author": "Azure Functions Team",
       "repositoryUrl": "https://github.com/Azure-Samples/durable-functions-quickstart-python-azd",
       "folderPath": ".",
-      "gitRef": "main",
+      "gitRef": "refs/heads/main",
       "whatsIncluded": [
         "Function code (.py)",
         "requirements.txt",
@@ -2125,7 +2125,7 @@
       "author": "Azure Functions Team",
       "repositoryUrl": "https://github.com/Azure-Samples/durable-functions-quickstart-typescript-azd",
       "folderPath": ".",
-      "gitRef": "main",
+      "gitRef": "refs/heads/main",
       "whatsIncluded": [
         "Function code (.ts)",
         "package.json",
@@ -2156,7 +2156,7 @@
       "author": "Azure Functions Team",
       "repositoryUrl": "https://github.com/Azure-Samples/Durable-Task-Scheduler",
       "folderPath": "samples/durable-functions/javascript/HelloCities",
-      "gitRef": "main",
+      "gitRef": "refs/heads/main",
       "whatsIncluded": [
         "Function code (.js)",
         "package.json",
@@ -2188,7 +2188,7 @@
       "author": "Azure Functions Team",
       "repositoryUrl": "https://github.com/Azure-Samples/Durable-Functions-Order-Processing",
       "folderPath": "",
-      "gitRef": "main",
+      "gitRef": "refs/heads/main",
       "whatsIncluded": [
         "Durable orchestration function",
         "Activity functions for order steps",
@@ -2221,7 +2221,7 @@
       "author": "Azure Functions Team",
       "repositoryUrl": "https://github.com/Azure-Samples/durable-functions-order-processing-python",
       "folderPath": "",
-      "gitRef": "main",
+      "gitRef": "refs/heads/main",
       "whatsIncluded": [
         "Durable orchestration function",
         "Activity functions for order steps",
@@ -2254,7 +2254,7 @@
       "author": "Azure Functions Team",
       "repositoryUrl": "https://github.com/Azure-Samples/Durable-Task-Scheduler",
       "folderPath": "samples/durable-functions/dotnet/DistributedTracing",
-      "gitRef": "main",
+      "gitRef": "refs/heads/main",
       "whatsIncluded": [
         "OpenTelemetry configuration",
         "Traced orchestration",
@@ -2285,7 +2285,7 @@
       "author": "Azure Functions Team",
       "repositoryUrl": "https://github.com/Azure-Samples/Durable-Task-Scheduler",
       "folderPath": "samples/durable-functions/dotnet/LargePayload",
-      "gitRef": "main",
+      "gitRef": "refs/heads/main",
       "whatsIncluded": [
         "Large payload handling",
         "Blob storage integration",
@@ -2317,7 +2317,7 @@
       "author": "Azure Functions Team",
       "repositoryUrl": "https://github.com/Azure-Samples/Durable-Task-Scheduler",
       "folderPath": "samples/durable-functions/dotnet/LargePayloadFanOutFanIn",
-      "gitRef": "main",
+      "gitRef": "refs/heads/main",
       "whatsIncluded": [
         "Function code (.cs)",
         "Project file (.csproj)",
@@ -2350,7 +2350,7 @@
       "author": "Azure Functions Team",
       "repositoryUrl": "https://github.com/Azure-Samples/Durable-Task-Scheduler",
       "folderPath": "samples/durable-functions/dotnet/Saga",
-      "gitRef": "main",
+      "gitRef": "refs/heads/main",
       "whatsIncluded": [
         "Orchestrator with compensation logic",
         "Activity functions",
@@ -2382,7 +2382,7 @@
       "author": "Azure Functions Team",
       "repositoryUrl": "https://github.com/Azure-Samples/Durable-Task-Scheduler",
       "folderPath": "samples/durable-functions/dotnet/AiAgentTravelPlanOrchestrator",
-      "gitRef": "main",
+      "gitRef": "refs/heads/main",
       "whatsIncluded": [
         "AI agent orchestration",
         "Multiple AI service integration",
@@ -2413,7 +2413,7 @@
       "author": "Azure Functions Team",
       "repositoryUrl": "https://github.com/Azure-Samples/Durable-Task-Scheduler",
       "folderPath": "samples/durable-functions/dotnet/AzureFunctionsAndDtsWithAspire",
-      "gitRef": "main",
+      "gitRef": "refs/heads/main",
       "whatsIncluded": [
         "Aspire AppHost configuration",
         "Durable Functions service",
@@ -2445,7 +2445,7 @@
       "author": "Azure Functions Team",
       "repositoryUrl": "https://github.com/Azure-Samples/Durable-Task-Scheduler",
       "folderPath": "samples/durable-functions/dotnet/PdfSummarizer",
-      "gitRef": "main",
+      "gitRef": "refs/heads/main",
       "whatsIncluded": [
         "PDF processing orchestration",
         "Azure OpenAI integration",
@@ -2477,7 +2477,7 @@
       "author": "Azure Functions Team",
       "repositoryUrl": "https://github.com/Azure-Samples/Durable-Task-Scheduler",
       "folderPath": "samples/durable-functions/python/pdf-summarizer",
-      "gitRef": "main",
+      "gitRef": "refs/heads/main",
       "whatsIncluded": [
         "PDF processing orchestration",
         "Azure OpenAI integration",
@@ -2509,7 +2509,7 @@
       "author": "Microsoft Agent Framework Team",
       "repositoryUrl": "https://github.com/microsoft/agent-framework",
       "folderPath": "python/samples/04-hosting/azure_functions/02_multi_agent",
-      "gitRef": "main",
+      "gitRef": "refs/heads/main",
       "whatsIncluded": [
         "Function code (.py)",
         "Multiple agent definitions",
@@ -2538,7 +2538,7 @@
       "author": "Azure Functions Team",
       "repositoryUrl": "https://github.com/Azure-Samples/azure-functions-flex-consumption-samples",
       "folderPath": "IaC/armtemplate",
-      "gitRef": "main",
+      "gitRef": "refs/heads/main",
       "whatsIncluded": [
         "ARM template files",
         "Parameter files",
@@ -2565,7 +2565,7 @@
       "author": "Azure Functions Team",
       "repositoryUrl": "https://github.com/Azure-Samples/azure-functions-flex-consumption-samples",
       "folderPath": "IaC/bicep",
-      "gitRef": "main",
+      "gitRef": "refs/heads/main",
       "whatsIncluded": [
         "Bicep modules",
         "Parameter files",
@@ -2592,7 +2592,7 @@
       "author": "Azure Functions Team",
       "repositoryUrl": "https://github.com/Azure-Samples/azure-functions-flex-consumption-samples",
       "folderPath": "IaC/terraformazapi",
-      "gitRef": "main",
+      "gitRef": "refs/heads/main",
       "whatsIncluded": [
         "Terraform configuration files",
         "AzAPI provider setup",
@@ -2619,7 +2619,7 @@
       "author": "Azure Functions Team",
       "repositoryUrl": "https://github.com/Azure-Samples/azure-functions-flex-consumption-samples",
       "folderPath": "IaC/terraformazurerm",
-      "gitRef": "main",
+      "gitRef": "refs/heads/main",
       "whatsIncluded": [
         "Terraform configuration files",
         "AzureRM provider setup",

--- a/Functions.Templates/Template-Manifest/schemas/manifest.schema.json
+++ b/Functions.Templates/Template-Manifest/schemas/manifest.schema.json
@@ -201,8 +201,8 @@
         },
         "gitRef": {
           "type": "string",
-          "default": "main",
-          "description": "Git ref to clone (signed tag or branch name). Defaults to main."
+          "default": "refs/heads/main",
+          "description": "Git ref to clone (signed tag or branch name) with refs/tags/v* or refs/heads/branch. Defaults to main reference."
         },
         "whatsIncluded": {
           "type": "array",

--- a/eng/scripts/validate-manifest-refs.ps1
+++ b/eng/scripts/validate-manifest-refs.ps1
@@ -5,9 +5,9 @@
 .DESCRIPTION
     For each unique (repositoryUrl, gitRef, folderPath) tuple in the manifest:
     1. Verifies the repository is accessible.
-    2. Verifies the gitRef resolves as a tag or branch.
+    2. Verifies the gitRef is fully qualified (refs/tags/* or refs/heads/*) and resolves on GitHub.
     3. Verifies the folderPath exists at that ref (skipped for '.').
-    Warns when gitRef is a branch instead of a signed tag.
+    Warns when gitRef is a branch (refs/heads/*) instead of a signed tag.
 
     Requires: gh CLI authenticated with repo read access.
 
@@ -63,18 +63,21 @@ foreach ($t in $manifest.templates) {
         continue
     }
 
-    # Check gitRef exists as tag
-    $null = gh api "repos/$repoPath/git/refs/tags/$($t.gitRef)" --jq '.ref' 2>&1
+    # Check gitRef exists — must be fully qualified (refs/tags/* or refs/heads/*)
+    $gitRef = $t.gitRef
+    if ($gitRef -notmatch '^refs/(tags|heads)/') {
+        $errors += "$($t.id): gitRef '$gitRef' is not fully qualified — must start with refs/tags/ or refs/heads/"
+        Write-Host "  FAIL  $label (gitRef not fully qualified)" -ForegroundColor Red
+        continue
+    }
+
+    $null = gh api "repos/$repoPath/git/$gitRef" --jq '.ref' 2>&1
     if ($LASTEXITCODE -ne 0) {
-        # Try as branch
-        $null = gh api "repos/$repoPath/git/refs/heads/$($t.gitRef)" --jq '.ref' 2>&1
-        if ($LASTEXITCODE -ne 0) {
-            $errors += "$($t.id): gitRef '$($t.gitRef)' not found in $repoPath"
-            Write-Host "  FAIL  $label (ref not found)" -ForegroundColor Red
-            continue
-        } else {
-            $warnings += "$($t.id): '$($t.gitRef)' is a branch, not a signed tag — $repoPath"
-        }
+        $errors += "$($t.id): gitRef '$gitRef' not found in $repoPath"
+        Write-Host "  FAIL  $label (ref not found)" -ForegroundColor Red
+        continue
+    } elseif ($gitRef -match '^refs/heads/') {
+        $warnings += "$($t.id): '$gitRef' is a branch, not a signed tag — $repoPath"
     }
 
     # Check folderPath exists at the gitRef


### PR DESCRIPTION
## Description

<!-- Brief description of changes -->

## Checklist

### When adding or updating templates

- [ ] `.nuspec` updated with new templates
- [ ] `Resources.resx` updated with template metadata
- [ ] Or: only updating an existing template

### When updating `Functions.Templates\Template-Manifest\manifest.json`

- [ ] Schema validation passes (`Test-Json` against `manifest.schema.json`)
- [x] Ran `pwsh ./eng/scripts/validate-manifest-refs.ps1` locally and all refs resolve
- [ ] Priority tiers in `docs/priority-tiers.md` are consistent with manifest entries
