### PR TITLE
Python v2: normalize 'trigger' casing in template names

### DIFF
--- a/Functions.Templates/Templates-v2/DaprServiceInvocationTrigger-Python/template.json
+++ b/Functions.Templates/Templates-v2/DaprServiceInvocationTrigger-Python/template.json
@@ -1,6 +1,6 @@
 {
     "author": "Ashique",
-    "name": "Dapr Service Invocation Trigger",
+    "name": "Dapr Service Invocation trigger",
     "description": "$DaprServiceInvocationTrigger_description",
     "programmingModel": "v2",
     "language": "python",

--- a/Functions.Templates/Templates-v2/DaprTopicTrigger-Python/template.json
+++ b/Functions.Templates/Templates-v2/DaprTopicTrigger-Python/template.json
@@ -1,6 +1,6 @@
 {
     "author": "Ashique",
-    "name": "Dapr Topic Trigger",
+    "name": "Dapr Topic trigger",
     "description": "$DaprTopicTrigger_description",
     "programmingModel": "v2",
     "language": "python",

--- a/Functions.Templates/Templates-v2/DurableFunctionsEntityTrigger-Python/template.json
+++ b/Functions.Templates/Templates-v2/DurableFunctionsEntityTrigger-Python/template.json
@@ -1,6 +1,6 @@
 {
     "author": "Andy Staples(andystaples)",
-    "name": "Durable Functions Entity Trigger",
+    "name": "Durable Functions Entity trigger",
     "description": "$EntityTrigger_description",
     "programmingModel": "v2",
     "language": "python",

--- a/Functions.Templates/Templates-v2/OpenAI-Assistant-Python/template.json
+++ b/Functions.Templates/Templates-v2/OpenAI-Assistant-Python/template.json
@@ -1,6 +1,6 @@
 {
     "author": "Gavin Aguiar",
-    "name": "OpenAI Assistant Trigger",
+    "name": "OpenAI Assistant trigger",
     "description": "Template to add an assistant to your project",
     "programmingModel": "v2",
     "language": "python",

--- a/Functions.Templates/Templates-v2/TimerTrigger-Python/template.json
+++ b/Functions.Templates/Templates-v2/TimerTrigger-Python/template.json
@@ -1,6 +1,6 @@
 {
     "author": "kashimiz",
-    "name": "Timer Trigger",
+    "name": "Timer trigger",
     "description": "$TimerTrigger_description",
     "programmingModel": "v2",
     "language": "python",


### PR DESCRIPTION
## What

Normalises the casing of "trigger" in five Python v2 template `name` fields so they match the existing convention used by `HTTP trigger`, `Queue trigger`, `Blob trigger`, etc.

| Folder | Before | After |
| --- | --- | --- |
| `DaprServiceInvocationTrigger-Python` | `Dapr Service Invocation Trigger` | `Dapr Service Invocation trigger` |
| `DaprTopicTrigger-Python` | `Dapr Topic Trigger` | `Dapr Topic trigger` |
| `DurableFunctionsEntityTrigger-Python` | `Durable Functions Entity Trigger` | `Durable Functions Entity trigger` |
| `OpenAI-Assistant-Python` | `OpenAI Assistant Trigger` | `OpenAI Assistant trigger` |
| `TimerTrigger-Python` | `Timer Trigger` | `Timer trigger` |

Non-trigger templates (`Durable Functions Orchestration`, `*Binding`) are intentionally left alone. No template ids or folder names changed, so portal / VS Code pins are unaffected.

## Background

This PR was scoped from a wider report that originally flagged three Python v2 issues:

1. **Missing `MCPToolTrigger_description` / `MCPResourceTrigger_description` resource keys** causing `$...` placeholder leaks at `func new` time.
2. **`MCPTrigger-Python` mislabelled as just "MCP trigger"** (it's the tool trigger).
3. **Inconsistent casing** of "Trigger" vs "trigger" across Python v2 names.

After auditing `dev`, issues 1 and 2 had already been resolved upstream (see #1775 and the subsequent MCP prompt template work):

- `Functions.Templates/Resources/Resources.resx` already contains `MCPToolTrigger_description`, `MCPResourceTrigger_description`, and `McpPromptTrigger_description`, with translations checked into `Functions.Templates/Resources_lcl/*/Resources.resx.lcl`.
- `MCPToolTrigger-Python/template.json` already uses `"name": "MCP Tool trigger"` and `"description": "$MCPToolTrigger_description"`.

So only the casing fix (issue 3) remained, and that's all this PR carries.

## Verification

- `python3 -c "import json; json.load(open(f))"` on every `Templates-v2/*/template.json` (all valid).
- Grepped `"name":` across `Templates-v2/*/template.json`: every Python v2 trigger template now uses lowercase `trigger`; no non-trigger template was changed.