### PR TITLE
Python-v2: Remove double .py extension for durable templates

### DIFF
--- a/Functions.Templates/Templates-v2/DurableFunctionsEntityTrigger-Python/template.json
+++ b/Functions.Templates/Templates-v2/DurableFunctionsEntityTrigger-Python/template.json
@@ -127,7 +127,7 @@
             "name": "writeFile_FunctionApp",
             "type": "WriteToFile",
             "source": "$(FUNCTION_APP_CONTENT)",
-            "filePath": "$(APP_FILENAME).py",
+            "filePath": "$(APP_FILENAME)",
             "continueOnError": false,
             "errorText": "Unable to create the function app",
             "replaceTokens": true,

--- a/Functions.Templates/Templates-v2/DurableFunctionsOrchestration-Python/template.json
+++ b/Functions.Templates/Templates-v2/DurableFunctionsOrchestration-Python/template.json
@@ -127,7 +127,7 @@
             "name": "writeFile_FunctionApp",
             "type": "WriteToFile",
             "source": "$(FUNCTION_APP_CONTENT)",
-            "filePath": "$(APP_FILENAME).py",
+            "filePath": "$(APP_FILENAME)",
             "continueOnError": false,
             "errorText": "Unable to create the function app",
             "replaceTokens": true,


### PR DESCRIPTION
## Description

Removes the .py suffix during template file create to prevent the default experience from creating azure_functions.py.py
Resolves #1797 

This seems to match the majority of other templates' behavior, but note that the EventGridTrigger and ServiceBusTopicTrigger templates for python also create using `$(APP_FILENAME).py` - not changed here since the issue doesn't mention them and I'm not part of those extensions' org

## Checklist

### When adding or updating templates

- [ ] `.nuspec` updated with new templates
- [ ] `Resources.resx` updated with template metadata
- [x] Or: only updating an existing template

### When updating `Functions.Templates\Template-Manifest\manifest.json`

- [ ] Schema validation passes (`Test-Json` against `manifest.schema.json`)
- [ ] Ran `pwsh ./eng/scripts/validate-manifest-refs.ps1` locally and all refs resolve
- [ ] Priority tiers in `docs/priority-tiers.md` are consistent with manifest entries
