### PR TITLE
Python-v2: remove double py extension from EventGridTrigger-Python, ServiceBusTopicTrigger templates

### DIFF
--- a/Functions.Templates/Templates-v2/EventGridTrigger-Python/template.json
+++ b/Functions.Templates/Templates-v2/EventGridTrigger-Python/template.json
@@ -127,7 +127,7 @@
             "name": "writeFile_FunctionApp",
             "type": "WriteToFile",
             "source": "$(FUNCTION_APP_CONTENT)",
-            "filePath": "$(APP_FILENAME).py",
+            "filePath": "$(APP_FILENAME)",
             "continueOnError": false,
             "errorText": "Unable to create the function app",
             "replaceTokens": true,

--- a/Functions.Templates/Templates-v2/ServiceBusTopicTrigger-Python/template.json
+++ b/Functions.Templates/Templates-v2/ServiceBusTopicTrigger-Python/template.json
@@ -199,7 +199,7 @@
             "name": "writeFile_FunctionApp",
             "type": "WriteToFile",
             "source": "$(FUNCTION_APP_CONTENT)",
-            "filePath": "$(APP_FILENAME).py",
+            "filePath": "$(APP_FILENAME)",
             "continueOnError": false,
             "errorText": "Unable to create the function app",
             "replaceTokens": true,


### PR DESCRIPTION
## Description
This pull request makes a minor update to the Python function app templates by changing the way the output file name is specified. Specifically, it removes the `.py` extension from the `filePath` property. Extension is defined by FileExtension property already.

- Updated the `filePath` in the `WriteToFile` step of both `EventGridTrigger-Python/template.json` and `ServiceBusTopicTrigger-Python/template.json` to use `$(APP_FILENAME)` instead of `$(APP_FILENAME).py`

## Checklist

### When adding or updating templates

- [ ] `.nuspec` updated with new templates
- [ ] `Resources.resx` updated with template metadata
- [x] Or: only updating an existing template

### When updating `Functions.Templates\Template-Manifest\manifest.json`

- [ ] Schema validation passes (`Test-Json` against `manifest.schema.json`)
- [ ] Ran `pwsh ./eng/scripts/validate-manifest-refs.ps1` locally and all refs resolve
- [ ] Priority tiers in `docs/priority-tiers.md` are consistent with manifest entries
