### PR TITLE
Replace #if DEBUG OTel guard with runtime env var check

### DIFF
--- a/Functions.Templates/ProjectTemplate_v4.x/CSharp-Isolated/Program.cs
+++ b/Functions.Templates/ProjectTemplate_v4.x/CSharp-Isolated/Program.cs
@@ -20,18 +20,12 @@ namespace Company.FunctionApp
             var host = new HostBuilder()
                 .ConfigureFunctionsWorkerDefaults()
                 .ConfigureServices(services => {
-#if DEBUG
                     if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("APPLICATIONINSIGHTS_CONNECTION_STRING")))
                     {
                         services.AddOpenTelemetry()
                             .UseFunctionsWorkerDefaults()
                             .UseAzureMonitorExporter();
                     }
-#else
-                    services.AddOpenTelemetry()
-                        .UseFunctionsWorkerDefaults()
-                        .UseAzureMonitorExporter();
-#endif
                 })
                 .Build();
 
@@ -43,18 +37,12 @@ namespace Company.FunctionApp
 var host = new HostBuilder()
     .ConfigureFunctionsWebApplication()
     .ConfigureServices(services => {
-#if DEBUG
         if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("APPLICATIONINSIGHTS_CONNECTION_STRING")))
         {
             services.AddOpenTelemetry()
                 .UseFunctionsWorkerDefaults()
                 .UseAzureMonitorExporter();
         }
-#else
-        services.AddOpenTelemetry()
-            .UseFunctionsWorkerDefaults()
-            .UseAzureMonitorExporter();
-#endif
     })
     .Build();
 
@@ -64,18 +52,12 @@ var builder = FunctionsApplication.CreateBuilder(args);
 
 builder.ConfigureFunctionsWebApplication();
 
-#if DEBUG
 if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("APPLICATIONINSIGHTS_CONNECTION_STRING")))
 {
     builder.Services.AddOpenTelemetry()
         .UseFunctionsWorkerDefaults()
         .UseAzureMonitorExporter();
 }
-#else
-builder.Services.AddOpenTelemetry()
-    .UseFunctionsWorkerDefaults()
-    .UseAzureMonitorExporter();
-#endif
 
 builder.Build().Run();
 #endif

--- a/Functions.Templates/ProjectTemplate_v4.x/FSharp-Isolated/Program.fs
+++ b/Functions.Templates/ProjectTemplate_v4.x/FSharp-Isolated/Program.fs
@@ -15,10 +15,11 @@ let main args =
         HostBuilder()
             .ConfigureFunctionsWebApplication()
             .ConfigureServices(fun services ->
-                services.AddOpenTelemetry()
-                    .UseFunctionsWorkerDefaults()
-                    .UseAzureMonitorExporter()
-                |> ignore)
+                if not (System.String.IsNullOrEmpty(System.Environment.GetEnvironmentVariable("APPLICATIONINSIGHTS_CONNECTION_STRING"))) then
+                    services.AddOpenTelemetry()
+                        .UseFunctionsWorkerDefaults()
+                        .UseAzureMonitorExporter()
+                    |> ignore)
             .Build()
 
     // If using the Cosmos DB, Blob or Tables extension, you need to configure the extensions manually using the extension methods below.
@@ -38,11 +39,12 @@ let main args =
 
     builder.ConfigureFunctionsWebApplication() |> ignore
 
-    builder.Services.AddOpenTelemetry()
-        .UseFunctionsWorkerDefaults()
-        .UseAzureMonitorExporter()
-    |> ignore
-            
+    if not (System.String.IsNullOrEmpty(System.Environment.GetEnvironmentVariable("APPLICATIONINSIGHTS_CONNECTION_STRING"))) then
+        builder.Services.AddOpenTelemetry()
+            .UseFunctionsWorkerDefaults()
+            .UseAzureMonitorExporter()
+        |> ignore
+
     // If using the Cosmos DB, Blob or Tables extension, you need to configure the extensions manually using the extension methods below.
     // Learn more about this here: https://go.microsoft.com/fwlink/?linkid=2245587
     // builder.ConfigureCosmosDBExtension() |> ignore


### PR DESCRIPTION
## Problem

The C# isolated `Program.cs` template wrapped the Azure Monitor OpenTelemetry registration in `#if DEBUG` / `#else` / `#endif`. The dotnet template engine **consumes** `#if` directives in `.cs` / `.fs` files and emits only the winning branch. Since `DEBUG` isn't a template symbol, it evaluates as false and the `#else` branch is emitted with the directives stripped. Users running `dotnet new func` never saw the DEBUG-guarded code, just an unconditional `AddOpenTelemetry().UseAzureMonitorExporter()` that fails at runtime if the connection string isn't set.

## Fix

Replace the preprocessor split with a single runtime check on `APPLICATIONINSIGHTS_CONNECTION_STRING`. This:
- Works in Debug and Release (no template-engine quirks).
- Protects every config from exporter failures when the env var is missing.
- Removes ~16 lines per template and a footgun for future edits.

Applied across all three branches of `CSharp-Isolated/Program.cs` (`NetFramework`, `FrameworkShouldUseV1Dependencies`, default) and both branches of `FSharp-Isolated/Program.fs` (which previously had no guard at all).

## Notes

- No `template.json` or `.csproj` changes needed.
- Considered escaping the directives via `##if`, but the behavior depends on the C# conditional handler version and would be a hidden footgun for the next editor.